### PR TITLE
MarioClock [Enhancement] - Nightmode + 3 levels of darkness + Settings persisted + New info banner messages

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -914,7 +914,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.10",
+    "version":"0.11",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps.json
+++ b/apps.json
@@ -914,7 +914,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.09",
+    "version":"0.10",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps.json
+++ b/apps.json
@@ -914,7 +914,7 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.11",
+    "version":"0.12",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -8,3 +8,4 @@
 0.08: Update date panel to be info panel toggling between Date, Battery and Temperature. Add Princes Daisy
 0.09: Add GadgetBridge functionality. Mario shows message type in speach bubble, while message scrolls in info panel
 0.10: Swiping left to enable night-mode now also reduces LCD brightness through 3 levels before returning to day-mode.
+0.11: User settings persisted and read to file.

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -7,3 +7,4 @@
 0.07: Swipe right to change between Mario and Toad characters, swipe left to toggle night mode
 0.08: Update date panel to be info panel toggling between Date, Battery and Temperature. Add Princes Daisy
 0.09: Add GadgetBridge functionality. Mario shows message type in speach bubble, while message scrolls in info panel
+0.10: Swiping left to enable night-mode now also reduces LCD brightness through 3 levels before returning to day-mode.

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -9,3 +9,4 @@
 0.09: Add GadgetBridge functionality. Mario shows message type in speach bubble, while message scrolls in info panel
 0.10: Swiping left to enable night-mode now also reduces LCD brightness through 3 levels before returning to day-mode.
 0.11: User settings persisted and read to file.
+0.12: Add info banner message when phone (dis)connects. Display low-battery warning (<=10%)

--- a/apps/marioclock/README.md
+++ b/apps/marioclock/README.md
@@ -8,7 +8,7 @@ Enjoy watching Mario, or one of the other game characters run through a level wh
 ## Features
 
 * Multiple characters - swipe the screen right to change the character between `Mario`, `Toad`, and `Daisy`
-* Night and Day modes - swipe left to toggle mode
+* Night and Day modes - swipe left to enter night mode, with 3 levels of darkness before returning to day mode.
 * Smooth animation
 * Awesome 8-bit style grey-scale graphics
 * Mario jumps to change the time, every minute

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -16,6 +16,8 @@ const is12Hour = settings["12hour"] || false;
 
 // Screen dimensions
 let W, H;
+// Screen brightness
+let brightness = 1;
 
 let intervalRef, displayTimeoutRef = null;
 
@@ -164,7 +166,17 @@ function switchCharacter() {
 }
 
 function toggleNightMode() {
-  nightMode = !nightMode;
+  if (!nightMode) {
+    nightMode = true;
+    return;
+  }
+
+  brightness -= 0.30;
+  if (brightness <= 0) {
+    brightness = 1;
+    nightMode = false;
+  }
+  Bangle.setLCDBrightness(brightness);
 }
 
 function incrementTimer() {
@@ -625,4 +637,4 @@ function init() {
 }
 
 // Initialise!
-init()
+init();

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -81,6 +81,16 @@ const phone = {
   messageType: null,
 };
 
+const SETTINGS_FILE = "marioclock.json";
+
+function readSettings() {
+  return require('Storage').readJSON(SETTINGS_FILE, 1) || {};
+}
+
+function writeSettings(newSettings) {
+  require("Storage").writeJSON(SETTINGS_FILE, newSettings);
+}
+
 function phoneOutbound(msg) {
   Bluetooth.println(JSON.stringify(msg));
 }
@@ -567,8 +577,31 @@ function startTimers(){
   redraw();
 }
 
+function loadSettings() {
+  const settings = readSettings();
+  if (!settings) return;
+
+  if (settings.character) characterSprite.character = settings.character;
+  if (settings.nightMode) nightMode = settings.nightMode;
+  if (settings.brightness) {
+    brightness = settings.brightness;
+    Bangle.setLCDBrightness(brightness);
+  }
+}
+
+function updateSettings() {
+  const newSettings = {
+    character: characterSprite.character,
+    nightMode: nightMode,
+    brightness: brightness,
+  };
+  writeSettings(newSettings);
+}
+
 // Main
 function init() {
+  loadSettings();
+
   clearInterval();
 
   // Initialise display
@@ -618,6 +651,8 @@ function init() {
       default:
         toggleNightMode();
     }
+
+    updateSettings();
   });
 
   // Phone connectivity

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -359,7 +359,7 @@ function drawNotice(x, y) {
       break;
   }
 
-  g.drawImage(img, characterSprite.x, characterSprite.y - 16);
+  if (img) g.drawImage(img, characterSprite.x, characterSprite.y - 16);
 }
 
 function drawCharacter(date, character) {
@@ -671,7 +671,6 @@ function init() {
   try { NRF.wake(); } catch (e) {}
 
   NRF.on('disconnect', () => {
-    Bangle.buzz();
     phoneNewMessage(null, "Phone disconnected");
   });
 
@@ -679,7 +678,6 @@ function init() {
     setTimeout(() => {
       phoneOutbound({ t: "status", bat: E.getBattery() });
     }, ONE_SECOND * 2);
-    Bangle.buzz();
     phoneNewMessage(null, "Phone connected");
   });
 


### PR DESCRIPTION
# Changes
* In night mode, further left swipes reduce the screen brightness (3 levels) until returning to day-mode
* Persist and load user settings
* Display info banner message when phone connects/disconnects
* Display info banner message when phone battery <= 10% (checks every 10 mins) along with character speech low-battery bubble.