### PR TITLE
sliding text clock BUGFIX: turning emulator option off. 

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -249,7 +249,7 @@
     "description": "Inspired by the Pebble sliding clock, old times are scrolled off the screen and new times on. You are also able to change language on the fly so you can see the time written in other languages using button 1. Currently English, French, Japanese, Spanish and German are supported",
     "tags": "clock",
     "type":"clock",
-    "allow_emulator":true,
+    "allow_emulator":false,
      "readme": "README.md",
     "custom":"custom.html",
     "storage": [


### PR DESCRIPTION
Emulator has stopped working because the clock is split into dynamic languages classes. Turning off the emulator otherwise people will think it doesn't work