### PR TITLE
feat: "my files" tab to list and download files

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
       <li class="tab-item" id="tab-myappscontainer">
         <a href="javascript:showTab('myappscontainer')">My Apps</a>
       </li>
+      <li class="tab-item" id="tab-myfscontainer">
+        <a href="javascript:showTab('myfscontainer')">My files</a>
+      </li>
       <li class="tab-item" id="tab-aboutcontainer">
         <a href="javascript:showTab('aboutcontainer')">About</a>
       </li>
@@ -87,9 +90,24 @@
     <div class="container bangle-tab" id="myappscontainer" style="display:none">
       <div class="panel">
         <div class="panel-header" style="text-align:right">
-          <button class="btn" id="myappsrefresh">Refresh...</button>
+          <button class="btn refresh">Refresh...</button>
         </div>
         <div class="panel-body columns"><!-- apps go here --></div>
+      </div>
+    </div>
+
+    <div class="container bangle-tab" id="myfscontainer" style="display:none">
+      <div class="panel">
+        <div class="panel-header column col-12 container">
+          <div class="columns col-gapless">
+            <p class="column col-9">Files currently stored on the watch. Click row to download.</p>
+            <div class="column col-3" style="text-align:right">
+              <button class="btn refresh">Refresh...</button>
+            </div>
+          </div>
+        </div>
+        <table class="table table-striped table-hover panel-body">
+        </table>
       </div>
     </div>
 
@@ -117,5 +135,6 @@
     <script src="comms.js"></script>
     <script src="appinfo.js"></script>
     <script src="index.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.2/dist/FileSaver.min.js" type="application/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
### What's in there?

- a new tab to list files on your watch
- it displays a table of files, indicating files type when possible
- when clicking on row, trigger download as a file on your host
- refresh button that works similarly to "My Apps" refresh button

![image](https://user-images.githubusercontent.com/186268/71415608-cf995280-265c-11ea-8964-dd7d69e8fd4e.png)

### Notes to reviewers

As application may create files on the watch, it would be nice to have a simple way to download them on your computer. In my case, I would like to retrieve the GPX files of my activities.

This implementation supports textual and binary files, and in particular, files in append mode, which the final octal sequence in name makes communication a bit hairy.
Without encoding accessed file names (with `encodeURIComponent`), Puck experiences either JSON parsing error (when listing the files) or general failure (when accessing file content)

One thing really deserve improvement: accessing content will crash if it does not fit the bangle available RAM.
I would like to read chunks one by one and collect them on browser side, but the Storage implementation does not support such thing (as far as I know).
I reused a pretty old-yet-reliable [3rd party](https://eligrey.com/blog/saving-generated-files-on-the-client-side/) lib to turn the file content into a downloadable file, but this piece could easily be re-written if needed (especially since we don't need to support IE/Edge browsers)

Finally, I apologize in advance if I broke the style guide. I am a little bit lost without eslint.