### PR TITLE
Unmotivagedgene show modal scroll fix

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1158,5 +1158,18 @@
       {"name":"batchart.app.js","url":"app.js"},
       {"name":"batchart.img","url":"app-icon.js","evaluate":true}
     ]
-  }
+  },
+  { "id": "nato",
+    "name": "NATO Alphabet",
+    "shortName" : "NATOAlphabet",
+    "icon": "nato.png",
+    "version":"0.01",
+    "type": "app",
+    "description": "Learn the NATO Phonetic alphabet plus some numbers.",
+    "tags": "app,learn,visual",
+    "storage": [
+      {"name":"nato.app.js","url":"nato.js"},
+      {"name":"nato.img","url":"nato-icon.js","evaluate":true}
+    ],
+  },
 ]

--- a/js/index.js
+++ b/js/index.js
@@ -185,7 +185,7 @@ function refreshLibrary() {
     var version = getVersionInfo(app, appInstalled);
     var versionInfo = version.text;
     if (versionInfo) versionInfo = " <small>("+versionInfo+")</small>";
-    var readme = `<a href="#" onclick="showReadme('${app.id}')">Read more...</a>`;
+    var readme = `<a href="javascript:;" onclick="showReadme('${app.id}')">Read more...</a>`;
     return `<div class="tile column col-6 col-sm-12 col-xs-12">
     <div class="tile-icon">
       <figure class="avatar"><img src="apps/${app.icon?`${app.id}/${app.icon}`:"unknown.png"}" alt="${escapeHtml(app.name)}"></figure><br/>

--- a/js/utils.js
+++ b/js/utils.js
@@ -49,7 +49,7 @@ function getVersionInfo(appListing, appInstalled) {
   var versionText = "";
   var canUpdate = false;
   function clicky(v) {
-    return `<a href="#" onclick="showChangeLog('${appListing.id}')">${v}</a>`;
+    return `<a href="javascript:;" onclick="showChangeLog('${appListing.id}')">${v}</a>`;
   }
 
   if (!appInstalled) {


### PR DESCRIPTION
I noticed on the bangle.js/apps page that clicking links that trigger modals would often scroll you to the top of the screen, losing your place in the list. I found 2 so far, for the showChangeLog and showReadMe type links.

My fix is changing target of link from "#" to "javascript:;"

Example
```
// change
< a href="#" onclick="showChangeLog()" > 
// to
< a href="javascript:;" onclick="showChangeLog()" > 
```