### PR TITLE
BugFix: Marioclock use of fillPoly adjustments

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1036,11 +1036,11 @@
   { "id": "marioclock",
     "name": "Mario Clock",
     "icon": "marioclock.png",
-    "version":"0.12",
+    "version":"0.13",
     "description": "Animated retro Mario clock, with Gameboy style 8-bit grey-scale graphics.",
     "tags": "clock,mario,retro",
     "type": "clock",
-    "allow_emulator":true,
+    "allow_emulator":false,
     "readme": "README.md",
     "storage": [
       {"name":"marioclock.app.js","url":"marioclock-app.js"},

--- a/apps/marioclock/ChangeLog
+++ b/apps/marioclock/ChangeLog
@@ -10,3 +10,4 @@
 0.10: Swiping left to enable night-mode now also reduces LCD brightness through 3 levels before returning to day-mode.
 0.11: User settings persisted and read to file.
 0.12: Add info banner message when phone (dis)connects. Display low-battery warning (<=10%)
+0.13: Fix drawPyramid function so pyramids are drawn in correct Y position

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -225,7 +225,7 @@ function drawFloor() {
 }
 
 function drawPyramid() {
-  const pPol = [pyramidSprite.x + 10, H - 6, pyramidSprite.x + 50, pyramidSprite.height, pyramidSprite.x + 90, H - 6]; // Pyramid poly
+  const pPol = [pyramidSprite.x + 10, H - 5, pyramidSprite.x + 50, pyramidSprite.height, pyramidSprite.x + 90, H - 5]; // Pyramid poly
 
   const color = (nightMode) ? DARK : LIGHT;
   g.setColor(color);


### PR DESCRIPTION
**Problem:**

Pyramids float above ground. Possibly due to changes to fillPoly function

**Solution:**

Adjust Pyramid Y values