### PR TITLE
Fix great circle formula in distance calculation

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -361,7 +361,7 @@
   { "id": "gpsnav",
     "name": "GPS Navigation",
     "icon": "icon.png",
-    "version":"0.03",
+    "version":"0.04",
     "description": "Displays GPS Course and Speed, + Directions to waypoint and waypoint recording, now with waypoint editor",
     "tags": "tool,outdoors,gps",
     "readme": "README.md",

--- a/apps/gpsnav/ChangeLog
+++ b/apps/gpsnav/ChangeLog
@@ -1,4 +1,4 @@
 0.01: New App!
 0.02: Add SCREENACCESS interface
 0.03: Add Waypoint Editor
-
+0.04: Fix great circle formula

--- a/apps/gpsnav/app.js
+++ b/apps/gpsnav/app.js
@@ -93,9 +93,8 @@ function bearing(a,b){
 }
 
 function distance(a,b){
-  var x = radians(a.lon-b.lon) * Math.cos(radians((a.lat+b.lat)/2));
-  var y = radians(b.lat-a.lat);
-  return Math.round(Math.sqrt(x*x + y*y) * 6371000);
+  var dsigma = Math.acos(Math.sin(radians(a.lat))*Math.sin(radians(b.lat))+Math.cos(radians(a.lat))*Math.cos(radians(b.lat))*Math.cos(radians(a.lon-b.lon)));
+  return Math.round(dsigma*6371000);
 }
 
 var selected = false;


### PR DESCRIPTION
The distance to the next way point computation was not quite right, more markedly so over large distances (as noticed on a long road trip). The submitted fix can exhibit machine precision issues on short distances with 32 floats, but the 64 bit floats used by Espruino seem to do just fine when tested. 