### PR TITLE
A small change to 3x2 Pixel Clock to make it work in the emulator

### DIFF
--- a/apps/clck3x2/clock3x2.js
+++ b/apps/clck3x2/clock3x2.js
@@ -60,7 +60,6 @@
 
   function drawTime() {
     g.clear();
-    //drawWidgets();
 
     let d = Date();
     let h = d.getHours();

--- a/apps/clck3x2/clock3x2.js
+++ b/apps/clck3x2/clock3x2.js
@@ -60,7 +60,7 @@
 
   function drawTime() {
     g.clear();
-    drawWidgets();
+    //drawWidgets();
 
     let d = Date();
     let h = d.getHours();

--- a/apps/clck3x2/clock3x2.js
+++ b/apps/clck3x2/clock3x2.js
@@ -60,7 +60,7 @@
 
   function drawTime() {
     g.clear();
-    try { drawWidgets(); } catch(err) {} // as drawWidgets does work in the Emulator
+    try { drawWidgets(); } catch(err) {} // as drawWidgets does not work in the Emulator
 
     let d = Date();
     let h = d.getHours();

--- a/apps/clck3x2/clock3x2.js
+++ b/apps/clck3x2/clock3x2.js
@@ -60,6 +60,7 @@
 
   function drawTime() {
     g.clear();
+    try { drawWidgets(); } catch(err) {} // as drawWidgets does work in the Emulator
 
     let d = Date();
     let h = d.getHours();
@@ -77,7 +78,7 @@
     }
 
     let t = d.getSeconds()*1000 + d.getMilliseconds();
-    let delta = (60000 - t) % 60000; // time till next minute
+    let delta = 60000 - t; // time till next minute
     idTimeout = setTimeout(drawTime, delta);  
   }
 
@@ -87,7 +88,6 @@
     }
   });
 
-  // special function to handle display switch on
   Bangle.on('lcdPower', function(on){
     if (on) {
       drawTime();


### PR DESCRIPTION
I have encapsulated the drawWidgets function into a try block to allow the app to run in the Emulator.
https://www.espruino.com/ide/emulator.html?codeurl=https://banglejs.com/apps/apps/clck3x2/clock3x2.js&upload
You can add the _run in the Emulator_ icon next to the app if you wish.