### PR TITLE
feature: all thirty-minute timezones

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -41,7 +41,7 @@
   { "id": "setting",
     "name": "Settings",
     "icon": "settings.png",
-    "version":"0.01",
+    "version":"0.02",
     "description": "A menu for setting up Bangle.js - by default this disables Bluetooth unless you enable 'BLE' AND 'Dev'",
     "tags": "tool,system",
     "storage": [

--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -1,0 +1,1 @@
+0.02: Add support for 30-minute timezones.

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -100,7 +100,7 @@ function showMainMenu() {
       max: 12,
       step: 0.5,
       onchange: v => {
-        settings.timezone = v;
+        settings.timezone = v || 0;
         updateSettings();
       }
     },

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -98,9 +98,9 @@ function showMainMenu() {
       value: settings.timezone,
       min: -11,
       max: 12,
-      step: 1,
+      step: 0.5,
       onchange: v => {
-        settings.timezone = 0 | v;
+        settings.timezone = v;
         updateSettings();
       }
     },


### PR DESCRIPTION
/cc @gfwilliams.

I tested it locally, it works. It'll be nice to work upstream on an alternate representation for this menu though (one that can go 5:30 instead of 5.5) but this should be as functional as anything.

Fixes: #68 