### PR TITLE
widbatpc: Fix drawing the bar when charging

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -872,7 +872,7 @@
     "id": "widbatpc",
     "name": "Battery Level Widget (with percentage)",
     "shortName": "Battery Widget",
-    "version": "0.13",
+    "version": "0.14",
     "description": "Show the current battery level and charging status in the top right of the clock, with charge percentage",
     "icon": "widget.png",
     "type": "widget",

--- a/apps/widbatpc/ChangeLog
+++ b/apps/widbatpc/ChangeLog
@@ -10,3 +10,4 @@
 0.11: Don't overwrite existing settings on app update
 0.12: Fixed for Bangle 2
 0.13: Fillbar setting added, see README
+0.14: Fix drawing the bar when charging

--- a/apps/widbatpc/README.md
+++ b/apps/widbatpc/README.md
@@ -5,12 +5,12 @@ Show the current battery level and charging status in the top right of the clock
 Works with Bangle 1 and Bangle 2
 
 When the fillbar setting is on the level colour will fill the entire
-bar.  This makes for an easier to read dsiplay when the charge is
+bar.  This makes for an easier to read display when the charge is
 below 50%.
 
 ![](widbatpc.full.jpg)
 
-When the fillbar setting is off the level colour will follow the battry percentage
+When the fillbar setting is off the level colour will follow the battery percentage
 
 ![](widbatpc.part.jpg)
 

--- a/apps/widbatpc/widget.js
+++ b/apps/widbatpc/widget.js
@@ -79,20 +79,20 @@
     // else...
     var s = 39;
     var x = this.x, y = this.y;
-    const l = E.getBattery();
-    let xl = x+4+l*(s-12)/100;
+    const l = E.getBattery(),
+          c = levelColor(l);
 
-    // show bar full in the level color, as you cant see the color if the bar is too small
-    if (setting('fillbar'))
-      xl = x+4+100*(s-12)/100;
-    
-    c = levelColor(l);
-    
     if (Bangle.isCharging() && setting('charger')) {
       g.setColor(chargerColor()).drawImage(atob(
         "DhgBHOBzgc4HOP////////////////////3/4HgB4AeAHgB4AeAHgB4AeAHg"),x,y);
       x+=16;
     }
+
+    let xl = x+4+l*(s-12)/100;
+    // show bar full in the level color, as you can't see the color if the bar is too small
+    if (setting('fillbar'))
+      xl = x+4+100*(s-12)/100;
+
     g.setColor(g.theme.fg);
     g.fillRect(x,y+2,x+s-4,y+21);
     g.clearRect(x+2,y+4,x+s-6,y+19);


### PR DESCRIPTION
When displaying the charging indicator, the whole widget moves to the right, now including the charge bar.
Also some minor typos in the readme.