### PR TITLE
Require correct module in apploader.js  and fix typo in appinfo.js

### DIFF
--- a/bin/apploader.js
+++ b/bin/apploader.js
@@ -15,6 +15,7 @@ var SETTINGS = {
 };
 var Utils = require("../js/utils.js");
 var AppInfo = require("../js/appinfo.js");
+var noble = require('@abandonware/noble');
 var apps;
 
 function ERROR(msg) {
@@ -62,7 +63,6 @@ function cmdInstallApp(appId) {
 }
 
 function bangleSend(command) {
-  var noble = require('noble');
   var log = function() {
     var args = [].slice.call(arguments);
     console.log("UART: "+args.join(" "));

--- a/js/appinfo.js
+++ b/js/appinfo.js
@@ -2,7 +2,7 @@ if (typeof btoa==="undefined") {
   // Don't define btoa as a function here because Apple's
   // iOS browser defines the function even though it's in
   // an IF statement that is never executed!
-  btoa = function(d) { return BufferA.from(d).toString('base64'); }
+  btoa = function(d) { return Buffer.from(d).toString('base64'); }
 }
 
 // Converts a string into most efficient way to send to Espruino (either json, base64, or compressed base64)


### PR DESCRIPTION
Thank you for the apploader.js. That is really helpful!
For being able to use the apploader.js I had to change some code.

After installing noble with `npm install -g '@abandonware/noble'` I had to require '@abandonware/noble' instead of just 'noble'.

I can't test the code in a apple browseri, but I think the `ABuffer` is a typo and should be `Buffer`.