### PR TITLE
Removed href="#" that scrolls pages on top

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -207,7 +207,7 @@ function refreshLibrary() {
     var version = getVersionInfo(app, appInstalled);
     var versionInfo = version.text;
     if (versionInfo) versionInfo = " <small>("+versionInfo+")</small>";
-    var readme = `<a href="#" onclick="showReadme('${app.id}')">Read more...</a>`;
+    var readme = `<a class="c-hand" onclick="showReadme('${app.id}')">Read more...</a>`;
     var favourite = favourites.find(e => e == app.id);
     return `<div class="tile column col-6 col-sm-12 col-xs-12">
     <div class="tile-icon">

--- a/js/utils.js
+++ b/js/utils.js
@@ -49,7 +49,7 @@ function getVersionInfo(appListing, appInstalled) {
   var versionText = "";
   var canUpdate = false;
   function clicky(v) {
-    return `<a href="#" onclick="showChangeLog('${appListing.id}')">${v}</a>`;
+    return `<a class="c-hand" onclick="showChangeLog('${appListing.id}')">${v}</a>`;
   }
 
   if (!appInstalled) {


### PR DESCRIPTION
I've replaced `href="#"` with `class="c-hand"` (available in Spectre framework) to avoid pages scrolling on top on every click on app changelogs or "Read mode..." links.