### PR TITLE
Speedo app: Allow widgets

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -286,7 +286,7 @@
   { "id": "speedo",
     "name": "Speedo",
     "icon": "speedo.png",
-    "version":"0.01",
+    "version":"0.02",
     "description": "Show the current speed according to the GPS",
     "tags": "tool,outdoors,gps",
     "storage": [

--- a/apps/speedo/speedo.js
+++ b/apps/speedo/speedo.js
@@ -1,12 +1,14 @@
+Bangle.loadWidgets();
 Bangle.setGPSPower(1);
 Bangle.setLCDMode("doublebuffered");
 var lastFix = {fix:0,satellites:0};
 function onGPS(fix) {
   lastFix = fix;
   g.clear();
+  Bangle.drawWidgets();
   g.setFontAlign(0,0);
   g.setFont("6x8");
-  g.drawString(fix.satellites+" satellites",120,6);
+  g.drawString(fix.satellites+" satellites",120,36);
   if (fix.fix) {
     var txt = (fix.speed<20) ? fix.speed.toFixed(1) : Math.round(fix.speed);
     var s = 80;


### PR DESCRIPTION
Enable Widgets in Speedo app

This allows e.g. GPS Recorder to work in the background while running Speedo.