### PR TITLE
gpstime 0.04: Fix shown UTC time zone sign

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -280,7 +280,7 @@
   { "id": "gpstime",
     "name": "GPS Time",
     "icon": "gpstime.png",
-    "version":"0.03",
+    "version":"0.04",
     "description": "Update the Bangle.js's clock based on the time from the GPS receiver",
     "tags": "tool,gps",
     "storage": [

--- a/apps/gpstime/ChangeLog
+++ b/apps/gpstime/ChangeLog
@@ -1,1 +1,2 @@
 0.03: Fix time output on new firmwares when no GPS time set (fix #104)
+0.04: Fix shown UTC time zone sign

--- a/apps/gpstime/gpstime.js
+++ b/apps/gpstime/gpstime.js
@@ -47,7 +47,7 @@ Bangle.on('GPS',function(f) {
   g.drawString(t[4],120,185); // time
   if (fix.time) {
     // timezone
-    var tz = (new Date()).getTimezoneOffset()/60;
+    var tz = (new Date()).getTimezoneOffset()/-60;
     if (tz==0) tz="UTC";
     else if (tz>0) tz="UTC+"+tz;
     else tz="UTC"+tz;


### PR DESCRIPTION
Like for example at [comms.js](https://github.com/espruino/BangleApps/blob/master/js/comms.js#L156), the `getTimezoneOffset()` return value must be inverted to get correct time zone.