### PR TITLE
gbridge: Add setting to show/hide icon

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -95,7 +95,7 @@
   { "id": "gbridge",
     "name": "Gadgetbridge",
     "icon": "app.png",
-    "version":"0.11",
+    "version":"0.12",
     "description": "The default notification handler for Gadgetbridge notifications from Android",
     "tags": "tool,system,android,widget",
     "type":"widget",
@@ -103,6 +103,9 @@
       {"name":"gbridge.settings.js","url":"settings.js"},
       {"name":"gbridge.img","url":"app-icon.js","evaluate":true},
       {"name":"gbridge.wid.js","url":"widget.js"}
+    ],
+    "data": [
+      {"name":"gbridge.json"}
     ]
   },
   { "id": "mclock",

--- a/apps/gbridge/ChangeLog
+++ b/apps/gbridge/ChangeLog
@@ -10,3 +10,4 @@
 0.09: Update Bluetooth connection state automatically
 0.10: Make widget play well with other Gadgetbridge widgets/apps
 0.11: Report battery status on connect and at regular intervals
+0.12: Setting to show/hide icon

--- a/apps/gbridge/settings.js
+++ b/apps/gbridge/settings.js
@@ -2,10 +2,28 @@
   function gb(j) {
     Bluetooth.println(JSON.stringify(j));
   }
-
+  const storage = require('Storage');
+  let settings = storage.readJSON("gbridge.json", true) || {};
+  if (!("showIcon" in settings)) {
+    settings.showIcon = true;
+  }
+  function updateSettings() {
+    storage.write('gbridge.json', settings);
+  }
+  function toggleIcon() {
+    settings.showIcon = !settings.showIcon;
+    updateSettings();
+    Bangle.loadWidgets();
+    Bangle.drawWidgets();
+  }
   var mainmenu = {
     "" : { "title" : "Gadgetbridge" },
     "Connected" : { value : NRF.getSecurityStatus().connected?"Yes":"No" },
+    "Show Icon" : {
+      value: settings.showIcon,
+      format: v => v?"Yes":"No",
+      onchange: toggleIcon
+    },
     "Find Phone" : function() { E.showMenu(findPhone); },
     "< Back" : back,
   };

--- a/apps/gbridge/settings.js
+++ b/apps/gbridge/settings.js
@@ -40,5 +40,5 @@
     "< Back" : function() { E.showMenu(mainmenu); },
   };
 
-  const menu = E.showMenu(mainmenu);
+  E.showMenu(mainmenu);
 })

--- a/apps/gbridge/settings.js
+++ b/apps/gbridge/settings.js
@@ -2,17 +2,20 @@
   function gb(j) {
     Bluetooth.println(JSON.stringify(j));
   }
