### PR TITLE
gbmusic: Increase text brightness, (try to) improve memory usage

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3004,7 +3004,7 @@
   "name": "Gadgetbridge Music Controls",
   "shortName":"Music Controls",
   "icon": "icon.png",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Control the music on your Gadgetbridge-connected phone",
   "tags": "tools,bluetooth,gadgetbridge,music",
   "type":"app",

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial version
+0.02: Increase text brightness, try to improve memory usage

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -3,24 +3,24 @@
  * Control the music on your Gadgetbridge-connected phone
  **/
 {
-  let autoClose = false // only if opened automatically
-  let state = ""
+  let autoClose = false; // only if opened automatically
+  let state = "";
   let info = {
     artist: "",
     album: "",
     track: "",
     n: 0,
     c: 0,
-  }
+  };
 
   const screen = {
     width: g.getWidth(),
     height: g.getHeight(),
     center: g.getWidth()/2,
     middle: g.getHeight()/2,
-  }
+  };
 
-  const TIMEOUT = 5*1000*60 // auto close timeout: 5 minutes
+  const TIMEOUT = 5*1000*60; // auto close timeout: 5 minutes
   // drawText defaults
   const defaults = {
     time: { // top center
@@ -78,36 +78,36 @@
       font: "6x8", // volume buttons
       volSize: 2, // volume buttons
     },
-  }
+  };
 
   class Ticker {
     constructor(interval) {
-      this.i = null
-      this.interval = interval
-      this.active = false
+      this.i = null;
+      this.interval = interval;
+      this.active = false;
     }
     clear() {
       if (this.i) {
-        clearInterval(this.i)
+        clearInterval(this.i);
       }
-      this.i = null
+      this.i = null;
     }
     start() {
-      this.active = true
-      this.resume()
+      this.active = true;
+      this.resume();
     }
     stop() {
-      this.active = false
-      this.clear()
+      this.active = false;
+      this.clear();
     }
     pause() {
-      this.clear()
+      this.clear();
     }
     resume() {
-      this.clear()
+      this.clear();
       if (this.active && Bangle.isLCDOn()) {
-        this.tick()
-        this.i = setInterval(() => {this.tick()}, this.interval)
+        this.tick();
+        this.i = setInterval(() => {this.tick();}, this.interval);
       }
     }
   }
@@ -117,28 +117,28 @@
    */
   class Clock extends Ticker {
     constructor() {
-      super(1000)
+      super(1000);
     }
     tick() {
-      g.reset()
-      const now = new Date
-      drawText("time", this.text(now))
-      drawText("date", require("locale").date(now, true))
+      g.reset();
+      const now = new Date;
+      drawText("time", this.text(now));
+      drawText("date", require("locale").date(now, true));
     }
     text(time) {
-      const l = require("locale")
-      const is12hour = (require("Storage").readJSON("setting.json", 1) || {})["12hour"]
+      const l = require("locale");
+      const is12hour = (require("Storage").readJSON("setting.json", 1) || {})["12hour"];
       if (!is12hour) {
-        return l.time(time, true)
+        return l.time(time, true);
       }
-      const date12 = new Date(time.getTime())
-      const hours = date12.getHours()
+      const date12 = new Date(time.getTime());
+      const hours = date12.getHours();
       if (hours===0) {
-        date12.setHours(12)
+        date12.setHours(12);
       } else if (hours>12) {
-        date12.setHours(hours-12)
+        date12.setHours(hours-12);
       }
-      return l.time(date12, true)+l.meridian(time)
+      return l.time(date12, true)+l.meridian(time);
     }
   }
 
@@ -147,26 +147,26 @@
    */
   class Fader extends Ticker {
     constructor() {
-      super(defaults.track.interval) // redraw at same speed as scroller
+      super(defaults.track.interval); // redraw at same speed as scroller
     }
     tick() {
-      drawMusic()
+      drawMusic();
     }
     start() {
-      this.since = Date.now()
-      super.start()
+      this.since = Date.now();
+      super.start();
     }
     stop() {
-      super.stop()
-      this.since = Date.now() // force redraw at 100% brightness
-      drawMusic()
-      this.since = null
+      super.stop();
+      this.since = Date.now(); // force redraw at 100% brightness
+      drawMusic();
+      this.since = null;
     }
     brightness() {
       if (fadeOut.since) {
-        return Math.max(0, 1-((Date.now()-fadeOut.since)/TIMEOUT))
+        return Math.max(0, 1-((Date.now()-fadeOut.since)/TIMEOUT));
       }
-      return 1
+      return 1;
     }
   }
 
