### PR TITLE
Force reload of app list after successful upload to prevent exception

### DIFF
--- a/js/comms.js
+++ b/js/comms.js
@@ -23,6 +23,8 @@ uploadApp : (app,skipReset) => { // expects an apps.json structure (i.e. with `s
           Puck.write(`\x10E.showMessage('Hold BTN3\\nto reload')\n`,(result) => {
             Progress.hide({sticky:true});
             if (result===null) return reject("");
+            // Reload apps to get a fresh list of apps and files
+            this.getInstalledApps();
             resolve(app);
           });
           return;

--- a/js/comms.js
+++ b/js/comms.js
@@ -24,7 +24,7 @@ uploadApp : (app,skipReset) => { // expects an apps.json structure (i.e. with `s
             Progress.hide({sticky:true});
             if (result===null) return reject("");
             // Reload apps to get a fresh list of apps and files
-            this.getInstalledApps();
+            this.getInstalledApps(true);
             resolve(app);
           });
           return;


### PR DESCRIPTION
I am forcing a reload of the app list after successful upload to prevent the following exception to occurr if one wants to remove an app right after installing it without reloading the apps or the web page in between:

> $SomeAppName removal failed, TypeError: Cannot read property 'split' of undefined

The error happens here:
https://github.com/espruino/BangleApps/blob/82790d5f38f288d50af7a089dea380fd12ebad4d/js/comms.js#L85