### PR TITLE
Barclock works fine on the Bangle.js 2 :-)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1690,7 +1690,7 @@
   {
     "id": "barclock",
     "name": "Bar Clock",
-    "version": "0.08",
+    "version": "0.09",
     "description": "A simple digital clock showing seconds as a bar",
     "icon": "clock-bar.png",
     "screenshots": [{"url":"screenshot.png"},{"url":"screenshot_pm.png"}],

--- a/apps.json
+++ b/apps.json
@@ -1696,7 +1696,7 @@
     "screenshots": [{"url":"screenshot.png"},{"url":"screenshot_pm.png"}],
     "type": "clock",
     "tags": "clock",
-    "supports": ["BANGLEJS"],
+    "supports": ["BANGLEJS","BANGLEJS2"],
     "readme": "README.md",
     "allow_emulator": true,
     "storage": [

--- a/apps/barclock/ChangeLog
+++ b/apps/barclock/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Improve accuracy
 0.07: Update to use Bangle.setUI instead of setWatch
 0.08: Use theme colors, Layout library
+0.09: Fix time/date disappearing after fullscreen notification

--- a/apps/barclock/clock-bar.js
+++ b/apps/barclock/clock-bar.js
@@ -24,7 +24,7 @@ function renderBar(l) {
     return;
   }
   const width = this.fraction*l.w;
-  g.fillRect(l.x, l.y, width-1, l.y+l.height-1);
+  g.fillRect(l.x, l.y, l.x+width-1, l.y+l.height-1);
 }
 
 const Layout = require("Layout");
@@ -78,7 +78,7 @@ function dateText(date) {
   return `${dayName}  ${dayMonth}`;
 }
 
-draw = function draw() {
+draw = function draw(force) {
   if (!Bangle.isLCDOn()) {return;} // no drawing, also no new update scheduled
   const date = new Date();
   layout.time.label = timeText(date);
@@ -86,6 +86,10 @@ draw = function draw() {
   layout.date.label = dateText(date);
   const SECONDS_PER_MINUTE = 60;
   layout.bar.fraction = date.getSeconds()/SECONDS_PER_MINUTE;
+  if (force) {
+    Bangle.drawWidgets();
+    layout.forgetLazyState();
+  }
   layout.render();
   // schedule update at start of next second
   const millis = date.getMilliseconds();
@@ -96,7 +100,7 @@ draw = function draw() {
 Bangle.setUI("clock");
 Bangle.on("lcdPower", function(on) {
   if (on) {
-    draw();
+    draw(true);
   }
 });
 g.reset().clear();


### PR DESCRIPTION
At least, it works just as well as on the Bangle.js 1, where it also breaks from fullscreen notifications.   
So fixed that, and now it really works fine on both devices.