-  const storage = require('Storage');
-  let settings = storage.readJSON("gbridge.json", true) || {};
-  if (!("showIcon" in settings)) {
-    settings.showIcon = true;
+  function settings() {
+    let settings = require('Storage').readJSON("gbridge.json", true) || {};
+    if (!("showIcon" in settings)) {
+      settings.showIcon = true;
+    }
+    return settings
   }
-  function updateSettings() {
-    storage.write('gbridge.json', settings);
+  function updateSetting(setting, value) {
+    let settings = require('Storage').readJSON("gbridge.json", true) || {};
+    settings[setting] = value
+    require('Storage').write('gbridge.json', settings);
   }
-  function toggleIcon() {
-    settings.showIcon = !settings.showIcon;
-    updateSettings();
+  function setIcon(visible) {
+    updateSetting('showIcon', visible);
     // need to re-layout widgets
     WIDGETS["gbridgew"].reload();
     g.clear();
@@ -22,9 +25,9 @@
     "" : { "title" : "Gadgetbridge" },
     "Connected" : { value : NRF.getSecurityStatus().connected?"Yes":"No" },
     "Show Icon" : {
-      value: settings.showIcon,
+      value: settings().showIcon,
       format: v => v?"Yes":"No",
-      onchange: toggleIcon
+      onchange: setIcon
     },
     "Find Phone" : function() { E.showMenu(findPhone); },
     "< Back" : back,

--- a/apps/gbridge/settings.js
+++ b/apps/gbridge/settings.js
@@ -13,7 +13,9 @@
   function toggleIcon() {
     settings.showIcon = !settings.showIcon;
     updateSettings();
-    Bangle.loadWidgets();
+    // need to re-layout widgets
+    WIDGETS["gbridgew"].reload();
+    g.clear();
     Bangle.drawWidgets();
   }
   var mainmenu = {
@@ -35,5 +37,5 @@
     "< Back" : function() { E.showMenu(mainmenu); },
   };
 
-  E.showMenu(mainmenu);
+  const menu = E.showMenu(mainmenu);
 })

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -1,7 +1,4 @@
 (() => {
-  const storage = require('Storage');
-  let settings;
-
   const state = {
     music: "stop",
 
@@ -14,6 +11,13 @@
     scrollPos: 0
   };
 
+  function settings() {
+    let settings = require('Storage').readJSON("gbridge.json", true) || {};
+    if (!("showIcon" in settings)) {
+      settings.showIcon = true;
+    }
+    return settings
+  }
 
   function gbSend(message) {
     Bluetooth.println("");
@@ -183,7 +187,6 @@
   });
 
   function draw() {
-    if (!settings.showIcon) return;
     g.setColor(-1);
     if (NRF.getSecurityStatus().connected)
       g.drawImage(require("heatshrink").decompress(atob("i0WwgHExAABCIwJCBYwJEBYkIBQ2ACgvzCwoECx/z/AKDD4WD+YLBEIYKCx//+cvnAKCBwU/mc4/8/HYv//Ev+Y4EEAePn43DBQkzn4rCEIoABBIwKHO4cjmczK42I6mqlqEEBQeIBQaDED4IgDUhi6KaBbmIA==")), this.x + 1, this.y + 1);
@@ -197,18 +200,16 @@
   }
 
   function reload() {
-    settings = storage.readJSON('gbridge.json', 1) || {};
-    if (!("showIcon" in settings)) {
-      settings.showIcon = true;
-    }
-    if (settings.showIcon) {
+    NRF.removeListener("connect", changedConnectionState);
+    NRF.removeListener("disconnect", changedConnectionState);
+    if (settings().showIcon) {
       WIDGETS["gbridgew"].width = 24;
+      WIDGETS["gbridgew"].draw = draw;
       NRF.on("connect", changedConnectionState);
       NRF.on("disconnect", changedConnectionState);
     } else {
       WIDGETS["gbridgew"].width = 0;
-      NRF.removeListener("connect", changedConnectionState);
-      NRF.removeListener("disconnect", changedConnectionState);
+      WIDGETS["gbridgew"].draw = ()=>{};
     }
   }
 

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -76,7 +76,7 @@
         var p = MAXCHARS;
         while (p > MAXCHARS - 8 && !" \t-_".includes(l[p]))
           p--;
-        if (p == MAXCHARS - 8) p = MAXCHARS;
+        if (p === MAXCHARS - 8) p = MAXCHARS;
         txt[i] = l.substr(0, p);
         txt.splice(i + 1, 0, l.substr(p));
       }
@@ -109,7 +109,7 @@
     const changed = state.music === event.state
     state.music = event.state
 
-    if (state.music == "play") {
+    if (state.music === "play") {
       showNotification(40, (y) => {
         g.setColor("#ffffff");
         g.drawImage(require("heatshrink").decompress(atob("jEYwILI/EAv/8gP/ARcMgOAASN8h+A/kfwP8n4CD/E/gHgjg/HA=")), 8, y + 8);
@@ -126,14 +126,14 @@
       }, changed);
     }
 
-    if (state.music == "pause") {
+    if (state.music === "pause") {
       hideNotification();
     }
   }
 
   function handleCallEvent(event) {
 
-    if (event.cmd == "accept") {
+    if (event.cmd === "accept") {
       showNotification(40, (y) => {
         g.setColor("#ffffff");
         g.drawImage(require("heatshrink").decompress(atob("jEYwIMJj4CCwACJh4CCCIMOAQMGAQMHAQMDAQMBCIMB4PwgHz/EAn4CBj4CBg4CBgACCAAw=")), 8, y + 8);
@@ -180,7 +180,7 @@
   });
 
   Bangle.on("swipe", (dir) => {
-    if (state.music == "play") {
+    if (state.music === "play") {
       const command = dir > 0 ? "next" : "previous"
       gbSend({ t: "music", n: command });
     }

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -1,4 +1,5 @@
 (() => {
+  const storage = require('Storage');
 
   const state = {
     music: "stop",
@@ -11,6 +12,11 @@
 
     scrollPos: 0
   };
+
+  let settings = storage.readJSON('gbridge.json',1) || {};
+  if (!("showIcon" in settings)) {
+    settings.showIcon = true;
+  }
 
   function gbSend(message) {
     Bluetooth.println("");
@@ -192,10 +198,15 @@
     g.flip(); // turns screen on
   }
 
-  NRF.on("connect", changedConnectionState);
-  NRF.on("disconnect", changedConnectionState);
-
-  WIDGETS["gbridgew"] = { area: "tl", width: 24, draw: draw };
+  if (settings.showIcon) {
+    WIDGETS["gbridgew"] = {area: "tl", width: 24, draw: draw};
+    NRF.on("connect", changedConnectionState);
+    NRF.on("disconnect", changedConnectionState);
+  } else {
+    NRF.removeListener("connect", changedConnectionState);
+    NRF.removeListener("disconnect", changedConnectionState);
+    delete WIDGETS["gbridgew"];
+  }
 
   function sendBattery() {
     gbSend({ t: "status", bat: E.getBattery() });


### PR DESCRIPTION
I noticed #131 also has this, but it looks like the notification overhaul stuff might take a while to do properly, and the icon was starting to bug me.

It's doing
```js
    Bangle.loadWidgets();
    Bangle.drawWidgets();
```
To make the show/hide take effect inside the settings, but that really eats RAM somehow.
I'll see if I can figure out why, and/or come up with a better way to show/hide the widget.
(maybe make hidden = width:0)