### PR TITLE
Small theme colour fix for Launcher

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -42,7 +42,7 @@
     "name": "Launcher (Default)",
     "shortName":"Launcher",
     "icon": "app.png",
-    "version":"0.06",
+    "version":"0.07",
     "description": "This is needed by Bangle.js to display a menu allowing you to choose your own applications. You can replace this with a customised launcher.",
     "tags": "tool,system,launcher,b2",
     "type":"launch",

--- a/apps/launch/ChangeLog
+++ b/apps/launch/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Now displays widgets
 0.05: Use g.theme for colours
 0.06: Use Bangle.setUI for buttons
+0.07: Theme colours fix

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -33,8 +33,10 @@ function drawMenu() {
     if (i+menuScroll==selected) {
       g.setColor(g.theme.bgH).fillRect(0,y,w-1,y+63);
       g.setColor(g.theme.fgH).drawRect(0,y,w-1,y+63);
-    } else
-      g.clearRect(0,y,w-1,y+63);
+    } else {
+      g.clearRect(0, y, w-1, y+63);
+      g.setColor(g.theme.fg);
+    }
     g.drawString(app.name,64,y+32);
     var icon=undefined;
     if (app.icon) icon = s.read(app.icon);


### PR DESCRIPTION
I was playing with a custom theme, and apps showed up in the wrong colour until I scrolled over them, this fixed it.