### PR TITLE
Mario Clock [Enhancement] - Extend info displayed + add Daisy

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -914,7 +914,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.07",
+    "version":"0.08",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -5,4 +5,4 @@
 0.05: use 12/24 hour clock from settings
 0.06: Performance refactor, and enhanced graphics!
 0.07: Swipe right to change between Mario and Toad characters, swipe left to toggle night mode
-0.08: Add Readme. Add Princes Daisy
+0.08: Add Readme. Add Princes Daisy. Update date panel to be info panel toggling between Date, Battery and Temperature

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -5,4 +5,4 @@
 0.05: use 12/24 hour clock from settings
 0.06: Performance refactor, and enhanced graphics!
 0.07: Swipe right to change between Mario and Toad characters, swipe left to toggle night mode
-0.08: Add Readme. Add Princes Daisy. Update date panel to be info panel toggling between Date, Battery and Temperature
+0.08: Update date panel to be info panel toggling between Date, Battery and Temperature. Add Princes Daisy.

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -5,3 +5,4 @@
 0.05: use 12/24 hour clock from settings
 0.06: Performance refactor, and enhanced graphics!
 0.07: Swipe right to change between Mario and Toad characters, swipe left to toggle night mode
+0.08: Add Readme. Add Princes Daisy

--- a/apps/marioclock/README.md
+++ b/apps/marioclock/README.md
@@ -12,8 +12,8 @@ Enjoy watching Mario, or one of the other game characters run through a level wh
 * Smooth animation
 * Awesome 8-bit style grey-scale graphics
 * Mario jumps to change the time, every minute
-* You can make Mario jump by pressing the top button (Button 1) on the watch
-* Toggle the info pannel bettween `Date`, `Battery level`, and `Temperature` by pressing the bottom button (Button 3).
+* You can make Mario jump by pressing the bottom button (Button 3) on the watch
+* Toggle the info pannel bettween `Date`, `Battery level`, and `Temperature` by pressing the top button (Button 1).
 
 ## Requests
 

--- a/apps/marioclock/README.md
+++ b/apps/marioclock/README.md
@@ -7,12 +7,13 @@ Enjoy watching Mario, or one of the other game characters run through a level wh
 
 ## Features
 
-* Multiple characters - swipe the screen right to change the character
+* Multiple characters - swipe the screen right to change the character between `Mario`, `Toad`, and `Daisy`
 * Night and Day modes - swipe left to toggle mode
 * Smooth animation
 * Awesome 8-bit style grey-scale graphics
 * Mario jumps to change the time, every minute
 * You can make Mario jump by pressing the top button (Button 1) on the watch
+* Toggle the info pannel bettween `Date`, `Battery level`, and `Temperature` by pressing the bottom button (Button 3).
 
 ## Requests
 

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -27,6 +27,7 @@ const DARKEST = "#122d3e";
 const NIGHT = "#001818";
 
 // Character names
+const DAISY = "daisy";
 const TOAD = "toad";
 const MARIO = "mario";
 
