### PR TITLE
qmsched: Correctly size widget on load

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3870,7 +3870,7 @@
     "id": "qmsched",
     "name": "Quiet Mode Schedule and Widget",
     "shortName": "Quiet Mode",
-    "version": "0.04",
+    "version": "0.05",
     "description": "Automatically turn Quiet Mode on or off at set times, and change LCD options while Quiet Mode is active.",
     "icon": "app.png",
     "screenshots": [{"url":"screenshot_b1_main.png"},{"url":"screenshot_b1_edit.png"},{"url":"screenshot_b1_lcd.png"},

--- a/apps/qmsched/ChangeLog
+++ b/apps/qmsched/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Add widget
 0.03: Bangle.js 2 support
 0.04: Move Quiet Mode LCD options from global settings to this app
+0.05: Avoid immediately redrawing widgets on load

--- a/apps/qmsched/widget.js
+++ b/apps/qmsched/widget.js
@@ -1,32 +1,36 @@
-WIDGETS["qmsched"] = {
-  area: "tl", width: 24, draw: function() {
-    const mode = (require("Storage").readJSON("setting.json", 1) || {}).quiet|0;
-    if (mode===0) { // Off
-      if (this.width!==0) {
-        this.width = 0;
-        Bangle.drawWidgets();
+(function() {
+  WIDGETS["qmsched"] = {
+    area: "tl",
+    width: ((require("Storage").readJSON("setting.json", 1) || {}).quiet|0) ? 24 : 0,
+    draw: function() {
+      const mode = (require("Storage").readJSON("setting.json", 1) || {}).quiet|0;
+      if (mode===0) { // Off
+        if (this.width!==0) {
+          this.width = 0;
+          Bangle.drawWidgets();
+        }
+        return;
       }
-      return;
-    }
-    // not Off: make sure width is correct
-    if (this.width!==24) {
-      this.width = 24;
-      Bangle.drawWidgets();
-      return; // drawWidgets will call draw again
-    }
-    let x = this.x, y = this.y;
-    g.clearRect(x, y, x+23, y+23);
-    // quiet mode: draw red one-way-street sign (dim red on Bangle.js 1)
-    x = this.x+11;y = this.y+11; // center of widget
-    g.setColor(process.env.HWVERSION===2 ? 1 : 0.8, 0, 0).fillCircle(x, y, 8);
-    g.setColor(g.theme.bg).fillRect(x-6, y-2, x+6, y+2);
-    if (mode>1) {return;} // no alarms
-    // alarms still on: draw alarm icon in bottom-right corner
-    x = this.x+18;y = this.y+17; // center of alarm
-    g.setColor(1, 1, 0)
-      .fillCircle(x, y, 3) // alarm body
-      .fillRect(x-5, y+2, x+5, y+3) // bottom ridge
-      .fillRect(x-1, y-5, x+1, y+5).drawLine(x, y-6, x, y+6) // top+bottom
-      .drawLine(x+5, y-3, x+3, y-5).drawLine(x-5, y-3, x-3, y-5); // wriggles
-  },
-};
+      // not Off: make sure width is correct
+      if (this.width!==24) {
+        this.width = 24;
+        Bangle.drawWidgets();
+        return; // drawWidgets will call draw again
+      }
+      let x = this.x, y = this.y;
+      g.clearRect(x, y, x+23, y+23);
+      // quiet mode: draw red one-way-street sign (dim red on Bangle.js 1)
+      x = this.x+11;y = this.y+11; // center of widget
+      g.setColor(process.env.HWVERSION===2 ? 1 : 0.8, 0, 0).fillCircle(x, y, 8);
+      g.setColor(g.theme.bg).fillRect(x-6, y-2, x+6, y+2);
+      if (mode>1) {return;} // no alarms
+      // alarms still on: draw alarm icon in bottom-right corner
+      x = this.x+18;y = this.y+17; // center of alarm
+      g.setColor(1, 1, 0)
+        .fillCircle(x, y, 3) // alarm body
+        .fillRect(x-5, y+2, x+5, y+3) // bottom ridge
+        .fillRect(x-1, y-5, x+1, y+5).drawLine(x, y-6, x, y+6) // top+bottom
+        .drawLine(x+5, y-3, x+3, y-5).drawLine(x-5, y-3, x-3, y-5); // wriggles
+    },
+  };
+})();


### PR DESCRIPTION
Fixes an issue where qmsched would cause widgets to be drawn twice on every app load.

This was especially noticeable on the Bangle 1 when it's snowing outside, since the snowflake icon renders particularly slowly :)