### PR TITLE
Remove "settings" from appid.info

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -120,7 +120,7 @@
   { "id": "setting",
     "name": "Settings",
     "icon": "settings.png",
-    "version":"0.16",
+    "version":"0.17",
     "description": "A menu for setting up Bangle.js",
     "tags": "tool,system",
     "storage": [

--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -18,3 +18,4 @@
 0.14: Reduce memory usage when running app settings page
 0.15: Reduce memory usage when running default clock chooser (#294)
 0.16: Reduce memory usage further when running app settings page
+0.17: Remove need for "settings" in appid.info

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -416,10 +416,19 @@ function showAppSettingsMenu() {
     '': { 'title': 'App Settings' },
     '< Back': ()=>showMainMenu(),
   }
-  const apps = storage.list(/\.info$/)
-    .map(app => {var a=storage.readJSON(app, 1);return (a&&a.settings)?{sortorder:a.sortorder,name:a.name,settings:a.settings}:undefined})
-    .filter(app => app) // filter out any undefined apps
-    .sort((a, b) => a.sortorder - b.sortorder)
+  const apps = storage.list(/\.settings\.js$/)
+    .map(s => s.substr(0, s.length-12))
+    .map(id => {
+      const a=storage.readJSON(id+'.info',1);
+      return {id:id,name:a.name,sortorder:a.sortorder};
+    })
+    .sort((a, b) => {
+      const n = (0|a.sortorder)-(0|b.sortorder);
+      if (n) return n; // do sortorder first
+      if (a.name<b.name) return -1;
+      if (a.name>b.name) return 1;
+      return 0;
+    })
   if (apps.length === 0) {
     appmenu['No app has settings'] = () => { };
   }
@@ -433,10 +442,7 @@ function showAppSettings(app) {
     E.showMessage(`${app.name}:\n${msg}!\n\nBTN1 to go back`);
     setWatch(showAppSettingsMenu, BTN1, { repeat: false });
   }
-  let appSettings = storage.read(app.settings);
-  if (!appSettings) {
-    return showError('Missing settings');
-  }
+  let appSettings = storage.read(app.id+'.settings.js');
   try {
     appSettings = eval(appSettings);
   } catch (e) {

--- a/js/appinfo.js
+++ b/js/appinfo.js
@@ -60,8 +60,6 @@ var AppInfo = {
       if (app.type && app.type!="app") json.type = app.type;
       if (fileContents.find(f=>f.name==app.id+".app.js"))
         json.src = app.id+".app.js";
-      if (fileContents.find(f=>f.name==app.id+".settings.js"))
-        json.settings = app.id+".settings.js";
       if (fileContents.find(f=>f.name==app.id+".img"))
         json.icon = app.id+".img";
       if (app.sortorder) json.sortorder = app.sortorder;


### PR DESCRIPTION
Didn't see you already improved it a bit, but this also removes the need for appid.info.settings.
(So now `appid.settings.js` is hardcoded in the settings app instead of during upload)

So we could get rid of https://github.com/espruino/BangleApps/blob/242c35dfac89f2e962b807292f8e17dc6d0bdc80/js/appinfo.js#L63-L64 once enough(?) people have updated the settings app.