### PR TITLE
BLE GATT Battery Service works on Bangle JS 2

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2852,7 +2852,7 @@
     "icon": "bluetooth.png",
     "type": "bootloader",
     "tags": "battery,ble,bluetooth,gatt",
-    "supports": ["BANGLEJS"],
+    "supports": ["BANGLEJS","BANGLEJS2"],
     "readme": "README.md",
     "storage": [
       {"name":"gattbat.boot.js","url":"boot.js"}


### PR DESCRIPTION
I've got the data going into Home Assistant already.