### PR TITLE
Gadgetbridge Music Controls: only auto-start from clock apps, auto close after 1 hour of inactivity 

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3043,7 +3043,7 @@
   "name": "Gadgetbridge Music Controls",
   "shortName":"Music Controls",
   "icon": "icon.png",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Control the music on your Gadgetbridge-connected phone",
   "tags": "tools,bluetooth,gadgetbridge,music",
   "type":"app",

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial version
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
+0.03: Only auto-start if active app is a clock

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -1,3 +1,3 @@
 0.01: Initial version
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
-0.03: Only auto-start if active app is a clock
+0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -538,7 +538,7 @@ function startLCDWatch() {
 /////////////////////
 // check for saved music stat (by widget) to load
 g.clear();
-global.gbmusic_active = true; // we don't need our widget
+global.gbmusic_active = true; // we don't need our widget (needed for <2.09 devices)
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 delete (global.gbmusic_active);

--- a/apps/gbmusic/widget.js
+++ b/apps/gbmusic/widget.js
@@ -2,6 +2,12 @@
   if (global.gbmusic_active || !(require("Storage").readJSON("gbmusic.json", 1) || {}).autoStart) {
     return
   }
+  if (typeof __FILE__ === 'string') { // only exists since 2v09
+    const info = require("Storage").readJSON(__FILE__.split(".")[0]+".info", 1) || false;
+    if (info && info.type!=="clock") { // info can have no type (but then it isn't a clock)
+      return;
+    }
+  }
 
   let state, info
   function checkMusic() {

--- a/apps/gbmusic/widget.js
+++ b/apps/gbmusic/widget.js
@@ -1,6 +1,6 @@
 (() => {
   if (global.gbmusic_active || !(require("Storage").readJSON("gbmusic.json", 1) || {}).autoStart) {
-    return
+    return;
   }
   if (typeof __FILE__ === 'string') { // only exists since 2v09
     const info = require("Storage").readJSON(__FILE__.split(".")[0]+".info", 1) || false;
@@ -9,36 +9,36 @@
     }
   }
 
-  let state, info
+  let state, info;
   function checkMusic() {
     if (state!=="play" || !info) {
-      return
+      return;
     }
     // playing music: launch music app
     require("Storage").writeJSON("gbmusic.load.json", {
       state: state,
       info: info,
-    })
-    load("gbmusic.app.js")
+    });
+    load("gbmusic.app.js");
   }
 
-  const _GB = global.GB
+  const _GB = global.GB;
   global.GB = (event) => {
     // we eat music events!
     switch(event.t) {
       case "musicinfo":
-        info = event
-        delete(info.t)
-        checkMusic()
-        break
+        info = event;
+        delete (info.t);
+        checkMusic();
+        break;
       case "musicstate":
-        state = event.state
-        checkMusic()
-        break
+        state = event.state;
+        checkMusic();
+        break;
       default:
         if (_GB) {
-          setTimeout(_GB, 0, event)
+          setTimeout(_GB, 0, event);
         }
     }
-  }
-})()
+  };
+})();


### PR DESCRIPTION
* only auto-start from clock apps, [(thanks for the hint)](https://github.com/espruino/BangleApps/pull/686#issuecomment-799260231)
* reformat widget code (as I was touching it anyway)
* auto close after `2*<song duration>` or 1 hour of inactivity: some (i.e. my) phones don't bother ending music updates when music simply finishes playing. (Duration seems reliable enough, but using the 1 hour fallback just in case some players don't report it.)