### PR TITLE
gbmusic: setting to disable touch controls (and a small bugfix)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3044,7 +3044,7 @@
   "name": "Gadgetbridge Music Controls",
   "shortName":"Music Controls",
   "icon": "icon.png",
-  "version":"0.03",
+  "version":"0.04",
   "description": "Control the music on your Gadgetbridge-connected phone",
   "tags": "tools,bluetooth,gadgetbridge,music",
   "type":"app",

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial version
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
+0.04: Minor bugfix

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -1,4 +1,4 @@
 0.01: Initial version
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
-0.04: Minor bugfix
+0.04: Setting to disable touch controls, minor bugfix

--- a/apps/gbmusic/README.md
+++ b/apps/gbmusic/README.md
@@ -16,9 +16,14 @@ Download the [latest Gadgetbridge for Android here](https://f-droid.org/packages
 
 ## Settings
 
-The app can automatically load when you play music and close when the music stops.
-You can change this under `Settings`->`App/Widget Settings`->`Music Controls`.
+You can change these under `Settings`->`App/Widget Settings`->`Music Controls`.
+
+**Auto start**: 
+Automatically load the app when you play music and close when the music stops.
 (If the app opened automatically, it closes after music has been paused for 5 minutes.)
+
+**Touch**:
+Enable touch controls?
 
 ## Controls
 

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -138,16 +138,13 @@ function infoColor(name) {
     s = 0;
   } else {
     // make color depend deterministically on info
-    let code = 0;
+    let code = textCode(info[name]);
     switch(name) {
-      case "track":
-        code += textCode(info.track);
-      // fallthrough: also use album+artist
-      case "album":
+      case "track": // also use album
         code += textCode(info.album);
-      // fallthrough: also use artist
-      default:
-        code += textCode(info[name]);
+      // fallthrough
+      case "album": // also use artist
+        code += textCode(info.artist);
     }
     h = code%360;
     s = 0.7;

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -13,6 +13,10 @@ let info = {
 };
 const POUT = 300000; // auto close timeout when paused: 5 minutes (in ms)
 const IOUT = 3600000; // auto close timeout for inactivity: 1 hour (in ms)
+// Touch controls?  0: off, 1: when LCD on, 2: always
+let s = require("Storage").readJSON("gbmusic.json", 1) || {};
+const TCTL = ("touch" in s) ? (s.touch|0)%3 : 1;
+delete s;
 
 ///////////////////////
 // Self-repeating timeouts
@@ -343,6 +347,7 @@ function controlColor(ctrl) {
   return (ctrl in tCommand) ? "#ff0000" : "#008800";
 }
 function drawControl(ctrl, x, y) {
+  if (!TCTL) {return;}
   g.setColor(controlColor(ctrl));
   const s = 20;
   if (stat!==controlState) {
@@ -515,7 +520,9 @@ function togglePlay() {
   sendCommand(stat==="play" ? "pause" : "play");
 }
 function startTouchWatches() {
+  if (!TCTL) {return;}
   Bangle.on("touch", side => {
+    if (TCTL<2 && !Bangle.isLCDOn()) {return;}
     switch(side) {
       case 1:
         sendCommand(stat==="play" ? "pause" : "previous");
@@ -528,6 +535,7 @@ function startTouchWatches() {
     }
   });
   Bangle.on("swipe", dir => {
+    if (TCTL<2 && !Bangle.isLCDOn()) {return;}
     sendCommand(dir===1 ? "previous" : "next");
   });
 }

--- a/apps/gbmusic/settings.js
+++ b/apps/gbmusic/settings.js
@@ -4,35 +4,40 @@
 (function(back) {
   const SETTINGS_FILE = "gbmusic.json",
     storage = require("Storage"),
-    translate = require("locale").translate
+    translate = require("locale").translate;
+  const TOUCH_OPTIONS = ["Off", "When LCD on", "Always"];
 
   // initialize with default settings...
   let s = {
     autoStart: true,
-  }
+    touch: 1,
+  };
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
-  const saved = storage.readJSON(SETTINGS_FILE, 1) || {}
+  const saved = storage.readJSON(SETTINGS_FILE, 1) || {};
   for(const key in saved) {
-    s[key] = saved[key]
+    s[key] = saved[key];
   }
 
-  // creates a function to safe a specific setting, e.g.  save('autoStart')(true)
-  function save(key) {
-    return function(value) {
-      s[key] = value
-      storage.write(SETTINGS_FILE, s)
-    }
+  function save(key, value) {
+    s[key] = value;
+    storage.write(SETTINGS_FILE, s);
   }
 
-  const menu = {
+  let menu = {
     "": {"title": "Music Control"},
-    "< Back": back,
-    "Auto start": {
-      value: s.autoStart,
-      format: v => translate(v ? "Yes" : "No"),
-      onchange: save("autoStart"),
-    }
-  }
-  E.showMenu(menu)
-})
+  };
+  menu[translate("< Back")] = back;
+  menu[translate("Auto start")] = {
+    value: s.autoStart,
+    format: v => translate(v ? "Yes" : "No"),
+    onchange: v => {save("autoStart", v);},
+  };
+  menu[translate("Touch")] = {
+    value: s.touch|0,
+    format: v => translate(TOUCH_OPTIONS[(v+3)%3]),
+    onchange: v => {save("touch", (v+3)%3);},
+  };
+
+  E.showMenu(menu);
+});


### PR DESCRIPTION
My sleeve touching the screen causing random song skips was bugging me, and I pretty much coded "completely disable touch controls" before realizing these were happening while the screen was off. So now it has three options :-p

Maybe we should just stick with a unconditional `isLDCOn` check?
But when the weather improves (i.e. no more long sleeves) blindly swiping to the next song might be nice. (At least that's the excuse I tell myself for not throwing away my shiny new code.)

Also a minor bugfix for dynamic colors, to make them actually behave as the comments claim they do.