### PR TITLE
Make counter work even when widgets are hidden, and make blobclk draw the time a bit sooner when LCD is powered on

### DIFF
--- a/apps/blobclk/clock-blob.js
+++ b/apps/blobclk/clock-blob.js
@@ -86,9 +86,9 @@ function clearTimers() {
 }
 function startTimers() {
   g.clear();
+  redraw();
   Bangle.drawWidgets();
   intervalRef = setInterval(redraw,1000);
-  redraw();
 }
 Bangle.loadWidgets();
 startTimers();

--- a/apps/counter/counter.js
+++ b/apps/counter/counter.js
@@ -43,6 +43,7 @@ g.drawString('Tap right or BTN1 to increase\nTap left or BTN3 to decrease\nPress
 
 Bangle.loadWidgets();
 Bangle.drawWidgets();
+updateScreen();
 
 // TODO: Enable saving counts to file
 // Add small watch

--- a/apps/counter/counter.js
+++ b/apps/counter/counter.js
@@ -1,9 +1,8 @@
 var counter = 0;
 
-g.setColor(0xFFFF);
-
 function updateScreen() {
   g.clearRect(0, 50, 250, 150);
+  g.setColor(0xFFFF);
   g.setFont("Vector",40).setFontAlign(0,0);
   g.drawString(Math.floor(counter), g.getWidth()/2, 100);
   g.drawString('-', 45, 100);
@@ -46,5 +45,4 @@ Bangle.loadWidgets();
 Bangle.drawWidgets();
 
 // TODO: Enable saving counts to file
-// Does not work if widgets are not visible
 // Add small watch


### PR DESCRIPTION
The bug in "counter" was that it wasn't setting the colour when updating the screen. That means if the widgets are not drawn and the colour is set to 0, then the screen is drawn in black and you can't see anything. It also means that if the last widget to be drawn left the colour as something other than white, then the counter is not drawn in white. The fix is to set the colour to white explicitly.

I found that "blobclk" took a noticeably long time to display the time on the screen when the LCD is powered on. Moving the `redraw()` call to happen a bit earlier makes an improvement, but not a massive one. It would be better to make "blobclk" more efficient if possible, but this is still an improvement for now, in my opinion.