### PR TITLE
fix widchime: make it actually chime the hour instead of crashing

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -585,7 +585,7 @@
   { "id": "widchime",
     "name": "Hour Chime",
     "icon": "widget.png",
-    "version":"0.01",
+    "version":"0.02",
     "description": "Buzz or beep on every whole hour.",
     "tags": "widget",
     "type": "widget",

--- a/apps/widchime/ChangeLog
+++ b/apps/widchime/ChangeLog
@@ -1,1 +1,2 @@
 0.01: First version
+0.02: Bugfix: now it actually chimes the hour instead of crashing

--- a/apps/widchime/widget.js
+++ b/apps/widchime/widget.js
@@ -1,26 +1,26 @@
 (function() {
   // 0: off, 1: buzz, 2: beep, 3: both
-  const type = (require("Storage").readJSON("widchime.json", 1) || {type: 1}).type
-  if (!type) return
+  const type = (require("Storage").readJSON("widchime.json", 1) || {type: 1}).type;
+  if (!type) return;
 
   function chime() {
-    if ((require("Storage").readJSON("setting.json", 1) || {}).quiet) return
-    if (type&1) Bangle.buzz(100)
-    if (type&2) Bangle.beep()
+    if ((require("Storage").readJSON("setting.json", 1) || {}).quiet) return;
+    if (type&1) Bangle.buzz(100);
+    if (type&2) Bangle.beep();
   }
 
-  let lastHour = (new Date()).getHours() // don't chime when (re)loaded at a whole hour
+  let lastHour = (new Date()).getHours(); // don't chime when (re)loaded at a whole hour
   function check() {
     const now = new Date(),
       h = now.getHours(), m = now.getMinutes(),
-      s = now.getSeconds(), ms = now.getMilliseconds()
-    if (h!==lastHour && m===0) chime()
-    lastHour = h
+      s = now.getSeconds(), ms = now.getMilliseconds();
+    if (h!==lastHour && m===0) chime();
+    lastHour = h;
     // check again when this hour is over
-    const mLeft = 60-m, sLeft = (mLeft*60)-s, msLeft = (sLeft*1000)-ms
-    setTimeout(check, msLeft)
+    const mLeft = 60-m, sLeft = (mLeft*60)-s, msLeft = (sLeft*1000)-ms;
+    setTimeout(check, msLeft);
   }
 
-  check()
+  check();
 })
-()
+();


### PR DESCRIPTION
Well, this is a bit embarrassing...   
Somehow the code I tested worked fine, and then I got fancy and removed semicolons before pushing, apparently without testing.   
Which means that
```js
  if (!type) return

  function chime() {
```
becomes a single statement, `chime()` isn't actually defined, and it now chimes the hour by crashing instead of buzzing.

Actually only needed two semicolons to fix, but I just added them everywhere (and will try to remember this the next time I think code w/o semicolons looks cleaner)