### PR TITLE
Add option in settings to hide battery indicator widget when battery is over 20%.

### DIFF
--- a/apps/widbatpc/widbatpc.settings.js
+++ b/apps/widbatpc/widbatpc.settings.js
@@ -11,6 +11,7 @@
     'color': COLORS[0],
     'percentage': true,
     'charger': true,
+    'hideifmorethan20pct': false,
   }
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -51,8 +52,13 @@
         const newIndex = (oldIndex + 1) % COLORS.length
         s.color = COLORS[newIndex]
         save('color')(s.color)
-      },
-    },
-  }
+       }
+     },
+    'Hide when \> 20\%': {
+      value: s.hideifmorethan20pct,
+      format: onOffFormat,
+      onchange: save('hideifmorethan20pct'),
+     },
+    } 
   E.showMenu(menu)
 })

--- a/apps/widbatpc/widbatpc.settings.json
+++ b/apps/widbatpc/widbatpc.settings.json
@@ -1,0 +1,1 @@
+{"color":"By Level","percentage":true,"charger":true,"hideifmorethan20pct":false}

--- a/apps/widbatpc/widbatpc.wid.js
+++ b/apps/widbatpc/widbatpc.wid.js
@@ -3,6 +3,7 @@ const DEFAULTS = {
   'color': 'By Level',
   'percentage': true,
   'charger': true,
+  'hideifmorethan20pct': false,
 }
 const COLORS = {
   'white': -1,
@@ -53,8 +54,16 @@ function setWidth() {
   }
 }
 function draw() {
+
   var s = 39;
   var x = this.x, y = this.y;
+  const l = E.getBattery(),
+  c = levelColor(l);
+  const xl = x+4+l*(s-12)/100
+
+  if(!Bangle.isCharging() && setting('hideifmorethan20pct') && l > 20){
+     return;}
+
   if (Bangle.isCharging() && setting('charger')) {
     g.setColor(chargerColor()).drawImage(atob(
       "DhgBHOBzgc4HOP////////////////////3/4HgB4AeAHgB4AeAHgB4AeAHg"),x,y);
@@ -64,9 +73,7 @@ function draw() {
   g.fillRect(x,y+2,x+s-4,y+21);
   g.clearRect(x+2,y+4,x+s-6,y+19);
   g.fillRect(x+s-3,y+10,x+s,y+14);
-  const l = E.getBattery(),
-    c = levelColor(l);
-  const xl = x+4+l*(s-12)/100
+
   g.setColor(c).fillRect(x+4,y+6,xl,y+17);
   g.setColor(-1);
   if (!setting('percentage')) {


### PR DESCRIPTION
In case the user only wants to know battery status when it is low enough to need charging soon, this setting will stop the widget from being drawn when the battery has >  20% capacity.  
It ain't too pretty here but it works. Suggestions / changes are of course welcome - I recognize my coding skills are pretty rusty. :)