### PR TITLE
Bugfix: Compass bearing not clearing correctly

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -599,7 +599,7 @@
   {
     "id": "compass",
     "name": "Compass",
-    "version": "0.04",
+    "version": "0.05",
     "description": "Simple compass that points North",
     "icon": "compass.png",
     "screenshots": [{"url":"screenshot_compass.png"}],

--- a/apps/compass/ChangeLog
+++ b/apps/compass/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Show text if uncalibrated
 0.03: Eliminate flickering
 0.04: Fix for Bangle.js 2 and themes
+0.05: Fix bearing not clearing correctly (visible in single or double digit bearings)

--- a/apps/compass/compass.js
+++ b/apps/compass/compass.js
@@ -48,7 +48,7 @@ Bangle.on('mag', function(m) {
     }
     g.setFontAlign(0,0).setFont("6x8",3);
     var y = 36;
-    g.clearRect(M-40,y,M+40,y+24);
+    g.clearRect(M-40,24,M+40,48);
     g.drawString(Math.round(m.heading),M,y,true);
   }
 


### PR DESCRIPTION
The box being cleared was off so on single or double digit bearings artefacts remained either side