### PR TITLE
sanitycheck: Error on incorrectly sized js icons

### DIFF
--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -60,6 +60,7 @@ const STORAGE_KEYS = ['name', 'url', 'content', 'evaluate', 'noOverwite', 'suppo
 const DATA_KEYS = ['name', 'wildcard', 'storageFile', 'url', 'content', 'evaluate'];
 const FORBIDDEN_FILE_NAME_CHARS = /[,;]/; // used as separators in appid.info
 const VALID_DUPLICATES = [ '.tfmodel', '.tfnames' ];
+const GRANDFATHERED_ICONS = ["hebrew_calendar", "fontclock", "slidingtext", "solarclock", "sweepclock", "matrixclock", "speedo", "s7clk", "mmonday", "bclock", "snek", "dane", "fclock", "digiclock", "astral", "alpinenav", "slomoclock", "tapelauncher", "arrow", "doztime", "swiperclocklaunch", "pebble", "rebble"];
 
 function globToRegex(pattern) {
   const ESCAPE = '.*+-?^${}()|[]\\';
@@ -187,7 +188,10 @@ apps.forEach((app,appIdx) => {
           else ERROR(`JS icon ${file.name} does not match the pattern 'require("heatshrink").decompress(atob("..."))'`);
         }
         if (match) {
-          if (icon[0] != 48 || icon[1] != 48) WARN(`JS icon ${file.name} should be 48x48px but is instead ${icon[0]}x${icon[1]}px`);
+          if (icon[0] != 48 || icon[1] != 48) {
+            if (GRANDFATHERED_ICONS.includes(app.id)) WARN(`JS icon ${file.name} should be 48x48px but is instead ${icon[0]}x${icon[1]}px`);
+            else ERROR(`JS icon ${file.name} should be 48x48px but is instead ${icon[0]}x${icon[1]}px`);
+          }
         }
     }
   });


### PR DESCRIPTION
Adds an error to sanitycheck.js for incorrectly sized app icons, to help catch issues like #1121. As something of a side-effect, it also ensures that app icon files follow the format described in the README.

Since there are currently 24 apps that would trigger the error, and I imagine they won't all be fixed right away, I added a `GRANDFATHERED_ICONS` list that makes them only trigger a warning instead of an error. Once the existing icons are fixed the `GRANDFATHERED_ICONS` list can be removed.

Circleclock should be fixed by #1113, so I didn't include it in the `GRANDFATHERED_ICONS` list.

These icons currently trigger the warning:

```
Warning: JS icon hebrew_calendar.img should be 48x48px but is instead 0x0px
Warning: JS icon fontclock.img should be 48x48px but is instead 40x40px
Warning: JS icon slidingtext.img should be 48x48px but is instead 40x40px
Warning: JS icon solarclock.img should be 48x48px but is instead 40x40px
Warning: JS icon sweepclock.img should be 48x48px but is instead 40x40px
Warning: JS icon matrixclock.img should be 48x48px but is instead 40x40px
Warning: JS icon speedo.img should be 48x48px but is instead 44x36px
Warning: JS icon s7clk.img should be 48x48px but is instead 50x50px
Warning: JS icon mmonday.img should be 48x48px but is instead 0x0px
Warning: JS icon bclock.img should be 48x48px but is instead 0x0px
Warning: JS icon snek.img should be 48x48px but is instead 64x64px
Warning: JS icon dane.img should be 48x48px but is instead 47x48px
Warning: JS icon fclock.img should be 48x48px but is instead 217x176px
Warning: JS icon digiclock.img should be 48x48px but is instead 254x254px
Warning: JS icon astral.img should be 48x48px but is instead 50x50px
Warning: JS icon alpinenav.img should be 48x48px but is instead 50x50px
Warning: JS icon slomoclock.img should be 48x48px but is instead 64x64px
Warning: JS icon tapelauncher.img should be 48x48px but is instead 0x0px
Warning: JS icon arrow.img should be 48x48px but is instead 50x50px
Warning: JS icon doztime.img should be 48x48px but is instead 40x40px
Warning: JS icon swiperclocklaunch.img should be 48x48px but is instead 40x40px
Warning: JS icon pebble.img should be 48x48px but is instead 64x64px
Warning: JS icon rebble.img should be 48x48px but is instead 64x64px
Warning: JS icon circlesclock.img should be 48x48px but is instead 176x176px
```