### PR TITLE
Fix datePattern and temperature of locale.en_JP

### DIFF
--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -146,7 +146,7 @@ var locales = {
     temperature: "°F",
     ampm: { 0: "", 1: "" },
     timePattern: { 0: "%HH:%MM:%SS ", 1: "%HH:%MM" },
-    datePattern: { 0: "%y/%M/%d", 1: "%y/%m;/%d" },
+    datePattern: { 0: "%Y/%m/%d", 1: "%y/%m/%d" },
     abmonth: "Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec",
     month: "January,February,March,April,May,June,July,August,September,October,November,December",
     abday: "Sun,Mon,Tue,Wed,Thu,Fri,Sat",

--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -143,7 +143,7 @@ var locales = {
     int_curr_symbol: "JPY",
     speed: "kmh",
     distance: { 0: "m", 1: "km" },
-    temperature: "°F",
+    temperature: "°C",
     ampm: { 0: "", 1: "" },
     timePattern: { 0: "%HH:%MM:%SS ", 1: "%HH:%MM" },
     datePattern: { 0: "%Y/%m/%d", 1: "%y/%m/%d" },


### PR DESCRIPTION
App Loader -> Languages -> Select `en_JP`, Upload -> `Morphing Clock` date display is broken(below image).

![E1994823-14AC-431C-8F66-704D78F60245_1_105_c](https://user-images.githubusercontent.com/193209/99132951-7747b680-265b-11eb-95f6-845418b73c9b.jpeg)


Web IDE console

```javascript
>var locale = require('locale');
={
  name: "en_JP",
  currencySym: "\xA5",
  dow: function (d,short) { ... },
  month: function (d,short) { ... },
  number: function (n,dec) { ... },
  currency: function (n) { ... },
  distance: function (n) { ... },
  speed: function (n) { ... },
  temp: function (t) { ... },
  translate: function (s) { ... },
  date: function (d,short) { ... },
  time: function (d,short) { ... },
  meridian: function (d) { ... }
 }
>locale.date(new Date(), 0);
="20/%M/14"
>locale.date(new Date(), 1);
="20/11;/14"
```


I fixed it (fe1c596)

```javascript
>var locale = require('locale');
={
  name: "en_JP",
  currencySym: "\xA5",
  dow: function (d,short) { ... },
  month: function (d,short) { ... },
  number: function (n,dec) { ... },
  currency: function (n) { ... },
  distance: function (n) { ... },
  speed: function (n) { ... },
  temp: function (t) { ... },
  translate: function (s) { ... },
  date: function (d,short) { ... },
  time: function (d,short) { ... },
  meridian: function (d) { ... }
 }
>locale.date(new Date(), 0);
="2020/11/14"
>locale.date(new Date(), 1);
="20/11/14"
```

And, unit of temperature in Japan is Celsius. I fixed it together.