### PR TITLE
refactor: real random clock support

### DIFF
--- a/apps/boot/bootloader.js
+++ b/apps/boot/bootloader.js
@@ -1,24 +1,42 @@
 // This runs after a 'fresh' boot
-var clockApp=(require("Storage").readJSON("setting.json",1)||{}).clock;
-if (clockApp) clockApp = require("Storage").read(clockApp);
-if (!clockApp) {
-  clockApp = require("Storage").list(/\.info$/)
-    .map(file => {
+const allClockApps = () => (
+  require("Storage").list(/\.info$/)
+    .map((file) => {
       const app = require("Storage").readJSON(file,1);
       if (app && app.type == "clock") {
         return app;
       }
     })
-    .filter(x=>x)
-    .sort((a, b) => a.sortorder - b.sortorder)[0];
-  if (clockApp)
-    clockApp = require("Storage").read(clockApp.src);
-}
-if (!clockApp) clockApp=`E.showMessage("No Clock Found");
-setWatch(() => {
-  Bangle.showLauncher();
-}, BTN2, {repeat:false,edge:"falling"});)
+    .filter((x) => x)
+);
+const clockNotFound = `
+  E.showMessage("No Clock Found");
+  setWatch(() => {
+    Bangle.showLauncher();
+  }, BTN2, {repeat:false,edge:"falling"});)
 `;
+const currentClockApp = () => {
+  const {clock: clockApp} = require("Storage").readJSON("setting.json",1) || {};
+  if (" random" === clockApp) {
+    const apps = allClockApps();
+    return apps.length > 0
+      ? require("Storage").read(apps[Math.floor(Math.random() * apps.length)].src);
+      : clockNotFound;
+  } else if (clockApp) {
+    return require("Storage").read(clockApp);
+  }
+  // fallback: first clock app we discover on the system
+  const [discoveredApp] = allClockApps().sort((a, b) => a.sortorder - b.sortorder);
+  return discoveredApp
+    ? require("Storage").read(discoveredApp.src)
+    // fallback: not found
+    : `E.showMessage("No Clock Found");
+      setWatch(() => {
+        Bangle.showLauncher();
+      }, BTN2, {repeat:false,edge:"falling"});)
+    `;
+};
+const evaluateCurrentClockApp = () => eval(currentClockApp());
 // check to see if our clock is wrong - if it is use GPS time
 if ((new Date()).getFullYear()<2000) {
   E.showMessage("Searching for\nGPS time");
@@ -28,8 +46,7 @@ if ((new Date()).getFullYear()<2000) {
     if (!g.time || (g.time.getFullYear()<2000) ||
        (g.time.getFullYear()>2200)) {
       // GPS receiver's time not set - just boot clock anyway
-      eval(clockApp);
-      delete clockApp;
+      evaluateCurrentClockApp();
       return;
     }
     // We have a GPS time. Set time and reboot (to load alarms properly)
@@ -38,6 +55,5 @@ if ((new Date()).getFullYear()<2000) {
   });
   Bangle.setGPSPower(1);
 } else {
-  eval(clockApp);
-  delete clockApp;
+  evaluateCurrentClockApp();
 }

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -402,6 +402,14 @@ function showClockMenu() {
   });
   if (clockApps.length === 0) {
     clockMenu["No Clocks Found"] = () => { };
+  } else {
+    clockMenu[`${settings.clock === " random" ? "* " : ""}random`] = () => {
+      if (settings.clock !== " random") {
+        settings.clock = " random";
+        updateSettings();
+        showMainMenu();
+      }
+    };
   }
   return E.showMenu(clockMenu);
 }


### PR DESCRIPTION
I don't really like the "random" clock app. It's clunky and it's fairly trivial to put the concept of random clock into the bootloader/settings. This PR does just that, in addition to a little general refactoring to make things a little neater.

I save the clock app as ` random`, space intentional. I figured this was a good way to keep it from ever conflicting with an actual app name, but if there's a better way to do that let me know.

P.S. I didn't actually run this code yet because I haven't actually tried uploading a new bootloader app (and it seems a tiny bit scary), and I would appreciate any guidance you could give me in that regard... e.g. not bricking my watch but being able to test this

P.P.S. recommend reviewing changes in 'split' mode