### PR TITLE
Make the alarm scheduling more reliable

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -137,7 +137,7 @@
     "name": "Default Alarm",
     "shortName":"Alarms",
     "icon": "app.png",
-    "version":"0.07",
+    "version":"0.08",
     "description": "Set and respond to alarms",
     "tags": "tool,alarm,widget",
     "storage": [

--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Add alarm.boot.js and move code from the bootloader
 0.06: Change 'New Alarm' to 'Save', allow Deletion of Alarms
 0.07: Don't overwrite existing settings on app update
+0.08: Make alarm scheduling more reliable

--- a/apps/alarm/boot.js
+++ b/apps/alarm/boot.js
@@ -11,7 +11,7 @@
       require('Storage').write('alarm.json',"[]");
     } else {
       var t = 3600000*(active[0].hr-hr);
-      if (active[0].last == time.getDate()) t += 86400000;
+      if (active[0].last == time.getDate() || t < 0) t += 86400000;
       if (t<1000) t=1000;
       /* execute alarm at the correct time. We avoid execing immediately
       since this code will get called AGAIN when alarm.js is loaded. alarm.js

--- a/apps/alarm/boot.js
+++ b/apps/alarm/boot.js
@@ -2,15 +2,16 @@
 (function() {
   var alarms = require('Storage').readJSON('alarm.json',1)||[];
   var time = new Date();
-  var active = alarms.filter(a=>a.on&&(a.last!=time.getDate()));
+  var active = alarms.filter(a=>a.on);
   if (active.length) {
-    active = active.sort((a,b)=>a.hr-b.hr);
+    active = active.sort((a,b)=>(a.hr-b.hr)+(a.last-b.last)*24);
     var hr = time.getHours()+(time.getMinutes()/60)+(time.getSeconds()/3600);
     if (!require('Storage').read("alarm.js")) {
       console.log("No alarm app!");
-      require('Storage').write('alarm.json',"[]")
+      require('Storage').write('alarm.json',"[]");
     } else {
       var t = 3600000*(active[0].hr-hr);
+      if (active[0].last == time.getDate()) t += 86400000;
       if (t<1000) t=1000;
       /* execute alarm at the correct time. We avoid execing immediately
       since this code will get called AGAIN when alarm.js is loaded. alarm.js
@@ -21,4 +22,4 @@
       },t);
     }
   }
-})()
+})();


### PR DESCRIPTION
Fixes https://github.com/espruino/BangleApps/issues/433: instead of only selecting the alarms that didn't already run during the current day for scheduling, get all active alarms, sort accordingly and add 24h to the timer if the alarm already ran.