### PR TITLE
Stop the cliock face redrawing and running out of memory

### DIFF
--- a/apps/cliock/ChangeLog
+++ b/apps/cliock/ChangeLog
@@ -1,1 +1,2 @@
 0.07: Submitted to App Loader
+0.08: Fixes issue where face would redraw on wake leading to all memory being used and watch crashing. 

--- a/apps/cliock/app.js
+++ b/apps/cliock/app.js
@@ -5,9 +5,6 @@ var flag = false;
 var WeekDays = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
 
 function drawAll(){
-  g.clear();
-  Bangle.loadWidgets();
-  Bangle.drawWidgets();
   updateTime();
   updateRest(new Date());
 }
@@ -42,6 +39,9 @@ function writeLine(str,line){
   g.drawString(str,25,marginTop+line*30);
 } 
 
+g.clear();
+Bangle.loadWidgets();
+Bangle.drawWidgets();
 drawAll();
 Bangle.on('lcdPower',function(on) {
   if (on)


### PR DESCRIPTION
Removes the clear screen and widget loading from each wake so it only runs the first time. Prevents the watch from running out of memory due to redraws after approx. 3 wakes.