### PR TITLE
Fix for TZ in Western hemisphere

### DIFF
--- a/apps/boot/bootloader.js
+++ b/apps/boot/bootloader.js
@@ -16,13 +16,13 @@ setWatch(() => {
 `;
 delete settings;
 // check to see if our clock is wrong - if it is use GPS time
-if ((new Date()).getFullYear()==1970) {
+if ((new Date()).getFullYear()<2000) {
   E.showMessage("Searching for\nGPS time");
   Bangle.on('GPS',function cb(g) {
     Bangle.setGPSPower(0);
     Bangle.removeListener("GPS",cb);
     if (!g.time || (g.time.getFullYear()<2000) ||
-       (g.time.getFullYear()==2250)) {
+       (g.time.getFullYear()>2200)) {
       // GPS receiver's time not set - just boot clock anyway
       eval(clockApp);delete clockApp;
       return;


### PR DESCRIPTION
In timezones in the Western hemisphere (UTC-1 etc.), the local year at UNIX epoch is 1969, not 1970. Therefore, instead of checking getFullYear()==1970, we should be checking getFullYear()<=1970 (I did < 2000 consistent with the existing code below on line 24).