### PR TITLE
multiclock - Added localisation to digi.js and timedat.js

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2260,7 +2260,7 @@
   { "id": "multiclock",
     "name": "Multi Clock",
     "icon": "multiclock.png",
-    "version":"0.12",
+    "version":"0.13",
     "description": "Clock with multiple faces - Big, Analogue, Digital, Text, Time-Date.\n Switch between faces with BTN1 & BTN3",
     "readme": "README.md",
     "tags": "clock",

--- a/apps/multiclock/ChangeLog
+++ b/apps/multiclock/ChangeLog
@@ -10,3 +10,4 @@
 0.10: Added GPS and Grid Ref clock faces
 0.11: Updated Pedometer clock to retrieve steps from either wpedom or activepedom
 0.12: Removed GPS and Grid Ref clock faces, superceded by GPS setup and Walkers Clock
+0.13: Localised digi.js and timdat.js

--- a/apps/multiclock/digi.js
+++ b/apps/multiclock/digi.js
@@ -1,5 +1,7 @@
 (() => {
 
+var locale = require("locale");
+
 function getFace(){
 
     var buf = Graphics.createArrayBuffer(240,92,1,{msb:true});
@@ -19,7 +21,7 @@ function getFace(){
       buf.drawString(time,buf.getWidth()/2,0);
       buf.setFont("6x8",2);
       buf.setFontAlign(0,-1);
-      var date = d.toString().substr(0,15);
+      var date = locale.dow(d, 1) + " " + locale.date(d, 1);
       buf.drawString(date, buf.getWidth()/2, 70);
       flip();
     }  

--- a/apps/multiclock/timdat.js
+++ b/apps/multiclock/timdat.js
@@ -1,16 +1,16 @@
 (() => {
+    var locale = require("locale");
+    var dayFirst = ["en_GB", "en_IN", "en_NAV", "de_DE", "nl_NL", "fr_FR", "en_NZ", "en_AU", "de_AT", "en_IL", "es_ES", "fr_BE", "de_CH", "fr_CH", "it_CH", "it_IT", "tr_TR", "pt_BR", "cs_CZ", "pt_PT"];
+    var withDot = ["de_DE", "nl_NL", "de_AT", "de_CH", "hu_HU", "cs_CZ", "sl_SI"];
+
     function getFace(){
         
         var lastmin=-1;
         function drawClock(){
           var d=Date();
           if (d.getMinutes()==lastmin) return;
-          d=d.toString().split(' ');
-          var min=d[4].substr(3,2);
-          var sec=d[4].substr(-2);
-          var tm=d[4].substring(0,5);
-          var hr=d[4].substr(0,2);
-          lastmin=min;
+          var tm=d.toString().split(' ')[4].substring(0,5);
+          lastmin=d.getMinutes();
           g.reset();
           g.clearRect(0,24,239,239);
           var w=g.getWidth();
@@ -19,7 +19,16 @@
           g.drawString(tm,4+(w-g.stringWidth(tm))/2,64);
           g.setFontVector(36);
           g.setColor(0x07ff);
-          var dt=d[0]+" "+d[1]+" "+d[2];//+" "+d[3];
+          var dt=locale.dow(d, 1) + " ";
+          if (dayFirst.includes(locale.name)) {
+            dt+=d.getDate();
+            if (withDot.includes(locale.name)) {
+              dt+=".";
+            }
+            dt+=" " + locale.month(d, 1);
+          } else {
+            dt+=locale.month(d, 1) + " " + d.getDate();
+          }
           g.drawString(dt,(w-g.stringWidth(dt))/2,160);
           g.flip();
         }


### PR DESCRIPTION
Hi there,

this is my first contribution, so I hope that I did not miss any requirements. If so, please tell me and I will fix my commit respectively.

I really like the multiclock timdat.js clock. However, it is not using the internationalisation mechanism. See also https://github.com/espruino/BangleApps/issues/136

Thus, I adapted the code - trying to change as few things as possible. I also adapted digi.js, which was quite simple. I did not touch txt.js since IMO it is alright to have this as an English skin and it would require a major effort to be adapted for other languages.

One technical remark: In timdat.js, a special date format consisting of day of week, month and day of month is used that is not available as a date pattern. Hence, I decided to build it there. I used this code together with the locales variable from [locales.js](https://github.com/espruino/BangleApps/blob/master/apps/locale/locales.js) to generate the dayFirst and withDot arrays:
```
const dayFirst = [];
const withDot = [];
for (key in locales) {
    const datePattern = locales[key].datePattern[1];
    if (datePattern.includes('.')) {
        withDot.push(locales[key].lang);
    }
    if (datePattern.indexOf('%d') < datePattern.indexOf('%m')) {
        dayFirst.push(locales[key].lang);
    }
}
console.log(withDot);
console.log(dayFirst);
```
Another possibility would be to add a third datePattern in locales.js if this is something useful in other places as well.

**Testing**: I've run the sanity check and tested the clock faces with no locale (default en_GB), de_DE and fr_FR.

Kind regards,
neshanjo

