### PR TITLE
messages: Open app when touching the widget (Bangle.js 2 only)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -57,7 +57,7 @@
   {
     "id": "messages",
     "name": "Messages",
-    "version": "0.10",
+    "version": "0.11",
     "description": "App to display notifications from iOS and Gadgetbridge",
     "icon": "app.png",
     "type": "app",

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -13,3 +13,4 @@
 0.09: Message now disappears after 60s if no action taken and clock loads (fix 922)
       Fix phone icon (#1014)
 0.10: Respect the 'new' attribute if it was set from iOS integrations
+0.11: Open app when touching the widget (Bangle.js 2 only)

--- a/apps/messages/widget.js
+++ b/apps/messages/widget.js
@@ -1,4 +1,5 @@
 WIDGETS["messages"]={area:"tl",width:0,draw:function() {
+  Bangle.removeListener('touch', this.touch);
   if (!this.width) return;
   var c = (Date.now()-this.t)/1000;
   g.reset().setBgColor((c&1) ? "#0f0" : "#030").setColor((c&1) ? "#000" : "#fff");
@@ -12,6 +13,7 @@ WIDGETS["messages"]={area:"tl",width:0,draw:function() {
     WIDGETS["messages"].buzz(); // buzz every 4 seconds
   }
   setTimeout(()=>WIDGETS["messages"].draw(), 1000);
+  if (process.env.HWVERSION>1) Bangle.on('touch', this.touch);
 },show:function(quiet) {
   WIDGETS["messages"].t=Date.now(); // first time
   WIDGETS["messages"].l=Date.now()-10000; // last buzz
@@ -33,6 +35,10 @@ WIDGETS["messages"]={area:"tl",width:0,draw:function() {
     if (c=="-") Bangle.buzz(500).then(()=>setTimeout(b,100));
   }
   b();
+},touch:function(b,c) {
+  var w=WIDGETS["messages"];
+  if (!w||!w.width||c.x<w.x||c.x>w.x+w.width||c.y<w.y||c.y>w.y+23) return;
+  load("messages.app.js");
 }};
 /* We might have returned here if we were in the Messages app for a
 message but then the watch was never viewed. In that case we don't


### PR DESCRIPTION
I figured that re-adding the `touch` listener every time we redraw the widget should prevent most breakage from apps doing `removeAllListeners`