### PR TITLE
Gpsrec OpenStreetMap track plotting

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -344,7 +344,7 @@
   { "id": "gpsrec",
     "name": "GPS Recorder",
     "icon": "app.png",
-    "version":"0.11",
+    "version":"0.12",
     "interface": "interface.html",
     "description": "Application that allows you to record a GPS track. Can run in background",
     "tags": "tool,outdoors,gps,widget",

--- a/apps/gpsrec/ChangeLog
+++ b/apps/gpsrec/ChangeLog
@@ -12,3 +12,4 @@
       Going 'back' from track view now doesn't load again
 0.10: Can now graph altitude & speed
 0.11: Ensure we don't turn GPS off if it was previously on (eg from another app/widget)
+0.12: Add option to plot on top of OpenStreetMap tiles (when they are installed on the watch)

--- a/apps/gpsrec/widget.js
+++ b/apps/gpsrec/widget.js
@@ -12,7 +12,7 @@
     g.reset();
     g.drawImage(atob("GBgCAAAAAAAAAAQAAAAAAD8AAAAAAP/AAAAAAP/wAAAAAH/8C9AAAB/8L/QAAAfwv/wAAAHS//wAAAAL//gAAAAf/+AAAAAf/4AAAAL//gAAAAD/+DwAAAB/Uf8AAAAfA//AAAACAf/wAAAAAH/0AAAAAB/wAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),this.x,this.y);
     if (hasFix) {
-      g.setColor("#FF0000");
+      g.setColor("#00FF00");
       g.drawImage(fixToggle ? atob("CgoCAAAAA0AAOAAD5AAPwAAAAAAAAAAAAAAAAA==") : atob("CgoCAAABw0AcOAHj5A8PwHwAAvgAB/wABUAAAA=="),this.x,this.y+14);
     } else {
       g.setColor("#0000FF");


### PR DESCRIPTION
I added an option to plot gpsrec tracks on top of OpenStreetMap tiles. 
The option only occurs when OpenStreetMap tiles are installed via the eponymous app. The tiles are centered on the 'center of gravity' of the track, and the track is scaled to the same scale as the OpenStreetMap tiles. The change is mostly a cut-and-paste job of the function drawopenstmap from the OpenStreetMap app.
Also includes a small change to change the color of the "gps signal acquired" icon in the widget from red to green - I found green to be much more visible in bright daylight than red.