### PR TITLE
menusmall: follow latest E_showMenu improvements

### DIFF
--- a/apps/menusmall/boot.js
+++ b/apps/menusmall/boot.js
@@ -46,7 +46,6 @@ E.showMenu = function(items) {
           rows = 1+rowmax-rowmin;
         }
       }
-      var less = idx>0;
       while (rows--) {
         var name = menuItems[idx];
         var item = items[name];
@@ -77,7 +76,7 @@ E.showMenu = function(items) {
       g.setColor((idx<menuItems.length)?g.theme.fg:g.theme.bg).fillPoly([72,166,104,166,88,174]);
       g.flip();
     },
-    select : function(dir) {
+    select : function() {
       var item = items[menuItems[options.selected]];
       if ("function" == typeof item) item(l);
       else if ("object" == typeof item) {
@@ -95,16 +94,13 @@ E.showMenu = function(items) {
       if (l.selectEdit) {
         var item = l.selectEdit;
         item.value -= (dir||1)*(item.step||1);
-        if (item.min!==undefined && item.value<item.min)
-          item.value = (item.wrap && item.max!==undefined) ? item.max : item.min;
-        if (item.max!==undefined && item.value>item.max)
-          item.value = (item.wrap && item.min!==undefined) ? item.min : item.max;
+        if (item.min!==undefined && item.value<item.min) item.value = item.wrap ? item.max : item.min;
+        if (item.max!==undefined && item.value>item.max) item.value = item.wrap ? item.min : item.max;
         if (item.onchange) item.onchange(item.value);
         l.draw(options.selected,options.selected);
       } else {
         var a=options.selected;
-        options.selected = (dir+options.selected)%menuItems.length;
-        if (options.selected<0) options.selected += menuItems.length;
+        options.selected = (dir+options.selected+menuItems.length)%menuItems.length;
         l.draw(Math.min(a,options.selected), Math.max(a,options.selected));
       }
     }


### PR DESCRIPTION
Apply https://github.com/espruino/EspruinoDocs/pull/616 / https://github.com/espruino/Espruino/pull/2085

Only small optimizations, so I figured skipping the version bump would be ok.

- remove unused variable
- remove unused parameter from `select()`
- shave a few bytes off `move()`

If a numerical item has `item.wrap` we no longer check if `item.min/max` is set, because your menu will be broken either way.