@@ -175,35 +175,35 @@
    */
   class Scroller extends Ticker {
     constructor() {
-      super(defaults.track.interval)
+      super(defaults.track.interval);
     }
     tick() {
-      this.offset += defaults.track.step
-      this.draw()
+      this.offset += defaults.track.step;
+      this.draw();
     }
     draw() {
-      const s = defaults.track
-      const sep = "   "
-      g.setFont(s.font, s.size)
-      g.setColor(infoColor("track"))
+      const s = defaults.track;
+      const sep = "   ";
+      g.setFont(s.font, s.size);
+      g.setColor(infoColor("track"));
       const text = sep+info.track,
         text2 = text.repeat(2),
         w1 = g.stringWidth(text),
-        bottom = screen.height-s.bottom
-      this.offset = this.offset%w1
-      g.setFontAlign(-1, 1)
+        bottom = screen.height-s.bottom;
+      this.offset = this.offset%w1;
+      g.setFontAlign(-1, 1);
       g.clearRect(0, bottom-s.size, screen.width, bottom)
-        .drawString(text2, -this.offset, screen.height-s.bottom)
+        .drawString(text2, -this.offset, screen.height-s.bottom);
     }
     start() {
-      this.offset = 0
-      super.start()
+      this.offset = 0;
+      super.start();
     }
     stop() {
-      super.stop()
+      super.stop();
       const s = defaults.track,
-        bottom = screen.height-s.bottom
-      g.clearRect(0, bottom-s.size, screen.width, bottom)
+        bottom = screen.height-s.bottom;
+      g.clearRect(0, bottom-s.size, screen.width, bottom);
     }
   }
 
@@ -212,49 +212,49 @@
       color: infoColor(name),
       size: infoSize(name),
       force: fadeOut.active,
-    }, options))
+    }, options));
   }
-  let oldText = {}
+  let oldText = {};
   function drawText(name, text, options) {
     if (name in oldText && oldText[name].text===text && !(options || {}).force) {
-      return // nothing to do
+      return; // nothing to do
     }
     const s = Object.assign(
       // deep clone defaults to prevent them being overwritten with options
       JSON.parse(JSON.stringify(defaults[name])),
       options || {},
-    )
-    g.setColor(s.color)
-    g.setFont(s.font, s.size)
+    );
+    g.setColor(s.color);
+    g.setFont(s.font, s.size);
     const ax = "left" in s ? -1 : ("right" in s ? 1 : 0),
-      ay = "top" in s ? -1 : ("bottom" in s ? 1 : 0)
-    g.setFontAlign(ax, ay)
+      ay = "top" in s ? -1 : ("bottom" in s ? 1 : 0);
+    g.setFontAlign(ax, ay);
     // drawString coordinates
     const x = "left" in s ? s.left : ("right" in s ? screen.width-s.right : s.center),
-      y = "top" in s ? s.top : ("bottom" in s ? screen.height-s.bottom : s.middle)
+      y = "top" in s ? s.top : ("bottom" in s ? screen.height-s.bottom : s.middle);
     // bounding rectangle
     const w = g.stringWidth(text), h = g.getFontHeight(),
       left = "left" in s ? x : ("right" in s ? x-w : x-w/2),
