### PR TITLE
Remove hardcoded hour buzz from aclock, beebclock, dotclock

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1255,7 +1255,7 @@
   { "id": "dotclock",
     "name": "Dot Clock",
     "icon": "clock-dot.png",
-    "version":"0.01",
+    "version":"0.02",
     "description": "A Minimal Dot Analog Clock",
     "tags": "clock",
     "type":"clock",

--- a/apps.json
+++ b/apps.json
@@ -272,7 +272,7 @@
   { "id": "aclock",
     "name": "Analog Clock",
     "icon": "clock-analog.png",
-    "version": "0.13",
+    "version": "0.14",
     "description": "An Analog Clock",
     "tags": "clock",
     "type":"clock",

--- a/apps.json
+++ b/apps.json
@@ -1900,7 +1900,7 @@
     "id": "beebclock",
     "name": "Beeb Clock",
     "icon": "beebclock.png",
-    "version":"0.02",
+    "version":"0.03",
     "description": "Clock face that may be coincidentally familiar to BBC viewers",
     "tags": "clock",
     "type": "clock",

--- a/apps/aclock/ChangeLog
+++ b/apps/aclock/ChangeLog
@@ -8,3 +8,4 @@
 0.11: shift face down for widget area, maximize face size, 0 pad single digit date, use locale for date
 0.12: Fix regression after 0.11
 0.13: Fix broken date padding (fix #376)
+0.14: Remove hardcoded hour buzz (you can install widchime if you miss it)

--- a/apps/aclock/clock-analog.js
+++ b/apps/aclock/clock-analog.js
@@ -113,9 +113,6 @@ const onMinute = () => {
   g.setColor(1, 1, 0.9);
   // Minute
   hand((360 * currentDate.getMinutes()) / 60, -8, faceWidth - 10);
-  if (currentDate.getHours() >= 0 && currentDate.getMinutes() === 0) {
-    Bangle.buzz();
-  }
   drawDate();
 };
 

--- a/apps/beebclock/ChangeLog
+++ b/apps/beebclock/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial commit.  Not very efficient, and widgets not working for some reason.
 0.02: Fixes; widget support
+0.03: Remove hardcoded hour buzz (you can install widchime if you miss it)

--- a/apps/beebclock/beebclock.js
+++ b/apps/beebclock/beebclock.js
@@ -262,12 +262,6 @@ Graphics.prototype.drawRotLine = function (sina, cosa, cx, cy, r1, r2) {
         g.drawRotLine(Math.sin(a), Math.cos(a), CX, CY+TM, RC1, R1);
       }
 
-      // Clock chime on the hour.
-      if (hours >= 0 && minutes === 0)
-        try {
-          Bangle.buzz();
-        } catch (e) { }
-
       // And draw widgets if we're in that mode
       if (with_widgets)
         Bangle.drawWidgets();

--- a/apps/dotclock/ChangeLog
+++ b/apps/dotclock/ChangeLog
@@ -1,1 +1,2 @@
-0.01: Based on the Analog Clock app, minimal dot interface
+0.01: Based on the Analog Clock app, minimal dot
+0.02: Remove hardcoded hour buzz (you can install widchime if you miss it)

--- a/apps/dotclock/clock-dot.js
+++ b/apps/dotclock/clock-dot.js
@@ -128,9 +128,6 @@ const onMinute = () => {
   g.setColor(1, 0.9, 0.9);
   // Minute
   minDot((360 * currentDate.getMinutes()) / 60,3);
-  if (currentDate.getHours() >= 0 && currentDate.getMinutes() === 0) {
-    Bangle.buzz();
-  }
   drawDate();
 };
 


### PR DESCRIPTION
Because we have a separate widget (`widchime`) for that now