### PR TITLE
Bar clock: fix SyntaxError

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -919,7 +919,7 @@
   { "id": "barclock",
     "name": "Bar Clock",
     "icon": "clock-bar.png",
-    "version":"0.03",
+    "version":"0.04",
     "description": "A simple digital clock showing seconds as a bar",
     "tags": "clock",
     "type":"clock",

--- a/apps/barclock/ChangeLog
+++ b/apps/barclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Created Bar Clock
 0.02: Apply locale, 12-hour setting
 0.03: Fix dates drawing over each other at midnight
+0.04: Small bugfix

--- a/apps/barclock/clock-bar.js
+++ b/apps/barclock/clock-bar.js
@@ -103,7 +103,10 @@
   const drawBar = function (date) {
     const b = settings.bar
     const seconds = date.getSeconds()
-    if (seconds === 0) return // zero-size rect stills draws one line of pixels
+    if (seconds === 0) {
+      // zero-size rect stills draws one line of pixels, we don't want that
+      return
+    }
     const fraction = seconds / SECONDS_PER_MINUTE,
       width = fraction * screen.width
     g.setColor(b.color)


### PR DESCRIPTION
Whoops, sorry about that.

Seems the app still works though
(Snuck in during code cleanup, I'm blaming autoformat)