### PR TITLE
apps.json fix: fwupdate is for Bangle.js 2 only

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -7,7 +7,7 @@
     "icon": "app.png",
     "type": "RAM",
     "tags": "tools,system",
-    "supports": ["BANGLEJS","BANGLEJS2"],
+    "supports": ["BANGLEJS2"],
     "custom": "custom.html",
     "customConnect": true,
     "storage": [],


### PR DESCRIPTION
This app used to be tagged `b2` only, but got both devices during the great `tags`->`supports` update: https://github.com/espruino/BangleApps/commit/a94790391a9f13ab83c9658ba48080b9d5967190#diff-70e375511009c0cb767fdc64667e148359c6d6b7b8cf4f100b7eb0e853f83529L8-R10