### PR TITLE
Add support for type:"storage" files

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -346,7 +346,7 @@
     "storage": [
       {"name":"widbatpc.wid.js","url":"widget.js"},
       {"name":"widbatpc.settings.js","url":"settings.js"},
-      {"name":"widbatpc.settings.json","content": "{}"}
+      {"name":"widbatpc.settings.json","type": "storage"}
     ]
   },
   { "id": "widbt",

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -71,7 +71,9 @@ apps.forEach((app,addIdx) => {
       ERROR(`App ${app.id} file ${file.name} is a duplicate`);
     fileNames.push(file.name);
     if (file.url) if (!fs.existsSync(appDir+file.url)) ERROR(`App ${app.id} file ${file.url} doesn't exist`);
-    if (!file.url && !file.content && !app.custom) ERROR(`App ${app.id} file ${file.name} has no contents`);
+    if (!file.url && !file.content && !app.custom && !('type' in file && file.type === 'storage')) {
+      ERROR(`App ${app.id} file ${file.name} has no contents`);
+    }
     var fileContents = "";
     if (file.content) fileContents = file.content;
     if (file.url) fileContents = fs.readFileSync(appDir+file.url).toString();

--- a/js/appinfo.js
+++ b/js/appinfo.js
@@ -14,8 +14,16 @@ var AppInfo = {
             return {
               name : storageFile.name,
               content : content,
-              evaluate : storageFile.evaluate
+              evaluate : storageFile.evaluate,
+              type: storageFile.type,
           }});
+        else if ('type' in storageFile && storageFile.type === 'storage') {
+          return Promise.resolve({
+            name : storageFile.name,
+            evaluate : storageFile.evaluate,
+            type: storageFile.type,
+          });
+        }
         else return Promise.resolve();
       })).then(fileContents => { // now we just have a list of files + contents...
         // filter out empty files
@@ -32,7 +40,7 @@ var AppInfo = {
             if (js.endsWith(";"))
               js = js.slice(0,-1);
             storageFile.cmd = `\x10require('Storage').write(${toJS(storageFile.name)},${js});`;
-          } else {
+          } else if ('content' in storageFile) {
             let code = storageFile.content;
             // write code in chunks, in case it is too big to fit in RAM (fix #157)
             var CHUNKSIZE = 4096;


### PR DESCRIPTION
Fix #216 
Add support for type:"storage" files

On install, these files are only uploaded if they actually have content
On update, these files are *not* overwritten if they already exist
On remove, these files *are* deleted

This is meant for e.g. `<appid>.settings.json` files, so updating does
not reset user configuration.

Also: install/update/remove now check `<appid>.info` on the device
* install: if app.info exists perform update instead
* update: only delete files that won't be overwritten with a new version
* remove: delete files listed in `<appid>.info`
(If we fail to load `<appid>.info` these all fall back to `apps.jaon`)