-      top = "top" in s ? y : ("bottom" in s ? y-h : y-h/2)
+      top = "top" in s ? y : ("bottom" in s ? y-h : y-h/2);
     if (name in oldText) {
-      const old = oldText[name]
+      const old = oldText[name];
       // only clear if text/area has changed
       if (old.text!==text
         || old.left!==left || old.top!==top
         || old.w!==w || old.h!==h) {
-        g.clearRect(old.left, old.top, old.left+old.w, old.top+old.h)
+        g.clearRect(old.left, old.top, old.left+old.w, old.top+old.h);
       }
     }
     if (text.length) {
-      g.drawString(text, x, y)
+      g.drawString(text, x, y);
       // remember which rectangle to clear before next draw
       oldText[name] = {
         text: text,
         left: left, top: top,
         w: w, h: h,
-      }
+      };
     } else {
-      delete oldText[name]
+      delete oldText[name];
     }
   }
 
@@ -265,26 +265,26 @@
    */
   function fitText(text) {
     if (!text.length) {
-      return Infinity
+      return Infinity;
     }
     // Vector: make a guess, then shrink/grow until it fits
     const getWidth = (size) => g.setFont("Vector", size).stringWidth(text)
-      , sw = screen.width
-    let guess = Math.round(sw/(text.length*0.6))
+      , sw = screen.width;
+    let guess = Math.round(sw/(text.length*0.6));
     if (getWidth(guess)===sw) { // good guess!
-      return guess
+      return guess;
     }
     if (getWidth(guess)<sw) {
       do {
-        guess++
-      } while(getWidth(guess)<=sw)
-      return guess-1
+        guess++;
+      } while(getWidth(guess)<=sw);
+      return guess-1;
     }
     // width > target
     do {
-      guess--
-    } while(getWidth(guess)>sw)
-    return guess
+      guess--;
+    } while(getWidth(guess)>sw);
+    return guess;
   }
 
   /**
@@ -293,210 +293,210 @@
    */
   function infoSize(name) {
     if (name==="num") { // fixed size
-      return defaults[name].size
+      return defaults[name].size;
     }
     return Math.min(
       defaults[name].size,
       fitText(info[name]),
-    )
+    );
   }
   /**
    * @param name
    * @return {string} Semi-random color to use for given info
    */
-  let infoColors = {}
+  let infoColors = {};
   function infoColor(name) {
-    let h, s, v
+    let h, s, v;
     if (name==="num") {
       // always white
-      h = 0
-      s = 0
+      h = 0;
+      s = 0;
     } else {
       // complicated scheme to make color depend deterministically on info
       // s=1 and hue depends on the text, so we always get a bright color
-      let text = ""
+      let text = "";
       switch(name) {
         case "track":
-          text = info.track
+          text = info.track;
         // fallthrough: also use album+artist
         case "album":
-          text += info.album
+          text += info.album;
         // fallthrough: also use artist
         case "artist":
-          text += info.artist
-          break
+          text += info.artist;
+          break;
         default:
-          text = info[name]
+          text = info[name];
       }
       if (name in infoColors && infoColors[name].text===text && !fadeOut.active) {
-        return infoColors[name].color
+        return infoColors[name].color;
       }
-      let code = 0 // just the sum of all ascii values of text
-      text.split("").forEach(c => code += c.charCodeAt(0))
+      let code = 0; // just the sum of all ascii values of text
+      text.split("").forEach(c => code += c.charCodeAt(0));
       // dark magic
-      h = code%360
-      s = 1
+      h = code%360;
+      s = 1;
     }
-    v = fadeOut.brightness()
+    v = fadeOut.brightness();
     const hsv2rgb = (h, s, v) => {
       const f = (n) => {
-        const k = (n+h/60)%6
-        return v-v*s*Math.max(Math.min(k, 4-k, 1), 0)
-      }
-      return {r: f(5), g: f(3), b: f(1)}
-    }
-    const rgb = hsv2rgb(h, s, v)
-    const f2hex = (f) => ("00"+(Math.round(f*255)).toString(16)).substr(-2)
-    const color = "#"+f2hex(rgb.r)+f2hex(rgb.g)+f2hex(rgb.b)
-    infoColors[name] = color
-    return color
+        const k = (n+h/60)%6;
+        return v-v*s*Math.max(Math.min(k, 4-k, 1), 0);
+      };
+      return {r: f(5), g: f(3), b: f(1)};
+    };
+    const rgb = hsv2rgb(h, s, v);
+    const f2hex = (f) => ("00"+(Math.round(f*255)).toString(16)).substr(-2);
+    const color = "#"+f2hex(rgb.r)+f2hex(rgb.g)+f2hex(rgb.b);
+    infoColors[name] = color;
+    return color;
   }
 
