### PR TITLE
notifyfs: fix custom render callback

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -93,7 +93,7 @@
     "name": "Fullscreen Notifications",
     "shortName":"Notifications",
     "icon": "notify.png",
-    "version":"0.02",
+    "version":"0.03",
     "description": "A handler for displaying notifications that displays them fullscreen. This may not fully restore the screen after on some apps. See `Notifications (default)` for more information about the notifications library.",
     "tags": "widget",
     "type": "notify",

--- a/apps/notifyfs/ChangeLog
+++ b/apps/notifyfs/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New Library!
 0.02: Add notification ID option
+0.03: Fix custom render callback

--- a/apps/notifyfs/notify.js
+++ b/apps/notifyfs/notify.js
@@ -68,7 +68,7 @@ exports.show = function(options) {
     g.setColor(-1).setFont("6x8", 2).setFontAlign(-1, -1, 0).drawString(body, x-4, y+4);
   }
 
-  if (options.render) options.render(320 - h);
+  if (options.render) options.render(120-h/2);
 
   if (options.on) Bangle.setLCDPower(1); // light up
   Bangle.on("touch", exports.hide);


### PR DESCRIPTION
Now draws properly in the middle of the screen, instead of outside it.