### PR TITLE
weather: Use Layout library

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -585,7 +585,7 @@
   { "id": "weather",
     "name": "Weather",
     "icon": "icon.png",
-    "version":"0.09",
+    "version":"0.10",
     "description": "Show Gadgetbridge weather report",
     "readme": "readme.md",
     "tags": "widget,outdoors",

--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -6,3 +6,4 @@
 0.07: Add theme support and unknown icon.
 0.08: Refactor and reduce widget ram usage.
 0.09: Fix crash when weather.json is absent.
+0.10: Use new Layout library

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -27,7 +27,7 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
     ]},
   ]},
   {filly: 1},
-  {type: "txt", font: "9%", id: "cond", label: "Weather line 1"},
+  {type: "txt", font: "9%", wrap: true, height: g.getHeight()*0.18, fillx: 1, id: "cond", label: "Weather condition"},
   {filly: 1},
   {type: "h", c: [
     {type: "txt", font: "6x8", pad: 2, id: "loc", label: "Toronto"},
@@ -54,7 +54,6 @@ function draw() {
   const wind = locale.speed(current.wind).match(/^(\D*\d*)(.*)$/);
   layout.wind.label = wind[1];
   layout.windUnit.label = wind[2] + " " + current.wrose.toUpperCase();
-  // TODO: split long weather conditions across multiple lines
   layout.cond.label = current.txt.charAt(0).toUpperCase()+current.txt.slice(1);
   layout.loc.label = current.loc;
   layout.updateTime.label = `${formatDuration(Date.now() - current.time)} ago`;

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -10,7 +10,7 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
   {type: "h", filly: 0, c: [
     {type: "custom", width: g.getWidth()/2, height: g.getWidth()/2, valign: -1, txt: "unknown", id: "icon",
       render: l => weather.drawIcon(l.txt, l.x+l.w/2, l.y+l.h/2, l.w/2-5)},
-    {type: "v", c: [
+    {type: "v", fillx: 1, c: [
       {type: "h", pad: 2, c: [
         {type: "txt", font: "18%", id: "temp", label: "000"},
         {type: "txt", font: "12%", valign: -1, id: "tempUnit", label: "°C"},
@@ -30,9 +30,9 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
   {type: "txt", font: "9%", wrap: true, height: g.getHeight()*0.18, fillx: 1, id: "cond", label: "Weather condition"},
   {filly: 1},
   {type: "h", c: [
-    {type: "txt", font: "6x8", pad: 2, id: "loc", label: "Toronto"},
+    {type: "txt", font: "6x8", pad: 4, id: "loc", label: "Toronto"},
     {fillx: 1},
-    {type: "txt", font: "6x8", pad: 2, id: "updateTime", label: "15 minutes ago"},
+    {type: "txt", font: "6x8", pad: 4, id: "updateTime", label: "15 minutes ago"},
   ]},
   {filly: 1},
 ]}, null, {lazy: true});
@@ -76,9 +76,9 @@ function update() {
   } else {
     layout.forgetLazyState();
     if (NRF.getSecurityStatus().connected) {
-      E.showMessage("Weather unknown\n\nIs Gadgetbridge\nweather reporting\nset up on your\nphone?");
+      E.showMessage("Weather\nunknown\n\nIs Gadgetbridge\nweather\nreporting set\nup on your\nphone?");
     } else {
-      E.showMessage("Weather unknown\n\nGadgetbridge\nnot connected");
+      E.showMessage("Weather\nunknown\n\nGadgetbridge\nnot connected");
       NRF.on("connect", update);
     }
   }

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -74,7 +74,7 @@ function update() {
   if (current) {
     draw();
   } else {
-    delete layout.rects;
+    layout.forgetLazyState();
     if (NRF.getSecurityStatus().connected) {
       E.showMessage("Weather unknown\n\nIs Gadgetbridge\nweather reporting\nset up on your\nphone?");
     } else {

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -1,96 +1,107 @@
-(() => {
-  const weather = require('weather');
-  let current = weather.get();
+const Layout = require('Layout');
+const locale = require('locale');
+const weather = require('weather');
+let current = weather.get();
 
-  function formatDuration(millis) {
-    let pluralize = (n, w) => n + " " + w + (n == 1 ? "" : "s");
-    if (millis < 60000) return "< 1 minute";
-    if (millis < 3600000) return pluralize(Math.floor(millis/60000), "minute");
-    if (millis < 86400000) return pluralize(Math.floor(millis/3600000), "hour");
-    return pluralize(Math.floor(millis/86400000), "day");
-  }
+Bangle.loadWidgets();
 
-  function draw() {
-    g.reset();
-    g.clearRect(0, 24, 239, 239);
+var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
+  {filly: 1},
+  {type: "h", filly: 0, c: [
+    {type: "custom", width: g.getWidth()/2, height: g.getWidth()/2, valign: -1, txt: "unknown", id: "icon",
+      render: l => weather.drawIcon(l.txt, l.x+l.w/2, l.y+l.h/2, l.w/2-5)},
+    {type: "v", c: [
+      {type: "h", pad: 2, c: [
+        {type: "txt", font: "18%", id: "temp", label: "000"},
+        {type: "txt", font: "12%", valign: -1, id: "tempUnit", label: "°C"},
+      ]},
+      {filly: 1},
+      {type: "txt", font: "6x8", pad: 2, halign: 1, label: "Humidity"},
+      {type: "txt", font: "9%", pad: 2, halign: 1, id: "hum", label: "000%"},
+      {filly: 1},
+      {type: "txt", font: "6x8", pad: 2, halign: -1, label: "Wind"},
+      {type: "h", halign: -1, c: [
+        {type: "txt", font: "9%", pad: 2, id: "wind",  label: "00"},
+        {type: "txt", font: "6x8", pad: 2, valign: -1, id: "windUnit", label: "km/h"},
+      ]},
+    ]},
+  ]},
+  {filly: 1},
+  {type: "txt", font: "9%", id: "cond", label: "Weather line 1"},
+  {filly: 1},
+  {type: "h", c: [
+    {type: "txt", font: "6x8", pad: 2, id: "loc", label: "Toronto"},
+    {fillx: 1},
+    {type: "txt", font: "6x8", pad: 2, id: "updateTime", label: "15 minutes ago"},
+  ]},
+  {filly: 1},
+]}, null, {lazy: true});
 
-    weather.drawIcon(current.txt, 65, 90, 55);
-    const locale = require("locale");
+function formatDuration(millis) {
+  let pluralize = (n, w) => n + " " + w + (n == 1 ? "" : "s");
+  if (millis < 60000) return "< 1 minute";
+  if (millis < 3600000) return pluralize(Math.floor(millis/60000), "minute");
+  if (millis < 86400000) return pluralize(Math.floor(millis/3600000), "hour");
+  return pluralize(Math.floor(millis/86400000), "day");
+}
 
-    g.reset();
+function draw() {
+  layout.icon.txt = current.txt;
+  const temp = locale.temp(current.temp-273.15).match(/^(\D*\d*)(.*)$/);
+  layout.temp.label = temp[1];
+  layout.tempUnit.label = temp[2];
+  layout.hum.label = current.hum+"%";
+  const wind = locale.speed(current.wind).match(/^(\D*\d*)(.*)$/);
+  layout.wind.label = wind[1];
+  layout.windUnit.label = wind[2] + " " + current.wrose.toUpperCase();
+  // TODO: split long weather conditions across multiple lines
+  layout.cond.label = current.txt.charAt(0).toUpperCase()+current.txt.slice(1);
+  layout.loc.label = current.loc;
+  layout.updateTime.label = `${formatDuration(Date.now() - current.time)} ago`;
+  layout.update();
+  layout.render();
+}
 
-    const temp = locale.temp(current.temp-273.15).match(/^(\D*\d*)(.*)$/);
-    let width = g.setFont("Vector", 40).stringWidth(temp[1]);
-    width += g.setFont("Vector", 20).stringWidth(temp[2]);
-    g.setFont("Vector", 40).setFontAlign(-1, -1, 0);
-    g.drawString(temp[1], 180-width/2, 70);
-    g.setFont("Vector", 20).setFontAlign(1, -1, 0);
-    g.drawString(temp[2], 180+width/2, 70);
+function drawUpdateTime() {
+  if (!current || !current.time) return;
+  layout.updateTime.label = `${formatDuration(Date.now() - current.time)} ago`;
+  layout.update();
+  layout.render();
+}
 
-    g.setFont("6x8", 1);
-    g.setFontAlign(-1, 0, 0);
-    g.drawString("Humidity", 135, 130);
-    g.setFontAlign(1, 0, 0);
-    g.drawString(current.hum+"%", 225, 130);
-    if ('wind' in current) {
-      g.setFontAlign(-1, 0, 0);
-      g.drawString("Wind", 135, 142);
-      g.setFontAlign(1, 0, 0);
-      g.drawString(locale.speed(current.wind)+' '+current.wrose.toUpperCase(), 225, 142);
-    }
-
-    g.setFont("6x8", 2).setFontAlign(0, 0, 0);
-    g.drawString(current.loc, 120, 170);
-
-    g.setFont("6x8", 1).setFontAlign(0, 0, 0);
-    g.drawString(current.txt.charAt(0).toUpperCase()+current.txt.slice(1), 120, 190);
-
-    drawUpdateTime();
-
-    g.flip();
-  }
-
-  function drawUpdateTime() {
-    if (!current || !current.time) return;
-    let text = `Last update received ${formatDuration(Date.now() - current.time)} ago`;
-    g.reset();
-    g.clearRect(0, 202, 239, 210);
-    g.setFont("6x8", 1).setFontAlign(0, 0, 0);
-    g.drawString(text, 120, 206);
-  }
-
-  function update() {
-    current = weather.get();
-    NRF.removeListener("connect", update);
-    if (current) {
-      draw();
-    } else if (NRF.getSecurityStatus().connected) {
+function update() {
+  current = weather.get();
+  NRF.removeListener("connect", update);
+  if (current) {
+    draw();
+  } else {
+    delete layout.rects;
+    if (NRF.getSecurityStatus().connected) {
       E.showMessage("Weather unknown\n\nIs Gadgetbridge\nweather reporting\nset up on your\nphone?");
     } else {
       E.showMessage("Weather unknown\n\nGadgetbridge\nnot connected");
       NRF.on("connect", update);
     }
   }
+}
 
-  let interval = setInterval(drawUpdateTime, 60000);
-  Bangle.on('lcdPower', (on) => {
-    if (interval) {
-      clearInterval(interval);
-      interval = undefined;
-    }
-    if (on) {
-      drawUpdateTime();
-      interval = setInterval(drawUpdateTime, 60000);
-    }
-  });
+let interval = setInterval(drawUpdateTime, 60000);
+Bangle.on('lcdPower', (on) => {
+  if (interval) {
+    clearInterval(interval);
+    interval = undefined;
+  }
+  if (on) {
+    drawUpdateTime();
+    interval = setInterval(drawUpdateTime, 60000);
+  }
+});
 
-  weather.on("update", update);
+weather.on("update", update);
 
-  update();
+update();
 
-  // Show launcher when middle button pressed
-  Bangle.setUI("clock");
+// Show launcher when middle button pressed
+Bangle.setUI("clock");
 
-  Bangle.loadWidgets();
-  Bangle.drawWidgets();
-})()
+Bangle.drawWidgets();

--- a/modules/Layout.js
+++ b/modules/Layout.js
@@ -73,6 +73,7 @@ Other functions:
 * `layout.update()` - update positions of everything if contents have changed
 * `layout.debug(obj)` - draw outlines for objects on screen
 * `layout.clear(obj)` - clear the given object (you can also just specify `bgCol` to clear before each render)
+* `layout.forgetLazyState()` - if lazy rendering is enabled, makes the next call to `render()` perform a full re-render
 
 */
 
@@ -257,6 +258,10 @@ Layout.prototype.render = function (l) {
     render(l);
   }
 };
+
+Layout.prototype.forgetLazyState = function () {
+  this.rects = {};
+}
 
 Layout.prototype.layout = function (l) {
   // l = current layout element


### PR DESCRIPTION
I took a stab at updating the weather app to use the new Layout library.

Some notes:

- Experimenting with different layout variations is very convenient!
- I found a small hack to sort-of-emulate different screen sizes: `g.getWidth=()=>176;g.getHeight=()=>176;`
- The initial layout / render adds a rather noticeable delay to the app's loading time
  - This is made worse by the fact that I construct the layout with placeholder labels (which implicitly calls `layout.update()`), and then I immediately fill out the labels with actual data (if available) and call `update()` again. It would be nice if there was a way to tell the Layout constructor to skip that initial `update()` call.
- I could see memory usage becoming an issue on the Bangle 1. On my watch this change increases memory usage from 44% all the way to 74%. I know you were thinking of rewriting the Layout library in C in order to improve performance - would it be possible to optimize the memory usage as well?
- If anything other than the layout object clears the screen, the lazy rendering state needs to be cleared. Right now I'm just doing `delete layout.rects`, but I should probably add a method for that.
- If you change the length of some text that's left- or right-aligned using `halign`, and you still want it to be properly aligned, you need to call `layout.update()` again. This feels like overkill when I'm just trying to update a single line in the corner of the screen. Being able to align the text itself within the bounds of the `txt` object would help.
- Multiline text with line wrapping would be handy. If you would like, I think I could port that over from my `trui` layout library. It would require a bit of modification to the layout algorithm to do properly, though, since the wrapping text would need to know how much horizontal space is available before it can calculate its minimum height. The simplest solution would probably be to calculate `_w` and `w` for all objects in a separate pass before calculating `_h` and `h`.

![screenshot (24)](https://user-images.githubusercontent.com/2780794/134971028-d72e7bdc-1d19-4928-a38a-eb2f884b14ba.png)

![screenshot (25)](https://user-images.githubusercontent.com/2780794/134971199-bb3c97c5-d3d8-42af-a7ef-4894f685e01e.png)
