### PR TITLE
pooq Round: tap for transient complications; bugfixes

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4941,7 +4941,7 @@
   { "id": "pooqround",
     "name": "pooq Round watch face",
     "shortName":"pooq Round",
-    "version":"0.00",
+    "version":"0.01",
     "description": "A 24 hour analogue watchface with high legibility and a novel style.",
     "icon": "app.png",
     "type": "clock",

--- a/apps/pooqround/ChangeLog
+++ b/apps/pooqround/ChangeLog
@@ -1,2 +1,2 @@
 0.00: Initial check-in.
-0.01: Add tap-to-decorate feature.
+0.01: Add tap-to-decorate feature. Bugfixes.

--- a/apps/pooqround/ChangeLog
+++ b/apps/pooqround/ChangeLog
@@ -1,1 +1,2 @@
 0.00: Initial check-in.
+0.01: Add tap-to-decorate feature.

--- a/apps/pooqround/README.md
+++ b/apps/pooqround/README.md
@@ -10,16 +10,18 @@ Either you'll like that, or you won't.
 
 ## Options
 
-Because sometimes I don't want to burn what I'm cooking and others I'm lazy and just want to know if it's afternoon yet,
-you can alter the number of ‘hands’ on the display. When the watch is unlocked, slide up to add dots representing the minute and second,
-or down to remove the distraction. There's also a setting that displays the second hand, but only if the watch is perfectly face-to-the-sky,
-in case you want the ability to check the _exact_ time, hands free, without the impact on battery life this usually entails.
-
 Although we generally obey the system-wide theming, you can long press on the display for a menu of additional options specific to the face.
 We don't observe the system 12/24 setting, since it the design of the face is equally good in either interpretation.
 
-By default, there is a backlight that comes on when you twist your wrist. This, of course, somewhat increases power draw and could be
-annoying in an intentionally dark environment, so there is an option to disable it.
+If you like an uncluttered display style, you can still bring up the day, date and minute hand transiently with a tap on the watchface (when unlocked).
+
+Similarly, because sometimes I don't want to burn what I'm cooking and others I'm lazy and just want to know if it's afternoon yet,
+you can quickly alter the number of ‘hands’ on the display. When the watch is unlocked, slide up to add dots representing the minute and second,
+or down to remove the distraction. There's also a setting that displays the second hand, but only if the watch is perfectly face-to-the-sky,
+in case you want the ability to check the _exact_ time, hands free, without the impact on battery life this usually entails.
+
+In some versions of the Bangle.js firmware, the backlight doesn't come on automatically when you twist your wrist. There's currently a workaround 
+for this integrated into the watchface; you can disable it in the menu, if you prefer.
 
 ## Limitations
 

--- a/apps/pooqround/app.js
+++ b/apps/pooqround/app.js
@@ -330,6 +330,8 @@ class Round {
       this.render(new Date()); // Not quite right, I think.
     }
 
+    enhanceUntil(t) {this.enhance = t;}
+
     pie(f, a0, a1, invert) {
         if (!invert) return this.pie(f, a1, a0 + 1, true);
         let t0 = Math.tan(a0 * 2 * Math.PI), t1 = Math.tan(a1 * 2 * Math.PI);
@@ -369,17 +371,18 @@ class Round {
         const g = this.g;
         const b = this.b, bI = this.bI;
         const c = this.c, cI = this.cI;
+        const e = d < this.enhance;
         const state = this.state;
         const options = this.options;
         const cal = options.calendric;
         const res = options.resolution;
-        const dow = (cal == 1 || cal > 2) && d.getDay();
+        const dow = (e || cal == 1 || cal > 2) && d.getDay();
         const ts = res < 2 && d.getSeconds();
-        const tm = res < 3 && d.getMinutes() + ts / 60;
+        const tm = (e || res < 3) && d.getMinutes() + ts / 60;
         const th = d.getHours() + d.getMinutes() / 60;
-        const dd = cal > 1 && d.getDate();
-        const dm = cal > 3 && d.getMonth();
-        const dy = cal > 4 && d.getFullYear();
+        const dd = (e || cal > 1) && d.getDate();
+        const dm = (e || cal > 3) && d.getMonth();
+        const dy = (e || cal > 4) && d.getFullYear();
         const xc = this.xc, yc = this.yc, r = this.r;
         const dlr = xc * 3/4, dlw = 8, dlhw = 4;
 
@@ -504,9 +507,15 @@ class Clock {
                                 this.options.resolution++;
                             this.rates.clock = this.timescales[this.options.resolution];
                             this.active();
-                        } else if (this.yX - this.yN < 20 && Date.now() - this.t0 > 500) {
-                            this.stop();
-                            this.options.interact();
+                        } else if (this.yX - this.yN < 20) {
+                            const now = new Date();
+                            if (now - this.t0 < 250) {
+                                face.enhanceUntil(now + 30000);
+                                face.render(now);
+                            } else if (now - this.t0 > 500) {
+                                this.stop();
+                                this.options.interact();
+                            }
                         }
                         this.t0 = null;
                     }

--- a/apps/pooqround/app.js
+++ b/apps/pooqround/app.js
@@ -83,7 +83,6 @@ class Options {
             Bangle.removeListener('drag', this.reactivator);
             this.emit('done');
         }
-        g.clear(true);
         E.showMenu(m);
     }
 
@@ -309,7 +308,7 @@ class Round {
             buffer: this.c.buffer, transparent: 0
         };
         this.options = new RoundOptions();
-        this.timescales = [1000, 0, 60000, 900000];
+        this.timescales = [1000, [1000, 60000], 60000, 900000];
         this.state = {};
         // Precomputed polygons for the border areas.
         this.tl = [0, 0, 58, 0, 0, 58];
@@ -323,7 +322,7 @@ class Round {
         this.r = this.xc - this.minR;
     }
 
-    reset() {this.state = {}; this.g.clear(true);}
+    reset(clear) {this.state = {}; clear && this.g.clear(true);}
 
     doIcons(which) {
       this.state[which] = null;
@@ -478,7 +477,6 @@ class Clock {
         this.timescales = face.timescales;
         this.options = face.options;
         this.rates = {};
-        this.faceUp = null;
 
         this.options.on('done', () => this.start());
         
@@ -488,7 +486,6 @@ class Clock {
             lock: () => {face.doIcons('locked'); this.active();},
             faceUp: up => {
                 this.conservative = !up;
-                this.faceUp = up;
                 this.active();
             },
             twist: _ => this.options.autolight && Bangle.setLCDPower(true),
@@ -529,7 +526,7 @@ class Clock {
 
     redraw(rate) {
         const now = this.updated = new Date();
-        if (this.refresh) this.face.reset();
+        if (this.refresh) this.face.reset(true);
         this.refresh = false;
         rate = this.face.render(now, rate);
         if (rate !== this.rates.face) {
@@ -544,7 +541,7 @@ class Clock {
         this.exception && clearTimeout(this.exception);
         this.interval && clearInterval(this.interval);
         this.timeout = this.exception = this.interval = this.rate = null;
-        this.face.reset(); // Cancel any ongoing background rendering
+        this.face.reset(false); // Cancel any ongoing background rendering
         return this;
     }
     


### PR DESCRIPTION
Add tap-to-enhance, turning on complications transiently.
Remove some dead code.
Fix a fairly serious bug arising from version skew in the orientation-dependent update rate mechanism, which was probably making a lot of unnecessary events.
Reduce the number of screen clears to eliminate unmotivated blanking.
Alter readme to elucidate that (as I now understand) lack of backlight-on-twist was a bug in the system, and this is not a permanent feature of the watchface.