### PR TITLE
Mario Clock [Enhancement] - Integrate GadgetBridge

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -914,7 +914,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.08",
+    "version":"0.09",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -5,4 +5,5 @@
 0.05: use 12/24 hour clock from settings
 0.06: Performance refactor, and enhanced graphics!
 0.07: Swipe right to change between Mario and Toad characters, swipe left to toggle night mode
-0.08: Update date panel to be info panel toggling between Date, Battery and Temperature. Add Princes Daisy.
+0.08: Update date panel to be info panel toggling between Date, Battery and Temperature. Add Princes Daisy
+0.09: Add GadgetBridge functionality. Mario shows message type in speach bubble, while message scrolls in info panel

--- a/apps/marioclock/README.md
+++ b/apps/marioclock/README.md
@@ -13,7 +13,8 @@ Enjoy watching Mario, or one of the other game characters run through a level wh
 * Awesome 8-bit style grey-scale graphics
 * Mario jumps to change the time, every minute
 * You can make Mario jump by pressing the bottom button (Button 3) on the watch
-* Toggle the info pannel bettween `Date`, `Battery level`, and `Temperature` by pressing the top button (Button 1).
+* Toggle the info pannel bettween `Date`, `Battery level`, and `Temperature` by pressing the top button (Button 1)
+* If you have [GadgetBridge](https://f-droid.org/packages/nodomain.freeyourgadget.gadgetbridge/) installed on your phone, Mario will let you know when you get a new call or notification. You can clear a message by pressing either Button 1 or Button 3
 
 ## Requests
 


### PR DESCRIPTION
# Summary

Integrate GadgeBridge (partially any way) in to Mario Clock.

# Details

If your BangleJS is connected to you mobile phone via GadgetBridge you will be notified of incoming calls and any generic notification.

Mario (or any of the characters) will show the notification type in a speech bubble, while the relevant details of the notification are scrolled along the info panel.

Pressing BTN1 or BTN3 will cancel the notification

# Issues

## Connection

It works fine, but having connected to the IDE, my Apps store, and Gadget bridge sometimes it wont find the device / connect without restarting the watch (turn off and on again). Maybe someone can see if I'm not handling the BLE properly?

## Emulator

The emulator complains the graphics buffer is out of memory. Can anyone see where I can save a few bytes?

# Images

![mario-gadget-bridge](https://user-images.githubusercontent.com/260514/78808419-4a446e80-79bd-11ea-8784-7cbed93e8169.gif)
