### PR TITLE
Rebble & Pebble: load steps from health app (as fallback)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4722,7 +4722,7 @@
     "id": "pebble",
     "name": "Pebble Clock",
     "shortName": "Pebble",
-    "version": "0.04",
+    "version": "0.06",
     "description": "A pebble style clock to keep the rebellion going",
     "readme": "README.md",
     "icon": "pebble.png",

--- a/apps.json
+++ b/apps.json
@@ -4875,7 +4875,7 @@
     "id": "rebble",
     "name": "Rebble Clock",
     "shortName": "Rebble",
-    "version": "0.02",
+    "version": "0.03",
     "description": "A Pebble style clock, with configurable background, three sidebars including steps, day, date, sunrise, sunset, long live the rebellion",
     "readme": "README.md",
     "icon": "rebble.png",

--- a/apps/pebble/ChangeLog
+++ b/apps/pebble/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Changed time+calendar font to LECO1976Regular, changed to slanting boot
 0.04: Fix widget hiding code (fix #1046)
 0.05: Fix typo in settings - Purple
+0.06: Get steps from health app (as fallback)

--- a/apps/pebble/pebble.app.js
+++ b/apps/pebble/pebble.app.js
@@ -103,6 +103,18 @@ function drawCalendar(x,y,wi,th,str) {
 function getSteps() {
   if (WIDGETS.wpedom !== undefined) {
     return WIDGETS.wpedom.getSteps();
+  } else {
+    var steps = 0;
+    let health;
+    try {
+      health = require("health");
+      if (health != undefined) {
+        health.readDay(new Date(), h=>steps+=h.steps);
+        return steps;
+      }
+    } catch (e) {
+      // Module health not found
+    }
   }
   return '????';
 }

--- a/apps/rebble/ChangeLog
+++ b/apps/rebble/ChangeLog
@@ -1,2 +1,3 @@
 0.01: First release
 0.02: Fix dependancies, fix type to Purple
+0.03: Load steps from health app (as fallback)

--- a/apps/rebble/rebble.app.js
+++ b/apps/rebble/rebble.app.js
@@ -209,6 +209,18 @@ function drawBattery(x,y,wi,hi) {
 function getSteps() {
   if (WIDGETS.wpedom !== undefined) {
     return WIDGETS.wpedom.getSteps();
+  } else {
+    var steps = 0;
+    let health;
+    try {
+      health = require("health");
+      if (health != undefined) {
+        health.readDay(new Date(), h=>steps+=h.steps);
+        return steps;
+      }
+    } catch (e) {
+      // Module health not found
+    }
   }
   return '????';
 }


### PR DESCRIPTION
I would like to see the Rebble watch have the fallback to load the daily steps from the health app (which is installed by default).

There is already at least one person on reddit which stumbled on the problem that Rebble and Pebble watch does not deliver steps without the pedometer widget installed (which is not installed by default):

https://www.reddit.com/r/Banglejs/comments/rg1llc/step_count_on_bangle_js_2/


Contains changes from previous MR: https://github.com/espruino/BangleApps/pull/1073


