### PR TITLE
Allow Calendar app to begin on Sunday

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -2392,7 +2392,7 @@
   {
     "id": "calendar",
     "name": "Calendar",
-    "version": "0.02",
+    "version": "0.03",
     "description": "Simple calendar",
     "icon": "calendar.png",
     "screenshots": [{"url":"screenshot_calendar.png"}],
@@ -2402,8 +2402,10 @@
     "allow_emulator": true,
     "storage": [
       {"name":"calendar.app.js","url":"calendar.js"},
+      {"name":"calendar.settings.js","url":"settings.js"},
       {"name":"calendar.img","url":"calendar-icon.js","evaluate":true}
     ]
+    "data": [{"name":"messages.json"}]
   },
   {
     "id": "hidjoystick",

--- a/apps.json
+++ b/apps.json
@@ -2404,7 +2404,7 @@
       {"name":"calendar.app.js","url":"calendar.js"},
       {"name":"calendar.settings.js","url":"settings.js"},
       {"name":"calendar.img","url":"calendar-icon.js","evaluate":true}
-    ]
+    ],
     "data": [{"name":"messages.json"}]
   },
   {

--- a/apps/calendar/ChangeLog
+++ b/apps/calendar/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Basic calendar
 0.02: Make Bangle 2 compatible
+0.03: Add setting to start week on Sunday

--- a/apps/calendar/README.md
+++ b/apps/calendar/README.md
@@ -6,3 +6,8 @@ Basic calendar
 
 - Use `BTN4` (left screen tap) to go to the previous month
 - Use `BTN5` (right screen tap) to go to the next month
+
+## Settings
+
+- Starts on Sunday: whether the calendar should start on Sunday (default is Monday).
+

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -18,6 +18,10 @@ const gray2 = "#888888";
 const gray3 = "#bbbbbb";
 const red = "#d41706";
 
+let settings = require('Storage').readJSON("calendar.json", true) || {};
+if (settings.startOnSun === undefined)
+  settings.startOnSun = false;
+
 function drawCalendar(date) {
   g.setBgColor(color4);
   g.clearRect(0, 0, maxX, maxY);
@@ -61,13 +65,18 @@ function drawCalendar(date) {
   );
 
   g.setFont("6x8", fontSize);
-  const dowLbls = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+  let dowLbls;
+  if (settings.startOnSun) {
+    dowLbls = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+  } else {
+    dowLbls = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+  }
   dowLbls.forEach((lbl, i) => {
     g.drawString(lbl, i * colW + colW / 2, headerH + rowH / 2);
   });
 
   date.setDate(1);
-  const dow = date.getDay();
+  const dow = date.getDay() + (settings.startOnSun ? 1 : 0);
   const dowNorm = dow === 0 ? 7 : dow;
 
   const monthMaxDayMap = {

--- a/apps/calendar/settings.js
+++ b/apps/calendar/settings.js
@@ -1,0 +1,24 @@
+(function(back) {
+  var FILE = "calendar.json";
+  var settings = require('Storage').readJSON(FILE, true) || {};
+  if (settings.startOnSun === undefined)
+    settings.startOnSun = true;
+
+  function writeSettings() {
+    require('Storage').writeJSON(FILE, settings);
+  }
+
+  E.showMenu({
+    "" : { "title" : "Calendar" },
+    "< Back" : () => back(),
+    'Start on Sunday': {
+      value: settings.startOnSun,
+      format: v => v?"Yes":"No",
+      onchange: v => {
+        settings.startOnSun = v;
+        writeSettings();
+      }
+    },
+  });
+})
+


### PR DESCRIPTION
Adds a setting in a Calendar app which allows it to start the week on Sunday rather than Monday.