### PR TITLE
Battery widget: color by level and percentage as text

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -326,7 +326,7 @@
   { "id": "widbat",
     "name": "Battery Level Widget",
     "icon": "widget.png",
-    "version":"0.04",
+    "version":"0.05",
     "description": "Show the current battery level and charging status in the top right of the clock",
     "tags": "widget,battery",
     "type":"widget",

--- a/apps.json
+++ b/apps.json
@@ -326,7 +326,7 @@
   { "id": "widbat",
     "name": "Battery Level Widget",
     "icon": "widget.png",
-    "version":"0.05",
+    "version":"0.06",
     "description": "Show the current battery level and charging status in the top right of the clock",
     "tags": "widget,battery",
     "type":"widget",

--- a/apps/widbat/ChangeLog
+++ b/apps/widbat/ChangeLog
@@ -2,3 +2,4 @@
 0.03: Tweaks for variable size widget system
 0.04: Ensure redrawing works with variable size widget system
 0.05: Change color depending on battery level
+0.06: Show battery percentage as text

--- a/apps/widbat/ChangeLog
+++ b/apps/widbat/ChangeLog
@@ -1,3 +1,4 @@
 0.02: Now refresh battery monitor every minute if LCD on
 0.03: Tweaks for variable size widget system
 0.04: Ensure redrawing works with variable size widget system
+0.05: Change color depending on battery level

--- a/apps/widbat/widget.js
+++ b/apps/widbat/widget.js
@@ -1,5 +1,10 @@
 (function(){
-var CHARGING = 0x07E0;
+const levelColor = (l) => {
+  if (Bangle.isCharging()) return 0x07E0; // "Green"
+  if (l >= 50) return 0x05E0; // slightly darker green
+  if (l >= 15) return 0xFD20; // "Orange"
+  return 0xF800; // "Red"
+}
 
 function setWidth() {
   WIDGETS["bat"].width = 40 + (Bangle.isCharging()?16:0);
@@ -7,15 +12,17 @@ function setWidth() {
 function draw() {
   var s = 39;
   var x = this.x, y = this.y;
+  const l = E.getBattery(), c = levelColor(l);
   if (Bangle.isCharging()) {
-    g.setColor(CHARGING).drawImage(atob("DhgBHOBzgc4HOP////////////////////3/4HgB4AeAHgB4AeAHgB4AeAHg"),x,y);
+    g.setColor(c).drawImage(atob(
+      "DhgBHOBzgc4HOP////////////////////3/4HgB4AeAHgB4AeAHgB4AeAHg"),x,y);
     x+=16;
   }
   g.setColor(-1);
   g.fillRect(x,y+2,x+s-4,y+21);
   g.clearRect(x+2,y+4,x+s-6,y+19);
   g.fillRect(x+s-3,y+10,x+s,y+14);
-  g.setColor(CHARGING).fillRect(x+4,y+6,x+4+E.getBattery()*(s-12)/100,y+17);
+  g.setColor(c).fillRect(x+4,y+6,x+4+l*(s-12)/100,y+17);
   g.setColor(-1);
 }
 Bangle.on('charging',function(charging) {

--- a/apps/widbat/widget.js
+++ b/apps/widbat/widget.js
@@ -24,6 +24,15 @@ function draw() {
   g.fillRect(x+s-3,y+10,x+s,y+14);
   g.setColor(c).fillRect(x+4,y+6,x+4+l*(s-12)/100,y+17);
   g.setColor(-1);
+  g.setFontAlign(-1,-1);
+  if (l >= 100) {
+    g.setFont('4x6', 2);
+    g.drawString(l, x + 6, y + 7);
+  } else {
+    if (l < 10) x+=6;
+    g.setFont('6x8', 2);
+    g.drawString(l, x + 6, y + 4);
+  }
 }
 Bangle.on('charging',function(charging) {
   if(charging) Bangle.buzz();


### PR DESCRIPTION
This has two commits:
0.05: Change color depending on battery level
0.06: Show battery percentage as text

Because I think the coloring is probably nice, but not sure if everybody would like the percentage? If not I could remove that (or maybe add settings?).