### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Bangle.js App Loader (and Apps)
 ================================
 
-[![Build Status](https://travis-ci.org/espruino/BangleApps.svg?branch=master)](https://travis-ci.org/espruino/BangleApps)
+[![Build Status](https://app.travis-ci.com/espruino/BangleApps.svg?branch=master)](https://app.travis-ci.com/github/espruino/BangleApps)
 
 * Try the **release version** at [banglejs.com/apps](https://banglejs.com/apps)
-* Try the **development version** at [github.io](https://espruino.github.io/BangleApps/)
+* Try the **development version** at [espruino.github.io](https://espruino.github.io/BangleApps/)
 
 **All software (including apps) in this repository is MIT Licensed - see [LICENSE](LICENSE)** By
 submitting code to this repository you confirm that you are happy with it being MIT licensed,


### PR DESCRIPTION
Updated links to travis-ci.org to app.travis-ci.com per "ORG Shutdown" https://blog.travis-ci.com/2021-05-07-orgshutdown