### PR TITLE
fixed activepedom widget, only exit after lastupdate has been recorded

### DIFF
--- a/apps/activepedom/widget.js
+++ b/apps/activepedom/widget.js
@@ -141,9 +141,6 @@
 
   function draw() {
     var height = 23; //width is deined globally
-    // not everyone likes a widget
-    if (setting('lineOne') == 'Hide' && setting('lineTwo') == 'Hide')
-      return;
     
     distance = (stepsCounted * setting('stepLength')) / 100 /1000; //distance in km
     
@@ -158,6 +155,12 @@
       stepsOutsideTime = 0;
     }
     lastUpdate = date;
+
+    // not everyone likes a widget, having refreshed lastUpdate we can exit
+    if (setting('lineOne') == 'Hide' && setting('lineTwo') == 'Hide') {
+      settings = 0; //reset settings to save memory
+      return;
+    }
     
     g.reset();
     g.clearRect(this.x, this.y, this.x+width, this.y+height);


### PR DESCRIPTION
my hide modification broke the widget, I was experiencing the widget resetting steps back to zero in the middle of the day.  This is because the draw() function updates the lastupdate variable. So move my return code to after that has been done.