### PR TITLE
gbmusic: Fix scrolling title background color

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3795,7 +3795,7 @@
     "id": "gbmusic",
     "name": "Gadgetbridge Music Controls",
     "shortName": "Music Controls",
-    "version": "0.07",
+    "version": "0.08",
     "description": "Control the music on your Gadgetbridge-connected phone",
     "icon": "icon.png",
     "screenshots": [{"url":"screenshot_v1.png"},{"url":"screenshot_v2.png"}],

--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Setting to disable double/triple press control, remove touch controls setting, reduce fadeout flicker
 0.06: Bangle.js 2 support
 0.07: Fix "previous" button image
+0.08: Fix scrolling title background color

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -91,7 +91,7 @@ function rScroller(l) {
     y = l.y+l.h/2;
   l.offset = l.offset%w;
   g.setClipRect(l.x, l.y, l.x+l.w-1, l.y+l.h-1)
-    .setColor(l.col)
+    .setColor(l.col).setBgColor(l.bgCol) // need to set colors: iScroll calls this function outside Layout
     .setFontAlign(-1, 0) // left center
     .clearRect(l.x, l.y, l.x+l.w-1, l.y+l.h-1)
     .drawString(l.label, l.x-l.offset+40, y)


### PR DESCRIPTION
We forgot to reset the background color when drawing the scrolling title.
Not very noticeable, until you get a notification and suddenly the title starts flashing in sync with the `messages` widget ;-)