### PR TITLE
Take into account discussion from #167

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -892,7 +892,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.03",
+    "version":"0.04",
     "description": "Animated Mario clock, jumps to change the time!",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Create mario app
 0.02: Fix day of the week and add padding
 0.03: use short date format from locale, take timeout from settings
+0.04: modify date to display to be more at the original idea but still localized

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -285,7 +285,10 @@ function drawTime() {
 function drawDate() {
   g.setFont("6x8");
   g.setColor(LIGHTEST);
-  const dateStr = locale.date(new Date(), true);
+  let d = new Date(); 
+  let dateStr = locale.date(d, true);
+  dateStr = dateStr.replace(d.getFullYear(), "").trim().replace(/\/$/i,"");
+  dateStr = locale.dow(d, true) + " " + dateStr;
   g.drawString(dateStr, (W - g.stringWidth(dateStr))/2, 0, true);
 }
 


### PR DESCRIPTION
Using now weekday abbrev, space, short dateformat with full-year removed.
This should work for most locales (I hardcoded also replacing a trailing slash esp for en_IL and fr_FR)