### PR TITLE
locale: Apply 12hour setting to time

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -170,7 +170,7 @@
   {
     "id": "locale",
     "name": "Languages",
-    "version": "0.09",
+    "version": "0.10",
     "description": "Translations for different countries",
     "icon": "locale.png",
     "type": "locale",

--- a/apps/locale/ChangeLog
+++ b/apps/locale/ChangeLog
@@ -9,3 +9,4 @@
 0.07: Improve handling of non-ASCII characters (fix #469)
 0.08: Added Mavigation units and en_NAV
 0.09: Added New Zealand en_NZ
+0.10: Apply 12hour setting to time

--- a/apps/locale/locale.html
+++ b/apps/locale/locale.html
@@ -146,7 +146,7 @@ exports = { name : "en_GB", currencySym:"£",
           "%-m": "d.getMonth()+1",
           "%d":  "('0'+d.getDate()).slice(-2)",
           "%-d": "d.getDate()",
-          "%HH": "('0'+d.getHours()).slice(-2)",
+          "%HH": "('0'+getHours(d)).slice(-2)",
           "%MM": "('0'+d.getMinutes()).slice(-2)",
           "%SS": "('0'+d.getSeconds()).slice(-2)",
           "%A":  "day.split(',')[d.getDay()]",
@@ -177,6 +177,13 @@ var day = ${js(locale.day + ',' + locale.abday)};
 var month = ${js(locale.month + ',' + locale.abmonth)};
 function round(n) {
   return n < 10 ? Math.round(n * 10) / 10 : Math.round(n);
+}
+var is12;
+function getHours(d) {
+  var h = d.getHours();
+  if (is12==undefined) is12 = (require('Storage',1).readJSON('setting.json')||{})["12hour"];
+  if (!is12) return h;
+  return (h%12==0) ? 12 : h%12;
 }
 exports = {
   name: ${js(locale.lang)},


### PR DESCRIPTION
Fixes #892

I figured it would be a good idea to not read+parse the settings file every time something wants to draw the time, so we remember it after the first call.