### PR TITLE
Add support for dismissing Gadgetbridge notifications through notify

### DIFF
--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -157,9 +157,9 @@
         currentNot = prettifyNotificationEvent(event);
         require("notify").show(currentNot);
         if (!(require('Storage').readJSON('setting.json',1)||{}).quiet) {
-            Bangle.buzz();
+          Bangle.buzz();
         }
-	break;
+        break;
       case "notify-":
         currentNot.t = "notify";
         currentNot.n = "DISMISS";

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -1,4 +1,7 @@
 (() => {
+  // Current shown notification, saved for dismissing.
+  var currentNot = null;
+
   // Music handling
   const state = {
     music: "stop",
@@ -151,15 +154,18 @@
   global.GB = (event) => {
     switch (event.t) {
       case "notify":
-      case "notify-":
-        if (event.t === "notify") {
-          require("notify").show(prettifyNotificationEvent(event));
-          if (!(require('Storage').readJSON('setting.json',1)||{}).quiet) {
+        currentNot = prettifyNotificationEvent(event);
+        require("notify").show(currentNot);
+        if (!(require('Storage').readJSON('setting.json',1)||{}).quiet) {
             Bangle.buzz();
-          }
-        } else { // notify-
-          require("notify").hide(event);
         }
+	break;
+      case "notify-":
+        currentNot.t = "notify";
+        currentNot.n = "DISMISS";
+        gbSend(currentNot);
+        currentNot = null;
+        require("notify").hide(event);
         break;
       case "musicinfo":
         state.musicInfo = event;

--- a/apps/notify/notify.js
+++ b/apps/notify/notify.js
@@ -141,7 +141,7 @@ exports.show = function(options) {
     if (pos > -size) setTimeout(anim, 15);
   }
   anim();
-  Bangle.on("touch", exports.hide);
+  Bangle.on("touch", exports.dismiss_and_hide);
 };
 
 /**
@@ -161,4 +161,21 @@ exports.hide = function(options) {
     if (pos < 0) setTimeout(anim, 10);
   }
   anim();
+};
+
+/**
+ Calls exports.hide(), but if Gadgetbridge is installed, dismiss through it
+ instead (which will call call exports.hide() itself).
+*/
+exports.dismiss_and_hide = function(options) {
+    options = options||{};
+    if (typeof(options) == "number") {
+        options = {};
+    }
+    if ("GB" in global) {
+        options["t"] = "notify-";
+        GB(options);
+    } else {
+        exports.hide(options);
+    }
 };


### PR DESCRIPTION
Most of the support was already there, so this is just a few small steps:
- `notify.js` gets a `dismiss_and_hide()` exported function that can send the "notify-" event to Gadgetbridge, if installed
- `dismiss_and_hide()` is called when the Bangle.js screen is touched, instead of just `hide()`
- Gadgetbridge's `widget.js` saves "notify"-type events to a variable
- Gadgetbridge's `widget.js` sends a `DISMISS` action back to the Android app on "notify-" events, using the saved event data

Note that this is a limited implementation. For example, only the most recent notfication is saved (when a new one comes in, the old one is overridden in the variable), so it will be dismissed on the phone. A more advanced implementation might make it possible to choose which notification to dismiss.

From my own testing, this does properly count as a "swipe-away" style dismiss event in Android, so apps that react to notifications being swiped away will be triggered as expected.