### PR TITLE
gbridge: don't turn on screen at start of every song

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -92,7 +92,7 @@
   { "id": "gbridge",
     "name": "Gadgetbridge",
     "icon": "app.png",
-    "version":"0.07",
+    "version":"0.08",
     "description": "The default notification handler for Gadgetbridge notifications from Android",
     "tags": "tool,system,android,widget",
     "type":"widget",

--- a/apps/gbridge/ChangeLog
+++ b/apps/gbridge/ChangeLog
@@ -6,3 +6,4 @@
       Optimize animation, limit title length
 0.06: Gadgetbridge App 'Connected' state is no longer toggleable
 0.07: Move configuration to settings menu
+0.08: Don't turn on LCD at start of every song

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -16,7 +16,8 @@
     Bluetooth.println(JSON.stringify(message));
   }
 
-  function showNotification(size, render) {
+  function showNotification(size, render, turnOn) {
+    if (turnOn === undefined) turnOn = true
     var oldMode = Bangle.getLCDMode();
 
     Bangle.setLCDMode("direct");
@@ -31,7 +32,7 @@
     g.fillRect(238, 240, 239, 319);
     g.fillRect(2, 318, 238, 319);
 
-    Bangle.setLCDPower(1); // light up
+    if (turnOn) Bangle.setLCDPower(1); // light up
     Bangle.setLCDMode(oldMode); // clears cliprect
 
     function anim() {
@@ -97,6 +98,7 @@
   }
 
   function handleMusicStateUpdate(event) {
+    const changed = state.music === event.state
     state.music = event.state
 
     if (state.music == "play") {
@@ -113,7 +115,7 @@
         g.setFont("6x8", 1);
         g.setColor("#ffffff");
         g.drawString(state.musicInfo.track, x, y + 22);
-      });
+      }, changed);
     }
 
     if (state.music == "pause") {


### PR DESCRIPTION
Do draw the notification, so you can still look up what is playing.