### PR TITLE
Add auto-snooze option to alarms

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -140,7 +140,7 @@
     "name": "Default Alarm",
     "shortName":"Alarms",
     "icon": "app.png",
-    "version":"0.08",
+    "version":"0.09",
     "description": "Set and respond to alarms",
     "tags": "tool,alarm,widget",
     "storage": [

--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Change 'New Alarm' to 'Save', allow Deletion of Alarms
 0.07: Don't overwrite existing settings on app update
 0.08: Make alarm scheduling more reliable
+0.09: Add per alarm auto-snooze option

--- a/apps/alarm/alarm.js
+++ b/apps/alarm/alarm.js
@@ -38,6 +38,10 @@ function showAlarm(alarm) {
         Bangle.buzz(100).then(function() {
           if (buzzCount--)
             setTimeout(buzz, 3000);
+          else if(alarm.as) { // auto-snooze
+            buzzCount = 10;
+            setTimeout(buzz, 600000);
+          }
         });
       },100);
     });

--- a/apps/alarm/alarm.js
+++ b/apps/alarm/alarm.js
@@ -24,9 +24,14 @@ function showAlarm(alarm) {
   }).then(function(sleep) {
     buzzCount = 0;
     if (sleep) {
+      alarm.ohr = alarm.hr;
       alarm.hr += 10/60; // 10 minutes
     } else {
       alarm.last = (new Date()).getDate();
+      if (alarm.ohr) {
+          alarm.hr = alarm.ohr;
+          delete alarm.ohr;
+      }
       if (!alarm.rp) alarm.on = false;
     }
     require("Storage").write("alarm.json",JSON.stringify(alarms));

--- a/apps/alarm/alarm.js
+++ b/apps/alarm/alarm.js
@@ -24,11 +24,11 @@ function showAlarm(alarm) {
   }).then(function(sleep) {
     buzzCount = 0;
     if (sleep) {
-      if(!alarm.ohr) alarm.ohr = alarm.hr;
+      if(alarm.ohr===undefined) alarm.ohr = alarm.hr;
       alarm.hr += 10/60; // 10 minutes
     } else {
       alarm.last = (new Date()).getDate();
-      if (alarm.ohr) {
+      if (alarm.ohr!==undefined) {
           alarm.hr = alarm.ohr;
           delete alarm.ohr;
       }

--- a/apps/alarm/alarm.js
+++ b/apps/alarm/alarm.js
@@ -24,7 +24,7 @@ function showAlarm(alarm) {
   }).then(function(sleep) {
     buzzCount = 0;
     if (sleep) {
-      alarm.ohr = alarm.hr;
+      if(!alarm.ohr) alarm.ohr = alarm.hr;
       alarm.hr += 10/60; // 10 minutes
     } else {
       alarm.last = (new Date()).getDate();

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -8,6 +8,7 @@ var alarms = require("Storage").readJSON("alarm.json",1)||[];
     msg : "Eat chocolate",
     last : 0, // last day of the month we alarmed on - so we don't alarm twice in one day!
     rp : true, // repeat
+    as : true, // auto snooze
   }
 ];*/
 
@@ -50,6 +51,7 @@ function editAlarm(alarmIndex) {
     mins = Math.round((a.hr-hrs)*60);
     en = a.on;
     repeat = a.rp;
+    as = a.as;
   }
   const menu = {
     '': { 'title': 'Alarms' },
@@ -70,6 +72,11 @@ function editAlarm(alarmIndex) {
       value: en,
       format: v=>v?"Yes":"No",
       onchange: v=>repeat=v
+    },
+    'Auto snooze': {
+      value: en,
+      format: v=>v?"Yes":"No",
+      onchange: v=>as=v
     }
   };
   function getAlarm() {
@@ -81,7 +88,7 @@ function editAlarm(alarmIndex) {
     // Save alarm
     return {
       on : en, hr : hr,
-      last : day, rp : repeat
+      last : day, rp : repeat, as: as
     };
   }
   menu["> Save"] = function() {


### PR DESCRIPTION
What the title says: this adds an "auto-snooze" option to the alarm editor which, if enabled, schedules a new round of buzzing 10 minutes later as if the snooze button was clicked.

I also added a behaviour fix for snoozing: the way it's implemented currently, snoozing adds 10 minutes to the alarm time and saves it; this means that, for repeating alarms, the next run will be 10 minutes * number of snoozes later, which is not something the user would expect.