### PR TITLE
Fix missing app.js defintion of clicompleteclock (fix #1095)

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4918,6 +4918,7 @@
     "supports" : ["BANGLEJS", "BANGLEJS2"],
     "readme": "README.md",
     "storage": [
+      {"name":"clicompleteclk.app.js","url":"app.js"},
       {"name":"clicompleteclk.img","url":"app-icon.js","evaluate":true},
       {"name":"clicompleteclk.settings.js","url":"settings.js"}
      ],


### PR DESCRIPTION
Looks like the app.js definition was lost during merging.

Fixes https://github.com/espruino/BangleApps/issues/1095
