### PR TITLE
Improve update process

### DIFF
--- a/js/comms.js
+++ b/js/comms.js
@@ -8,7 +8,7 @@ reset : (opt) => new Promise((resolve,reject) => {
     setTimeout(resolve,500);
   });
 }),
-uploadApp : (app,skipReset) => {
+uploadApp : (app,skipReset) => { // expects an apps.json structure (i.e. with `storage`)
   Progress.show({title:`Uploading ${app.name}`,sticky:true});
   return AppInfo.getFiles(app, httpGet).then(fileContents => {
     return new Promise((resolve,reject) => {
@@ -79,11 +79,11 @@ getInstalledApps : () => {
     });
   });
 },
-removeApp : app => { // expects an app structure
+removeApp : app => { // expects an appid.info structure (i.e. with `files`)
+  if (app.files === '') return Promise.resolve(); // nothing to erase
   Progress.show({title:`Removing ${app.name}`,sticky:true});
-  var storage = [{name:app.id+".info"}].concat(app.storage);
-  var cmds = storage.map(file=>{
-    return `\x10require("Storage").erase(${toJS(file.name)});\n`;
+  var cmds = app.files.split(',').map(file=>{
+    return `\x10require("Storage").erase(${toJS(file)});\n`;
   }).join("");
   console.log("removeApp", cmds);
   return Comms.reset().then(new Promise((resolve,reject) => {


### PR DESCRIPTION
Fix #216
Cleaner PR than #235: just improves the update process without worrying about special settings/data files.

- Always fill `appsInstalled` before uploading
- Install: if `appid.info` already on device, update instead
- Update: get files to remove from `appid.info`, only remove files which
          won't be overwritten anyway
- Remove: get files to remove from `appid.info`