### PR TITLE
weather: Bangle.js 2 support

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -749,12 +749,12 @@
   {
     "id": "weather",
     "name": "Weather",
-    "version": "0.10",
+    "version": "0.11",
     "description": "Show Gadgetbridge weather report",
     "icon": "icon.png",
     "screenshots": [{"url":"screenshot.png"}],
     "tags": "widget,outdoors",
-    "supports": ["BANGLEJS"],
+    "supports": ["BANGLEJS","BANGLEJS2"],
     "readme": "readme.md",
     "storage": [
       {"name":"weather.app.js","url":"app.js"},

--- a/apps/gbridge/sample_messages.js
+++ b/apps/gbridge/sample_messages.js
@@ -15,7 +15,7 @@ GB({"t":"notify","id":1592721714,"src":"ALARMCLOCKRECEIVER"})
 GB({"t":"notify-","id":1592721714})
 
 // Weather update (doesn't show a notification, not handled by gbridge app: see weather app)
-GB({"t":"weather","temp":288,"hum":94,"txt":"Light rain","wind":0,"loc":"Test City"})
+GB({"t":"weather","temp":288,"hum":94,"txt":"Light rain","wind":0,"wdir":120,"loc":"Test City"})
 
 // Nextcloud updated a file
 GB({"t":"notify","id":1594184421,"src":"Nextcloud","title":"Downloaded","body":"test.file downloaded"})

--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -7,3 +7,4 @@
 0.08: Refactor and reduce widget ram usage.
 0.09: Fix crash when weather.json is absent.
 0.10: Use new Layout library
+0.11: Bangle.js 2 support

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -53,8 +53,8 @@ function draw() {
   layout.hum.label = current.hum+"%";
   const wind = locale.speed(current.wind).match(/^(\D*\d*)(.*)$/);
   layout.wind.label = wind[1];
-  layout.windUnit.label = wind[2] + " " + current.wrose.toUpperCase();
-  layout.cond.label = current.txt.charAt(0).toUpperCase()+current.txt.slice(1);
+  layout.windUnit.label = wind[2] + " " + (current.wrose||'').toUpperCase();
+  layout.cond.label = current.txt.charAt(0).toUpperCase()+(current.txt||'').slice(1);
   layout.loc.label = current.loc;
   layout.updateTime.label = `${formatDuration(Date.now() - current.time)} ago`;
   layout.update();

--- a/apps/weather/lib.js
+++ b/apps/weather/lib.js
@@ -1,4 +1,5 @@
 const storage = require('Storage');
+const B2 = process.env.HWVERSION===2;
 
 let expiryTimeout;
 function scheduleExpiry(json) {
@@ -54,13 +55,13 @@ scheduleExpiry(storage.readJSON('weather.json')||{});
 
 exports.drawIcon = function(cond, x, y, r) {
   function drawSun(x, y, r) {
-    g.setColor(g.theme.dark ? "#FE0" : "#FC0");
+    g.setColor(B2 ? '#FF0' : (g.theme.dark ? "#FE0" : "#FC0"));
     g.fillCircle(x, y, r);
   }
 
   function drawCloud(x, y, r, c) {
     const u = r/12;
-    if (c==null) c = g.theme.dark ? "#BBB" : "#AAA";
+    if (c==null) c = B2 ? '#FFF': (g.theme.dark ? "#BBB" : "#AAA");
     g.setColor(c);
     g.fillCircle(x-8*u, y+3*u, 4*u);
     g.fillCircle(x-4*u, y-2*u, 5*u);
@@ -77,7 +78,7 @@ exports.drawIcon = function(cond, x, y, r) {
   }
 
   function drawBrokenClouds(x, y, r) {
-    drawCloud(x+1/8*r, y-1/8*r, 7/8*r, "#777");
+    drawCloud(x+1/8*r, y-1/8*r, 7/8*r, "#777"); // dithers on B2, but that's ok
     drawCloud(x-1/8*r, y+1/8*r, 7/8*r);
   }
 
@@ -87,23 +88,23 @@ exports.drawIcon = function(cond, x, y, r) {
   }
 
   function drawRainLines(x, y, r) {
-    g.setColor(g.theme.dark ? "#0CF" : "#07F");
+    g.setColor(B2 ? '#0FF' : (g.theme.dark ? "#0CF" : "#07F"));
     const y1 = y+1/2*r;
     const y2 = y+1*r;
-    
-    g.fillPolyAA([
+    const poly = g.fillPolyAA ? p => g.fillPolyAA(p) : p => g.fillPoly(p);
+    poly([
       x-6/12*r, y1,
       x-8/12*r, y2,
       x-7/12*r, y2,
       x-5/12*r, y1,
     ]);
-    g.fillPolyAA([
+    poly([
       x-2/12*r, y1,
       x-4/12*r, y2,
       x-3/12*r, y2,
       x-1/12*r, y1,
     ]);
-    g.fillPolyAA([
+    poly([
       x+2/12*r, y1,
       x+0/12*r, y2,
       x+1/12*r, y2,
@@ -123,7 +124,7 @@ exports.drawIcon = function(cond, x, y, r) {
 
   function drawThunderstorm(x, y, r) {
     function drawLightning(x, y, r) {
-      g.setColor(g.theme.dark ? "#FE0" : "#FC0");
+      g.setColor(B2 ? '#FF0' : (g.theme.dark ? "#FE0" : "#FC0"));
       g.fillPoly([
         x-2/6*r, y-r,
         x-4/6*r, y+1/6*r,
@@ -151,7 +152,7 @@ exports.drawIcon = function(cond, x, y, r) {
       }
     }
 
-    g.setColor(g.theme.dark ? "#FFF" : "#CCC");
+    g.setColor(B2 ? '#FFF' : (g.theme.dark ? "#FFF" : "#CCC"));
     const w = 1/12*r;
     for(let i = 0; i<=6; ++i) {
       const points = [
@@ -186,7 +187,7 @@ exports.drawIcon = function(cond, x, y, r) {
       [-0.2, 0.3],
     ];
 
-    g.setColor(g.theme.dark ? "#FFF" : "#CCC");
+    g.setColor(B2 ? '#FFF' : (g.theme.dark ? "#FFF" : "#CCC"));
     for(let i = 0; i<5; ++i) {
       g.fillRect(x+layers[i][0]*r, y+(0.4*i-0.9)*r, x+layers[i][1]*r,
         y+(0.4*i-0.7)*r-1);
@@ -196,7 +197,7 @@ exports.drawIcon = function(cond, x, y, r) {
   }
 
   function drawUnknown(x, y, r) {
-    drawCloud(x, y, r, "#777");
+    drawCloud(x, y, r, "#777"); // dithers on B2, but that's ok
     g.setColor(g.theme.fg).setFontAlign(0, 0).setFont('Vector', r*2).drawString("?", x+r/10, y+r/6);
   }
 


### PR DESCRIPTION
- use `g.fillPoly` when device doesn't support `g.fillPolyAA`
- use (mostly) 3-bit colors instead of dithering
- crash a bit less on incomplete weather data