### PR TITLE
Simpletimer: remember last set time, make BTN2 work

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1634,7 +1634,7 @@
     "id": "simpletimer",
     "name": "Timer",
     "icon": "app.png",
-    "version": "0.03",
+    "version": "0.04",
     "description": "Simple timer, useful when playing board games or cooking",
     "tags": "timer",
     "readme": "README.md",
@@ -1658,6 +1658,11 @@
         "name": "simpletimer.img",
         "url": "app-icon.js",
         "evaluate": true
+      }
+    ],
+    "data": [
+      {
+        "name": "simpletimer.json"
       }
     ]
   },

--- a/apps/simpletimer/ChangeLog
+++ b/apps/simpletimer/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial version
 0.02: Reset with gesture
 0.03: BTN2 to open launcher
+0.04: Remember last set time

--- a/apps/simpletimer/README.md
+++ b/apps/simpletimer/README.md
@@ -15,4 +15,5 @@ Simple timer, useful when playing board games or cooking
 - Tap on seconds to increase them one by one
 - Press BTN3 to reset time to 0
 - Press BTN1 to start the timer or reset to the original time
+- Press BTN2 to return to the launcher (only while countdown is not running)
 - When the time is up use the [swipeleft](https://github.com/espruino/BangleApps/tree/master/apps/gesture) gesture to reset the timer

--- a/apps/simpletimer/app.js
+++ b/apps/simpletimer/app.js
@@ -111,7 +111,6 @@ function reset(value) {
   state = value === 0 ? "unset" : "set";
 }
 
-setWatch(Bangle.showLauncher, BTN2, { repeat: false, edge: "falling" });
 function addWatch() {
   clearWatch();
   setWatch(changeState, BTN1, {
@@ -119,6 +118,16 @@ function addWatch() {
     repeat: true,
     edge: "falling"
   });
+  setWatch(() => {
+    if (state !== "started") {
+      Bangle.showLauncher();
+    }},
+  BTN2,
+  {
+    repeat: false,
+    edge: "falling",
+  },
+  );
   setWatch(
     () => {
       reset(0);

--- a/apps/simpletimer/app.js
+++ b/apps/simpletimer/app.js
@@ -2,6 +2,7 @@ let counter = 0;
 let setValue = 0;
 let counterInterval;
 let state;
+let saved = require("Storage").readJSON("simpletimer.json",true) || {};
 
 const DEBOUNCE = 50;
 
@@ -61,6 +62,8 @@ function clearIntervals() {
 function set(delta) {
   if (state === "started") return;
   counter += delta;
+  saved.counter = counter;
+  require("Storage").write("simpletimer.json", saved);
   if (state === "unset") {
     state = "set";
   }
@@ -160,5 +163,5 @@ Bangle.on("aiGesture", gesture => {
   if (gesture === "swipeleft" && state === "stopped") reset(0);
 });
 
-reset(0);
+reset(saved.counter || 0);
 addWatch();


### PR DESCRIPTION
- Fix BTN2 to really open the launcher
- Remember last set time

I figured the fix for BTN2 doesn't need a separate version/changelog.