-  let lastTrack
+  let lastTrack;
   function drawTrack() {
     // we try if we can squeeze this in with a slightly smaller font, but if
     // the title is too long we start up the scroller instead
-    const trackInfo = ([info.artist, info.album, info.n, info.track]).join("-")
+    const trackInfo = ([info.artist, info.album, info.n, info.track]).join("-");
     if (trackInfo===lastTrack) {
-      return // already visible
+      return; // already visible
     }
     if (infoSize("track")<defaults.track.min_size) {
-      scroller.start()
+      scroller.start();
     } else {
-      scroller.stop()
-      drawInfo("track")
+      scroller.stop();
+      drawInfo("track");
     }
-    lastTrack = trackInfo
+    lastTrack = trackInfo;
   }
 
   function drawArtistAlbum() {
     // we just use small enough fonts to make these always fit
-    let album_middle = defaults.album.middle
-    const artist_size = infoSize("artist")
+    let album_middle = defaults.album.middle;
+    const artist_size = infoSize("artist");
     if (info.artist) {
-      album_middle += defaults.artist.size
+      album_middle += defaults.artist.size;
     }
     drawInfo("artist", {
       size: artist_size,
-    })
+    });
     drawInfo("album", {
       middle: album_middle,
-    })
+    });
   }
   const icons = {
     pause: function(x, y, s) {
-      const w1 = s/3
-      g.drawRect(x, y, x+w1, y+s)
-      g.drawRect(x+s-w1, y, x+s, y+s)
+      const w1 = s/3;
+      g.drawRect(x, y, x+w1, y+s);
+      g.drawRect(x+s-w1, y, x+s, y+s);
     },
     play: function(x, y, s) {
       g.drawPoly([
         x, y,
         x+s, y+s/2,
         x, y+s,
-      ], true)
+      ], true);
     },
     previous: function(x, y, s) {
-      const w2 = s*1/5
+      const w2 = s*1/5;
       g.drawPoly([
         x+s, y,
         x+w2, y+s/2,
         x+s, y+s,
-      ], true)
-      g.drawRect(x, y, x+w2, y+s)
+      ], true);
+      g.drawRect(x, y, x+w2, y+s);
     },
     next: function(x, y, s) {
-      const w2 = s*4/5
+      const w2 = s*4/5;
       g.drawPoly([
         x, y,
         x+w2, y+s/2,
         x, y+s,
-      ], true)
-      g.drawRect(x+w2, y, x+s, y+s)
+      ], true);
+      g.drawRect(x+w2, y, x+s, y+s);
     },
-  }
+  };
   function controlColor(control) {
-    const s = defaults.controls
+    const s = defaults.controls;
     if (volCmd && control===volCmd) {
       // volume button kept pressed down
-      return s.activeColor
+      return s.activeColor;
     }
-    return (control in tCommand) ? s.activeColor : s.color
+    return (control in tCommand) ? s.activeColor : s.color;
   }
   function drawControl(control, x, y) {
-    g.setColor(controlColor(control))
-    const s = defaults.controls.size
+    g.setColor(controlColor(control));
+    const s = defaults.controls.size;
     if (state!==controlState) {
-      g.clearRect(x, y, x+s, y+s)
+      g.clearRect(x, y, x+s, y+s);
     }
-    icons[control](x, y, s)
+    icons[control](x, y, s);
   }
