### PR TITLE
Report battery status to Gadgetbridge more often

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -95,7 +95,7 @@
   { "id": "gbridge",
     "name": "Gadgetbridge",
     "icon": "app.png",
-    "version":"0.10",
+    "version":"0.11",
     "description": "The default notification handler for Gadgetbridge notifications from Android",
     "tags": "tool,system,android,widget",
     "type":"widget",

--- a/apps/gbridge/ChangeLog
+++ b/apps/gbridge/ChangeLog
@@ -9,3 +9,4 @@
 0.08: Don't turn on LCD at start of every song
 0.09: Update Bluetooth connection state automatically
 0.10: Make widget play well with other Gadgetbridge widgets/apps
+0.11: Report battery status on connect and at regular intervals

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -197,5 +197,11 @@
 
   WIDGETS["gbridgew"] = { area: "tl", width: 24, draw: draw };
 
-  gbSend({ t: "status", bat: E.getBattery() });
+  function sendBattery() {
+    gbSend({ t: "status", bat: E.getBattery() });
+  }
+
+  NRF.on("connect", () => setTimeout(sendBattery, 2000));
+  setInterval(sendBattery, 10*60*1000);
+  sendBattery();
 })();

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -13,6 +13,7 @@
   };
 
   function gbSend(message) {
+    Bluetooth.println("");
     Bluetooth.println(JSON.stringify(message));
   }
 


### PR DESCRIPTION
Make gbridge widget report battery status at regular intervals and shortly after connecting, instead of just when the widget is loaded.