### PR TITLE
devstopwatch - Persist stopwatch state

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1394,7 +1394,7 @@
   "name": "Dev Stopwatch",
   "shortName":"Dev Stopwatch",
   "icon": "app.png",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Stopwatch with 5 laps supported (cyclically replaced)",
   "tags": "stopwatch, chrono, timer, chronometer",
   "allow_emulator":true,

--- a/apps/devstopwatch/ChangeLog
+++ b/apps/devstopwatch/ChangeLog
@@ -1,1 +1,2 @@
 0.01: App created
+0.02: Persist state to storage to enable stopwatch to continue in the background

--- a/apps/devstopwatch/app.js
+++ b/apps/devstopwatch/app.js
@@ -9,21 +9,25 @@ const Y_BTN3 = 225;
 const FONT = '6x8';
 const CHRONO = '/* C H R O N O */';
 
-var laps = [EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP];
-var started = false;
 var reset = false;
-var whenStarted;
-var whenStartedTotal;
-var currentLapIndex = 1;
 var currentLap = '';
 var chronoInterval;
+
+// Read state from storage or create default state if it doesn't exist
+var state = require("Storage").readJSON("devstopwatch.state.json",1) || {
+  started: false,
+  whenStarted: null,
+  whenStartedTotal: null,
+  currentLapIndex: 1,
+  laps: [EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP],
+};
 
 // Set laps.
 setWatch(() => {
 
   reset = false;
   
-  if (started) {
+  if (state.started) {
     changeLap();
   } else {
     if (!reset) {
@@ -39,10 +43,10 @@ setWatch(() => { resetChrono(); }, BTN3, { repeat: true, edge: 'rising' });
 setWatch(Bangle.showLauncher, BTN2, { repeat: false, edge: 'falling' });
 
 function resetChrono() {
-  laps = [EMPTY_H, EMPTY_H, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP];
-  started = false;
+  state.laps = [EMPTY_H, EMPTY_H, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP, EMPTY_LAP];
+  state.started = false;
   reset = true;
-  currentLapIndex = 1;
+  state.currentLapIndex = 1;
   currentLap = '';
 
   if (chronoInterval !== undefined) {
@@ -54,32 +58,32 @@ function resetChrono() {
 
 function chronometer() {
 
-  if (!started) {
+  if (!state.started) {
     var rightNow = Date.now();
-    whenStarted = rightNow;
-    whenStartedTotal = rightNow;
-    started = true;
+    state.whenStarted = rightNow;
+    state.whenStartedTotal = rightNow;
+    state.started = true;
     reset = false;
   }
 
-  currentLap = calculateLap(whenStarted);
-  total = calculateLap(whenStartedTotal);
+  currentLap = calculateLap(state.whenStarted);
+  total = calculateLap(state.whenStartedTotal);
 
-  laps[0] = total;
-  laps[1] = currentLap;
+  state.laps[0] = total;
+  state.laps[1] = currentLap;
   printChrono();
 }
 
 function changeLap() {
 
-  currentLapIndex++;
+  state.currentLapIndex++;
 
-  if ((currentLapIndex) > MAX_LAPS) {
-    currentLapIndex = 2;
+  if ((state.currentLapIndex) > MAX_LAPS) {
+    state.currentLapIndex = 2;
   }
 
-  laps[currentLapIndex] = currentLap;
-  whenStarted = Date.now();
+  state.laps[state.currentLapIndex] = currentLap;
+  state.whenStarted = Date.now();
 }
 
 function calculateLap(whenStarted) {
@@ -108,8 +112,8 @@ function printChrono() {
 
   g.setColor(0, 220, 0);
   g.setFont(FONT, 3);
-  print = ` T ${laps[0]}\n`;
-  print += ` C ${laps[1]}\n`;
+  print = ` T ${state.laps[0]}\n`;
+  print += ` C ${state.laps[1]}\n`;
   g.drawString(print, XY_CENTER, Y_HEADER, true);
 
   g.setColor(255, 255, 255);
@@ -119,12 +123,12 @@ function printChrono() {
 
     g.setColor(255, 255, 255);
     let suffix = ' ';
-    if (currentLapIndex === i) {
+    if (state.currentLapIndex === i) {
       let suffix = '*';
       g.setColor(255, 200, 0);
     }
 
-    const lapLine = `L${i - 1} ${laps[i]} ${suffix}\n`;
+    const lapLine = `L${i - 1} ${state.laps[i]} ${suffix}\n`;
     g.drawString(lapLine, XY_CENTER, Y_LAPS + (15 * (i - 1)), true);
   }
 
@@ -156,4 +160,13 @@ g.clear();
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
-resetChrono();
+// Write the current state to storage
+E.on('kill', function(){
+  require("Storage").writeJSON("devstopwatch.state.json", state);
+});
+
+if(state.started){
+  chronoInterval = setInterval(chronometer, 10); 
+} else {
+  resetChrono();  
+}


### PR DESCRIPTION
This PR updates devstopwatch to keep all state related variables in a `state` object which is persisted to storage on `kill` and read from storage on app launch. This gives the stopwatch the illusion of continuing to run in the background while other apps are active.

Using flash storage for this seems a bit overkill but I couldn't find a way of writing to global RAM that persists between app launches. Does such a mechanism exist?