-  let controlState
+  let controlState;
   function drawControls() {
-    const s = defaults.controls
+    const s = defaults.controls;
     if (state==="play") {
       // left touch
-      drawControl("pause", s.left, screen.height-(s.bottom+s.size))
+      drawControl("pause", s.left, screen.height-(s.bottom+s.size));
       // right touch
-      drawControl("next", screen.width-(s.right+s.size), screen.height-(s.bottom+s.size))
+      drawControl("next", screen.width-(s.right+s.size), screen.height-(s.bottom+s.size));
     } else {
-      drawControl("previous", s.left, screen.height-(s.bottom+s.size))
-      drawControl("play", screen.width-(s.right+s.size), screen.height-(s.bottom+s.size))
+      drawControl("previous", s.left, screen.height-(s.bottom+s.size));
+      drawControl("play", screen.width-(s.right+s.size), screen.height-(s.bottom+s.size));
     }
-    g.setFont("6x8", s.volSize)
+    g.setFont("6x8", s.volSize);
     // BTN1
-    g.setFontAlign(1, -1)
-    g.setColor(controlColor("volumeup"))
-    g.drawString("+", screen.width, s.top)
+    g.setFontAlign(1, -1);
+    g.setColor(controlColor("volumeup"));
+    g.drawString("+", screen.width, s.top);
     // BTN2
-    g.setFontAlign(1, 1)
-    g.setColor(controlColor("volumedown"))
-    g.drawString("-", screen.width, screen.height-s.bottom)
-    controlState = state
+    g.setFontAlign(1, 1);
+    g.setColor(controlColor("volumedown"));
+    g.drawString("-", screen.width, screen.height-s.bottom);
+    controlState = state;
   }
 
   function setNumInfo() {
-    info.num = ""
+    info.num = "";
     if ("n" in info && info.n>0) {
-      info.num = "#"+info.n
+      info.num = "#"+info.n;
       if ("c" in info && info.c>0) { // I've seen { c:-1 }
-        info.num += "/"+info.c
+        info.num += "/"+info.c;
       }
     }
   }
   function drawMusic() {
-    g.reset()
-    setNumInfo()
-    drawInfo("num")
-    drawTrack()
-    drawArtistAlbum()
-    drawControls()
+    g.reset();
+    setNumInfo();
+    drawInfo("num");
+    drawTrack();
+    drawArtistAlbum();
+    drawControls();
   }
-  let tQuit
+  let tQuit;
   function updateMusic() {
     // if paused for five minutes, load the clock
     // (but timeout resets if we get new info, even while paused)
     if (tQuit) {
-      clearTimeout(tQuit)
+      clearTimeout(tQuit);
     }
-    tQuit = null
+    tQuit = null;
     if (state!=="play" && autoClose) {
       if (state==="stop") { // never actually happens with my phone :-(
-        load()
+        load();
       } else { // also quit when paused for a long time
-        tQuit = setTimeout(load, TIMEOUT)
-        fadeOut.start()
+        tQuit = setTimeout(load, TIMEOUT);
+        fadeOut.start();
       }
     } else {
-      fadeOut.stop()
+      fadeOut.stop();
     }
-    drawMusic()
+    drawMusic();
   }
 
   // create tickers
-  const clock = new Clock()
-  const fadeOut = new Fader()
-  const scroller = new Scroller()
+  const clock = new Clock();
+  const fadeOut = new Fader();
+  const scroller = new Scroller();
 
   ////////////////////
   // Events
@@ -505,17 +505,17 @@
   // pause timers while screen is off
   Bangle.on("lcdPower", on => {
     if (on) {
-      clock.resume()
-      scroller.resume()
-      fadeOut.resume()
+      clock.resume();
+      scroller.resume();
+      fadeOut.resume();
     } else {
-      clock.pause()
-      scroller.pause()
-      fadeOut.pause()
+      clock.pause();
+      scroller.pause();
+      fadeOut.pause();
     }
-  })
+  });
 
-  let tLauncher
+  let tLauncher;
   // we put starting of watches inside a function, so we can defer it until we
   // asked the user about autoStart
   function startLauncherWatch() {
@@ -523,156 +523,156 @@
     // short-press: toggle play/pause
     setWatch(function() {
       if (tLauncher) {
-        clearTimeout(tLauncher)
+        clearTimeout(tLauncher);
       }
-      tLauncher = setTimeout(Bangle.showLauncher, 1000)
-    }, BTN2, {repeat: true, edge: "rising"})
+      tLauncher = setTimeout(Bangle.showLauncher, 1000);
+    }, BTN2, {repeat: true, edge: "rising"});
     setWatch(function() {
       if (tLauncher) {
-        clearTimeout(tLauncher)
-        tLauncher = null
+        clearTimeout(tLauncher);
+        tLauncher = null;
       }
-      togglePlay()
-    }, BTN2, {repeat: true, edge: "falling"})
+      togglePlay();
+    }, BTN2, {repeat: true, edge: "falling"});
   }
 
