### PR TITLE
Poweroff app -> tool and emulator

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4593,9 +4593,10 @@
   "version":"0.01",
   "description": "Simple app to power off your Bangle.js",
   "icon": "app.png",
-  "tags": "poweroff, shutdown",
+  "tags": "tool, poweroff, shutdown",
   "supports" : ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",
+  "allow_emulator": true,
   "storage": [
     {"name":"poweroff.app.js","url":"app.js"},
     {"name":"poweroff.img","url":"app-icon.js","evaluate":true}


### PR DESCRIPTION
- Tagged poweroff app with "tool"
- Allowed it for emulator