@@ -65,11 +66,18 @@ function genRanNum(min, max) {
 
 function switchCharacter() {
   const curChar = characterSprite.character;
+
   let newChar;
-  if (curChar === MARIO) {
-    newChar = TOAD;
-  } else {
-    newChar = MARIO;
+  switch(curChar) {
+    case DAISY:
+      newChar = MARIO;
+      break;
+    case  TOAD:
+      newChar = DAISY;
+      break;
+    case MARIO:
+    default:
+      newChar = TOAD;
   }
 
   characterSprite.character = newChar;
@@ -193,6 +201,19 @@ function drawCoin() {
   drawCoinFrame(coinSprite.x, coinSprite.y);
 }
 
+function drawDaisyFrame(idx, x, y) {
+  switch(idx) {
+    case 0:
+      const dFr1 = require("heatshrink").decompress(atob("h8UxH+AAsHAIgAI60HAIQOJBYIABDpMHAAwNNB4wOJB4gIEHgQBBBxYQCBwYLDDhIaEBxApEw4qDAgIOHDwiIEBwtcFIRWIUgWHw6TIAQXWrlcWZAqBDQIeBBxQaBDxIcCHIQ8JDAIAFWJLPHA=="));
+      g.drawImage(dFr1, x, y);
+      break;
+    case 1:
+    default:
+      const dFr2 = require("heatshrink").decompress(atob("h8UxH+AAsHAIgAI60HAIQOJBYIABDpMHAAwNNB4wOJB4gIEHgQBBBxYQCBwYLDDhIaEBxApEw4qDAgIOHDwiIEBwtcFIRWIUgQvBSZACCBwNcWZQcCAAIPIDgYACFw4YBDYIOCD4waEDYI+HaBQ="));
+      g.drawImage(dFr2, x, y);
+  }
+}
+
 function drawMarioFrame(idx, x, y) {
   switch(idx) {
     case 0:
@@ -200,10 +221,9 @@ function drawMarioFrame(idx, x, y) {
       g.drawImage(mFr1, x, y);
       break;
     case 1:
+    default:
       const mFr2 = require("heatshrink").decompress(atob("h8UxH+AAkHAAYKFBolcAAIPIBgYPDBpgfGFIY7EA4YcEBIPWAAYdDC4gLDAII5ECoYOFDogODFgoJCBwYZCAQYOFBAhAFFwZKGHQpMDw+HCQYEBSowOBBQIdCCgTOIFgiVHFwYCBUhA9FBwz8HAo73GACQA=")); // Mario frame 2
       g.drawImage(mFr2, x, y);
-      break;
-    default:
   }
 }
 
@@ -214,10 +234,9 @@ function drawToadFrame(idx, x, y) {
       g.drawImage(tFr1, x, y);
       break;
     case 1:
+    default:
       const tFr2 = require("heatshrink").decompress(atob("iEUxH+ACkHAAoNJrnWAAQRGg/WrgACB4QEBCAYOBB44QFB4QICAg4QBBAQbDEgwPCHpAGCGAQ9KAYQPKCYg/EJAoADAwaKFw4BEP4YQCBIIABB468EB4QADYIoQGDwQOGBYQrDb4wcGFxYLDMoYgHRYgwKABAMBA")); // Mario frame 2
       g.drawImage(tFr2, x, y);
-      break;
-    default:
   }
 }
 
@@ -251,10 +270,13 @@ function drawCharacter(date, character) {
   }
 
   switch(characterSprite.character) {
-    case(TOAD):
+    case DAISY:
+      drawDaisyFrame(characterSprite.frameIdx, characterSprite.x, characterSprite.y);
+      break;
+    case TOAD:
       drawToadFrame(characterSprite.frameIdx, characterSprite.x, characterSprite.y);
       break;
-    case(MARIO):
+    case MARIO:
     default:
       drawMarioFrame(characterSprite.frameIdx, characterSprite.x, characterSprite.y);
   }
@@ -362,13 +384,7 @@ function init() {
     Bangle.showLauncher();
   }, BTN2, {repeat:false,edge:"falling"});
 
-  Bangle.on('lcdPower', (on) => {
-    if (on) {
-      startTimers();
-    } else {
-      clearTimers();
-    }
-  });
+  Bangle.on('lcdPower', (on) => on ? startTimers() : clearTimers());
 
   Bangle.on('faceUp', (up) => {
     if (up && !Bangle.isLCDOn()) {
@@ -382,11 +398,11 @@ function init() {
 
     switch(sDir) {
       // Swipe right (1) - change character (on a loop)
-      case(1):
+      case 1:
         switchCharacter();
         break;
       // Swipe left (-1) - change day/night mode (on a loop)
-      case(-1):
+      case -1:
       default:
         toggleNightMode();
     }

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -450,7 +450,7 @@ function init() {
   setWatch(() => {
     if (intervalRef && !characterSprite.isJumping) characterSprite.isJumping = true;
     resetDisplayTimeout();
-  }, BTN1, {repeat: true});
+  }, BTN3, {repeat: true});
 
   // Close watch and load launcher app
   setWatch(() => {
@@ -461,7 +461,7 @@ function init() {
   // Change info mode
   setWatch(() => {
     changeInfoMode();
-  }, BTN3, {repeat: true});
+  }, BTN1, {repeat: true});
 
   Bangle.on('lcdPower', (on) => on ? startTimers() : clearTimers());
 

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -33,7 +33,7 @@ const MARIO = "mario";
 
 const characterSprite = {
   frameIdx: 0,
-  x: 35,
+  x: 33,
   y: 55,
   jumpCounter: 0,
   jumpIncrement: Math.PI / 6,


### PR DESCRIPTION
# Details
Press BTN3 to toggle what was displayed on the date panel (now referred to as the info panel) between the `Date`, `Battery level %`, and `Temperature`.

Add new character (this will be the last on I add) which is Princess Daisy.

## Info

This feature has been added as requests have come in to display widgets which is not possible in 80x80 display mode, nor was this watch face designed to show anything but what it currently does.

So as a compromise, I have updated the app to let you display the date, battery, and temperature in the one panel, by cycling through them on BTN3 press.

I think this works really well, and is not distracting nor taking up valuable space that wasn't already being used.

## Images
### Info panel
#### Date
![screenshot (11)](https://user-images.githubusercontent.com/260514/78680899-fade3f80-78e3-11ea-8613-63e4f89ba5c8.png)
#### Battery
![screenshot (12)](https://user-images.githubusercontent.com/260514/78680946-07629800-78e4-11ea-99a5-b58f89da54d6.png)
#### Temperature
![screenshot (14)](https://user-images.githubusercontent.com/260514/78680964-0e89a600-78e4-11ea-8474-788c76f976d4.png)
### New character
#### Princess Daisy
![screenshot (16)](https://user-images.githubusercontent.com/260514/78681006-1b0dfe80-78e4-11ea-9b56-c884ff70c86f.png)