-  let tCommand = {}
+  let tCommand = {};
   /**
    * Send command and highlight corresponding control
    * @param command "play/pause/next/previous/volumeup/volumedown"
    */
   function sendCommand(command) {
-    Bluetooth.println(JSON.stringify({t: "music", n: command}))
+    Bluetooth.println(JSON.stringify({t: "music", n: command}));
     // for controlColor
     if (command in tCommand) {
-      clearTimeout(tCommand[command])
+      clearTimeout(tCommand[command]);
     }
     tCommand[command] = setTimeout(function() {
-      delete tCommand[command]
-      drawControls()
-    }, defaults.controls.highlight)
-    drawControls()
+      delete tCommand[command];
+      drawControls();
+    }, defaults.controls.highlight);
+    drawControls();
   }
 
   // BTN1/3: volume control (with repeat after long-press)
-  let tVol, volCmd
+  let tVol, volCmd;
   function volUp() {
-    volStart("up")
+    volStart("up");
   }
   function volDown() {
-    volStart("down")
+    volStart("down");
   }
   function volStart(dir) {
-    const command = "volume"+dir
-    stopVol()
-    sendCommand(command)
-    volCmd = command
-    tVol = setTimeout(repeatVol, 500)
+    const command = "volume"+dir;
+    stopVol();
+    sendCommand(command);
+    volCmd = command;
+    tVol = setTimeout(repeatVol, 500);
   }
   function repeatVol() {
-    sendCommand(volCmd)
-    tVol = setTimeout(repeatVol, 100)
+    sendCommand(volCmd);
+    tVol = setTimeout(repeatVol, 100);
   }
   function stopVol() {
     if (tVol) {
-      clearTimeout(tVol)
-      tVol = null
+      clearTimeout(tVol);
+      tVol = null;
     }
-    volCmd = null
-    drawControls()
+    volCmd = null;
+    drawControls();
   }
   function startVolWatches() {
-    setWatch(volUp, BTN1, {repeat: true, edge: "rising"})
-    setWatch(stopVol, BTN1, {repeat: true, edge: "falling"})
-    setWatch(volDown, BTN3, {repeat: true, edge: "rising"})
-    setWatch(stopVol, BTN3, {repeat: true, edge: "falling"})
+    setWatch(volUp, BTN1, {repeat: true, edge: "rising"});
+    setWatch(stopVol, BTN1, {repeat: true, edge: "falling"});
+    setWatch(volDown, BTN3, {repeat: true, edge: "rising"});
+    setWatch(stopVol, BTN3, {repeat: true, edge: "falling"});
   }
 
   // touch/swipe: navigation
   function togglePlay() {
-    sendCommand(state==="play" ? "pause" : "play")
+    sendCommand(state==="play" ? "pause" : "play");
   }
   function startTouchWatches() {
     Bangle.on("touch", function(side) {
       switch(side) {
         case 1:
-          sendCommand(state==="play" ? "pause" : "previous")
-          break
+          sendCommand(state==="play" ? "pause" : "previous");
+          break;
         case 2:
-          sendCommand(state==="play" ? "next" : "play")
-          break
+          sendCommand(state==="play" ? "next" : "play");
+          break;
         case 3:
-          togglePlay()
+          togglePlay();
       }
-    })
+    });
     Bangle.on("swipe", function(dir) {
-      sendCommand(dir===1 ? "previous" : "next")
-    })
+      sendCommand(dir===1 ? "previous" : "next");
+    });
   }
   /////////////////////
   // Startup
   /////////////////////
   // check for saved music state (by widget) to load
