### PR TITLE
Red Torch - Update for Bangle 2

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1698,14 +1698,15 @@
     "id": "rtorch",
     "name": "Red Torch",
     "shortName": "RedTorch",
-    "version": "0.01",
-    "description": "Turns screen RED to help you see in the dark without breaking your night vision. Select from the launcher or press BTN3,BTN1,BTN3,BTN1 quickly to start when in any app that shows widgets",
+    "version": "0.02",
+    "description": "Turns screen RED to help you see in the dark without breaking your night vision. Select from the launcher or on Bangle 1 press BTN3,BTN1,BTN3,BTN1 quickly to start when in any app that shows widgets",
     "icon": "app.png",
     "tags": "tool,torch",
-    "supports": ["BANGLEJS"],
+    "supports": ["BANGLEJS","BANGLEJS2"],
+    "allow_emulator": true,
     "storage": [
       {"name":"rtorch.app.js","url":"app.js"},
-      {"name":"rtorch.wid.js","url":"widget.js"},
+      {"name":"rtorch.wid.js","url":"widget.js", "supports": ["BANGLEJS"]},
       {"name":"rtorch.img","url":"app-icon.js","evaluate":true}
     ]
   },

--- a/apps/rtorch/ChangeLog
+++ b/apps/rtorch/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Cloning torch and making it red :D
+0.02: Modify for setUI and Bangle 2

--- a/apps/rtorch/app.js
+++ b/apps/rtorch/app.js
@@ -2,21 +2,38 @@ Bangle.setLCDPower(1);
 Bangle.setLCDTimeout(0);
 g.reset();
 c = 1;
+
 function setColor(delta){
   c+=delta;
   c = Math.max(c,0);
   c = Math.min(c,2);
   if (c<1){
     g.setColor(c,0,0);
+    Bangle.setLCDBrightness(c >= 0.1 ? c : 0.1);
   }else{
     g.setColor(1,c-1,c-1);
+    Bangle.setLCDBrightness(1);
   }
   g.fillRect(0,0,g.getWidth(),g.getHeight());
 }
-setColor(0)
-// BTN1 light up toward white
-// BTN3 light down to red
-// BTN2 to reset
-setWatch(()=>setColor(0.1), BTN1, { repeat:true, edge:"rising", debounce: 50 });
-setWatch(()=>load(), BTN2);
-setWatch(()=>setColor(-0.1), BTN3, { repeat:true, edge:"rising", debounce: 50 });
+
+function updownHandler(direction){
+  if (direction == undefined){
+    c=1;
+    setColor(0);
+  } else {
+    setColor(-direction * 0.1);
+  }
+}
+
+setColor(0);
+
+// Bangle 1:
+// BTN1: light up toward white
+// BTN3: light down to red
+// BTN2: reset
+// Bangle 2:
+// Swipe up: light up toward white
+// Swipe down: light down to red
+// BTN1: reset
+Bangle.setUI("updown", updownHandler);


### PR DESCRIPTION
- Use setUI instead of Bangle.watch
- Quickstart sequence does just work on Bangle 1, since Bangle 2 is missing the additional two buttons and the only remaining button is often used for functions in apps (see: https://github.com/espruino/BangleApps/pull/1083#issuecomment-993444082)