### PR TITLE
Don't clear all intervals during initialisation of Large Clock

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1690,7 +1690,7 @@
     "id": "largeclock",
     "name": "Large Clock",
     "icon": "largeclock.png",
-    "version": "0.06",
+    "version": "0.07",
     "description": "A readable and informational digital watch, with date, seconds and moon phase",
     "readme": "README.md",
     "tags": "clock",

--- a/apps/largeclock/ChangeLog
+++ b/apps/largeclock/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Adjust layout to account for new vector font
 0.05: Add support for 12 hour time
 0.06: Allow to disable BTN1 and BTN3 buttons
+0.07: Don't clear all intervals during initialisation

--- a/apps/largeclock/largeclock.js
+++ b/apps/largeclock/largeclock.js
@@ -198,7 +198,6 @@ if (BTN3app) setWatch(
 );
 
 g.clear();
-clearInterval();
 drawClockFace();
 interval = setInterval(drawClockFace, REFRESH_RATE);
 


### PR DESCRIPTION
The `clearInterval()` stops any boot code or widgets that use intervals from working.

See conversation here: http://forum.espruino.com/conversations/356341/

> Large Clock that line is totally pointless and could just be removed