-  g.clear()
-  global.gbmusic_active = true // we don't need our widget
-  Bangle.loadWidgets()
-  Bangle.drawWidgets()
-  delete (global.gbmusic_active)
+  g.clear();
+  global.gbmusic_active = true; // we don't need our widget
+  Bangle.loadWidgets();
+  Bangle.drawWidgets();
+  delete (global.gbmusic_active);
 
   function startEmulator() {
     if (typeof Bluetooth==="undefined") { // emulator!
       Bluetooth = {
-        println: (line) => {console.log("Bluetooth:", line)},
-      }
+        println: (line) => {console.log("Bluetooth:", line);},
+      };
       // some example info
-      GB({"t": "musicinfo", "artist": "Some Artist Name", "album": "The Album Name", "track": "The Track Title Goes Here", "dur": 241, "c": 2, "n": 2})
-      GB({"t": "musicstate", "state": "play", "position": 0, "shuffle": 1, "repeat": 1})
+      GB({"t": "musicinfo", "artist": "Some Artist Name", "album": "The Album Name", "track": "The Track Title Goes Here", "dur": 241, "c": 2, "n": 2});
+      GB({"t": "musicstate", "state": "play", "position": 0, "shuffle": 1, "repeat": 1});
     }
   }
   function startWatches() {
-    startVolWatches()
-    startLauncherWatch()
-    startTouchWatches()
+    startVolWatches();
+    startLauncherWatch();
+    startTouchWatches();
   }
   function start() {
     // start listening for music updates
-    const _GB = global.GB
+    const _GB = global.GB;
     global.GB = (event) => {
       // we eat music events!
       switch(event.t) {
         case "musicinfo":
-          info = event
-          delete (info.t)
-          break
+          info = event;
+          delete (info.t);
+          break;
         case "musicstate":
-          state = event.state
-          break
+          state = event.state;
+          break;
         default:
           // pass on other events
           if (_GB) {
-            setTimeout(_GB, 0, event)
+            setTimeout(_GB, 0, event);
           }
-          return // no drawMusic
+          return; // no drawMusic
       }
-      updateMusic()
-    }
-    startWatches()
-    drawMusic()
-    clock.start()
-    startEmulator()
+      updateMusic();
+    };
+    startWatches();
+    drawMusic();
+    clock.start();
+    startEmulator();
   }
 
-  let saved = require("Storage").readJSON("gbmusic.load.json", true)
-  require("Storage").erase("gbmusic.load.json")
+  let saved = require("Storage").readJSON("gbmusic.load.json", true);
+  require("Storage").erase("gbmusic.load.json");
   if (saved) {
     // autoloaded: load state was saved by widget
-    info = saved.info
-    state = saved.state
-    delete (saved)
-    autoClose = true
-    start()
+    info = saved.info;
+    state = saved.state;
+    delete (saved);
+    autoClose = true;
+    start();
   } else {
-    const s = require("Storage").readJSON("gbmusic.json", 1) || {}
+    const s = require("Storage").readJSON("gbmusic.json", 1) || {};
     if (!("autoStart" in s)) {
       // user opened the app, but has not picked a setting yet
       // ask them about autoloading now
@@ -680,12 +680,12 @@
         "Automatically load\n"+
         "when playing music?\n",
       ).then(function(autoStart) {
-        s.autoStart = autoStart
-        require("Storage").writeJSON("gbmusic.json", s)
-        setTimeout(start, 0)
-      })
+        s.autoStart = autoStart;
+        require("Storage").writeJSON("gbmusic.json", s);
+        setTimeout(start, 0);
+      });
     } else {
-      start()
+      start();
     }
   }
 }


### PR DESCRIPTION
Turns out that pure blue (#0000FF) is quite hard to read in daylight :-( So tweak the colors a bit to always throw in at least some R+G.    
Also try to improve memory usage a bit by just drawing scrolling titles twice instead of concatenating to itself, and not keeping quite as many copies of strings in memory

(I suppose inlining constants instead of [putting them all in an object](https://github.com/espruino/BangleApps/blob/6c481a118b3bf7c04ac21bf15e6a4f3ceddfdb44/apps/gbmusic/app.js#L25-L81) might also help... Maybe even just get rid of (most of) the fancy dynamic drawing and just code in a few different functions.)