### PR TITLE
gbmusic: Setting to disable double/triple press control, remove touch controls setting, reduce fadeout flicker

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3044,7 +3044,7 @@
   "name": "Gadgetbridge Music Controls",
   "shortName":"Music Controls",
   "icon": "icon.png",
-  "version":"0.04",
+  "version":"0.05",
   "description": "Control the music on your Gadgetbridge-connected phone",
   "tags": "tools,bluetooth,gadgetbridge,music",
   "type":"app",

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -2,4 +2,4 @@
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
 0.04: Setting to disable touch controls, minor bugfix
-0.05: Reduce fadeout flicker
+0.05: Simplify touch controls setting, reduce fadeout flicker

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -2,4 +2,4 @@
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
 0.04: Setting to disable touch controls, minor bugfix
-0.05: Remove touch controls setting, reduce fadeout flicker
+0.05: Setting to disable double/triple press control, remove touch controls setting, reduce fadeout flicker

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -2,4 +2,4 @@
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
 0.04: Setting to disable touch controls, minor bugfix
-0.05: Simplify touch controls setting, reduce fadeout flicker
+0.05: Remove touch controls setting, reduce fadeout flicker

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Increase text brightness, improve controls, (try to) reduce memory usage
 0.03: Only auto-start if active app is a clock, auto close after 1 hour of inactivity
 0.04: Setting to disable touch controls, minor bugfix
+0.05: Reduce fadeout flicker

--- a/apps/gbmusic/README.md
+++ b/apps/gbmusic/README.md
@@ -22,8 +22,6 @@ You can change these under `Settings`->`App/Widget Settings`->`Music Controls`.
 Automatically load the app when you play music and close when the music stops.
 (If the app opened automatically, it closes after music has been paused for 5 minutes.)
 
-**Touch controls**:
-Enable touch controls?
 
 ## Controls
 

--- a/apps/gbmusic/README.md
+++ b/apps/gbmusic/README.md
@@ -22,6 +22,9 @@ You can change these under `Settings`->`App/Widget Settings`->`Music Controls`.
 Automatically load the app when you play music and close when the music stops.
 (If the app opened automatically, it closes after music has been paused for 5 minutes.)
 
+**Simple button**:
+Disable double/triple pressing Button 2: always simply toggle play/pause.
+(For music players which handle multiple button presses themselves.)
 
 ## Controls
 

--- a/apps/gbmusic/README.md
+++ b/apps/gbmusic/README.md
@@ -22,7 +22,7 @@ You can change these under `Settings`->`App/Widget Settings`->`Music Controls`.
 Automatically load the app when you play music and close when the music stops.
 (If the app opened automatically, it closes after music has been paused for 5 minutes.)
 
-**Touch**:
+**Touch controls**:
 Enable touch controls?
 
 ## Controls

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -13,10 +13,6 @@ let info = {
 };
 const POUT = 300000; // auto close timeout when paused: 5 minutes (in ms)
 const IOUT = 3600000; // auto close timeout for inactivity: 1 hour (in ms)
-// Touch controls?
-let s = require("Storage").readJSON("gbmusic.json", 1) || {};
-const TCTL = ("touch" in s) ? !!s.touch : true; // previous versions used an int for this setting
-delete s;
 
 ///////////////////////
 // Self-repeating timeouts
