### PR TITLE
Fix 93dub on Thursdays

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4575,7 +4575,7 @@
    "shortName":"93 Dub",
    "icon": "93dub.png",
    "screenshots": [{"url":"screenshot.png"}],
-   "version":"0.04",
+   "version":"0.05",
    "description": "Fan recreation of orviwan's 91 Dub app for the Pebble smartwatch. Uses assets from his 91-Dub-v2.0 repo",
    "tags": "clock",
    "type": "clock",

--- a/apps/93dub/ChangeLog
+++ b/apps/93dub/ChangeLog
@@ -2,3 +2,4 @@
 0.02: DiscoMinotaur's adjustments (removed battery and adjusted spacing)
 0.03: Code style cleanup
 0.04: Set 00:00 to 12:00 for 12 hour time
+0.05: Display time, even on Thursday

--- a/apps/93dub/README.md
+++ b/apps/93dub/README.md
@@ -5,8 +5,8 @@
 Uses many portions from Espruino documentation, example watchfaces, and the waveclk app. It also sourced from Jon Barlow's 91 Dub v2.0 source code and resources and adapted for Bangle.js 2's screen. Time, date and the battery display works. It is not pixel perfect to the original.
 
 Contributors:
-Leer10
-Orviwan (original watchface and assets)
-Gordon Williams (Bangle.js, watchapps for reference code and documentation)
-DiscoMinotaur (adjustments)
-Ray Holder (minor 12 hour time rendering adjustment)
+* Leer10
+* Orviwan (original watchface and assets)
+* Gordon Williams (Bangle.js, watchapps for reference code and documentation)
+* DiscoMinotaur (adjustments)
+* Ray Holder (minor 12 hour time rendering adjustment, fix Thursdays)

--- a/apps/93dub/app.js
+++ b/apps/93dub/app.js
@@ -93,7 +93,7 @@ function draw(){
   if (w == 1) {imgW = imgMon;}
   if (w == 2) {imgW = imgTue;}
   if (w == 3) {imgW = imgWed;}
-  if (w == 4) {imgW = imgThr;}
+  if (w == 4) {imgW = imgThu;}
   if (w == 5) {imgW = imgFri;}
   if (w == 6) {imgW = imgSat;}
   g.drawImage(imgW, 85, 63);


### PR DESCRIPTION
This should fix a crash for 93dub that only shows up on Thursdays. When this happens it even seems to disable navigation back to the Settings app from the button on a Banglejs 2 when set as the default clock.

I've tested this on the emulator, and it appears to do the correct thing now.