### PR TITLE
Gadgetbridge notification optimization

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -91,7 +91,7 @@
   { "id": "gbridge",
     "name": "Gadgetbridge",
     "icon": "app.png",
-    "version":"0.04",
+    "version":"0.05",
     "description": "The default notification handler for Gadgetbridge notifications from Android",
     "tags": "tool,system,android,widget",
     "storage": [

--- a/apps/gbridge/ChangeLog
+++ b/apps/gbridge/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Increase contrast (darker notification background, white text)
 0.03: Gadgetbridge widget now shows connection state
 0.04: Tweaks for variable size widget system
+0.05: Optimize animation, limit title length

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -89,7 +89,7 @@
       if (musicState=="play")
         show(40,function(y) {
           g.setColor("#ffffff");
-          g.drawImage(              require("heatshrink").decompress(atob("jEYwILI/EAv/8gP/ARcMgOAASN8h+A/kfwP8n4CD/E/gHgjg/HA=")),8,y+8);
+          g.drawImage(require("heatshrink").decompress(atob("jEYwILI/EAv/8gP/ARcMgOAASN8h+A/kfwP8n4CD/E/gHgjg/HA=")),8,y+8);
           g.setFontAlign(-1,-1);
           g.setFont("6x8",1);
           var x = 40;

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -58,7 +58,8 @@
           g.drawString(j.src,x,y+7);
           g.setColor("#ffffff");
           g.setFont("6x8",2);
-          g.drawString(j.title,x,y+25);
+          if (j.title === undefined) g.drawString(j.title,x,y+25);
+          else g.drawString(j.title.slice(0,17),x,y+25);
           g.setFont("6x8",1);
           g.setColor("#ffffff");
           // split text up a word boundaries

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -22,7 +22,7 @@
       scrollPos-=2;
       if (scrollPos<-size) scrollPos=-size;
       Bangle.setLCDOffset(scrollPos);
-      if (scrollPos>-size) setTimeout(anim,10);
+      if (scrollPos>-size) setTimeout(anim,15);
     }
     anim();
   }


### PR DESCRIPTION
The 10ms timeout delay for the animation was kinda laggy on my watch.
i've changed the timeout delay to 15ms and it looks more fluently now.
Some notifications like Whatsapp group chat have very long titles because they consists of chat name + name of the person. These caused the title to go out of bound. Therefore i've limited the title length to 18 characters.