### PR TITLE
Adjust 93dub midnight for 12hr time

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4531,7 +4531,7 @@
    "shortName":"93 Dub",
    "icon": "93dub.png",
    "screenshots": [{"url":"screenshot.png"}],
-   "version":"0.03",
+   "version":"0.04",
    "description": "Fan recreation of orviwan's 91 Dub app for the Pebble smartwatch. Uses assets from his 91-Dub-v2.0 repo",
    "tags": "clock",
    "type": "clock",

--- a/apps/93dub/ChangeLog
+++ b/apps/93dub/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial version for upload
 0.02: DiscoMinotaur's adjustments (removed battery and adjusted spacing)
 0.03: Code style cleanup
+0.04: Set 00:00 to 12:00 for 12 hour time

--- a/apps/93dub/README.md
+++ b/apps/93dub/README.md
@@ -9,3 +9,4 @@ Leer10
 Orviwan (original watchface and assets)
 Gordon Williams (Bangle.js, watchapps for reference code and documentation)
 DiscoMinotaur (adjustments)
+Ray Holder (minor 12 hour time rendering adjustment)

--- a/apps/93dub/app.js
+++ b/apps/93dub/app.js
@@ -78,6 +78,9 @@ function draw(){
     } else {
       h = " " + h;
     }
+  } else if (h === 0) {
+    // display 12:00 instead of 00:00 for 12 hr mode
+    h = "12";
   }
 
   //draw separator


### PR DESCRIPTION
Currently the `93dub` watch face displays midnight for the 12 hour time setting as 00:00. This PR changes it to more correctly display 12:00.

I've tested this change in the emulator to verify that the 24 hour time setting remains unchanged for various dates with hour values of midnight (00:00). Testing these same inputs for the 12 hour setting now displays values of 12:00 for 00:00.