@@ -355,7 +351,6 @@ function controlColor(ctrl) {
   return (ctrl in tCommand) ? "#ff0000" : "#008800";
 }
 function drawControl(ctrl, x, y) {
-  if (!TCTL) {return;}
   g.setColor(controlColor(ctrl));
   const s = 20;
   if (stat!==controlState) {
@@ -537,7 +532,6 @@ function togglePlay() {
   sendCommand(stat==="play" ? "pause" : "play");
 }
 function startTouchWatches() {
-  if (!TCTL) {return;}
   Bangle.on("touch", side => {
     if (!Bangle.isLCDOn()) {return;} // for <2v10 firmware
     switch(side) {

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -485,11 +485,19 @@ function startButtonWatches() {
       tPress = setTimeout(() => {Bangle.showLauncher();}, 3000);
     }
   }, BTN2, {repeat: true, edge: "rising"});
-  setWatch(() => {
-    nPress++;
-    clearTimeout(tPress);
-    tPress = setTimeout(handleButton2Press, 500);
-  }, BTN2, {repeat: true, edge: "falling"});
+  const s = require("Storage").readJSON("gbmusic.json", 1) || {};
+  if (s.simpleButton) {
+    setWatch(() => {
+      clearTimeout(tPress);
+      togglePlay();
+    }, BTN2, {repeat: true, edge: "falling"});
+  } else {
+    setWatch(() => {
+      nPress++;
+      clearTimeout(tPress);
+      tPress = setTimeout(handleButton2Press, 500);
+    }, BTN2, {repeat: true, edge: "falling"});
+  }
 }
 function handleButton2Press() {
   tPress = null;

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -13,9 +13,9 @@ let info = {
 };
 const POUT = 300000; // auto close timeout when paused: 5 minutes (in ms)
 const IOUT = 3600000; // auto close timeout for inactivity: 1 hour (in ms)
-// Touch controls?  0: off, 1: when LCD on, 2: always
+// Touch controls?
 let s = require("Storage").readJSON("gbmusic.json", 1) || {};
-const TCTL = ("touch" in s) ? (s.touch|0)%3 : 1;
+const TCTL = ("touch" in s) ? !!s.touch : true; // previous versions used an int for this setting
 delete s;
 
 ///////////////////////
@@ -539,7 +539,7 @@ function togglePlay() {
 function startTouchWatches() {
   if (!TCTL) {return;}
   Bangle.on("touch", side => {
-    if (TCTL<2 && !Bangle.isLCDOn()) {return;}
+    if (!Bangle.isLCDOn()) {return;} // for <2v10 firmware
     switch(side) {
       case 1:
         sendCommand(stat==="play" ? "pause" : "previous");
@@ -552,7 +552,7 @@ function startTouchWatches() {
     }
   });
   Bangle.on("swipe", dir => {
-    if (TCTL<2 && !Bangle.isLCDOn()) {return;}
+    if (!Bangle.isLCDOn()) {return;} // for <2v10 firmware
     sendCommand(dir===1 ? "previous" : "next");
   });
 }

--- a/apps/gbmusic/settings.js
+++ b/apps/gbmusic/settings.js
@@ -5,12 +5,11 @@
   const SETTINGS_FILE = "gbmusic.json",
     storage = require("Storage"),
     translate = require("locale").translate;
-  const TOUCH_OPTIONS = ["Off", "When LCD on", "Always"];
 
   // initialize with default settings...
   let s = {
     autoStart: true,
-    touch: 1,
+    touch: true,
   };
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -19,24 +18,27 @@
     s[key] = saved[key];
   }
 
-  function save(key, value) {
-    s[key] = value;
-    storage.write(SETTINGS_FILE, s);
+  function save(key) {
+    return function (value) {
+      s[key] = value;
+      storage.write(SETTINGS_FILE, s);
+    }
   }
 
+  const yesNo = (v) => translate(v ? "Yes" : "No");
   let menu = {
     "": {"title": "Music Control"},
   };
   menu[translate("< Back")] = back;
   menu[translate("Auto start")] = {
-    value: s.autoStart,
-    format: v => translate(v ? "Yes" : "No"),
-    onchange: v => {save("autoStart", v);},
+    value: !!s.autoStart,
+    format: yesNo,
+    onchange: save("autoStart"),
   };
-  menu[translate("Touch")] = {
-    value: s.touch|0,
-    format: v => translate(TOUCH_OPTIONS[(v+3)%3]),
-    onchange: v => {save("touch", (v+3)%3);},
+  menu[translate("Touch controls")] = {
+    value: !!s.touch,
+    format: yesNo,
+    onchange: save("touch"),
   };
 
   E.showMenu(menu);

--- a/apps/gbmusic/settings.js
+++ b/apps/gbmusic/settings.js
@@ -9,7 +9,6 @@
   // initialize with default settings...
   let s = {
     autoStart: true,
-    touch: true,
   };
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -34,11 +33,6 @@
     value: !!s.autoStart,
     format: yesNo,
     onchange: save("autoStart"),
-  };
-  menu[translate("Touch controls")] = {
-    value: !!s.touch,
-    format: yesNo,
-    onchange: save("touch"),
   };
 
   E.showMenu(menu);

--- a/apps/gbmusic/settings.js
+++ b/apps/gbmusic/settings.js
@@ -9,6 +9,7 @@
   // initialize with default settings...
   let s = {
     autoStart: true,
+    simpleButton: false,
   };
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -33,6 +34,11 @@
     value: !!s.autoStart,
     format: yesNo,
     onchange: save("autoStart"),
+  };
+  menu[translate("Simple button")] = {
+    value: !!s.simpleButton,
+    format: yesNo,
+    onchange: save("simpleButton"),
   };
 
   E.showMenu(menu);


### PR DESCRIPTION
* Setting to disable double/triple press control for http://forum.espruino.com/comments/15984222/
* Remove touch controls setting, because [firmware `2v10` will ignore touch/swipe events while the LCD is off anyway](https://github.com/espruino/Espruino/commit/917ceab9710a8ed1a8f1d50aa01dcae25059e2a5), so just having a setting to disable them seems silly.
(we still check the LCD is off before handling touch events, as probably not everybody is using `2v10` yet ;-)
* Don't clear the area while redrawing for fade out, to prevent flicker
* Some JSDoc improvements