### PR TITLE
qmsched: fix #1117: properly check WIDGETS is set before redrawing the widget.

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -3896,7 +3896,7 @@
     "id": "qmsched",
     "name": "Quiet Mode Schedule and Widget",
     "shortName": "Quiet Mode",
-    "version": "0.05",
+    "version": "0.06",
     "description": "Automatically turn Quiet Mode on or off at set times, and change LCD options while Quiet Mode is active.",
     "icon": "app.png",
     "screenshots": [{"url":"screenshot_b1_main.png"},{"url":"screenshot_b1_edit.png"},{"url":"screenshot_b1_lcd.png"},

--- a/apps/qmsched/ChangeLog
+++ b/apps/qmsched/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Bangle.js 2 support
 0.04: Move Quiet Mode LCD options from global settings to this app
 0.05: Avoid immediately redrawing widgets on load
+0.06: Fix: don't try to redraw widget when widgets not loaded

--- a/apps/qmsched/lib.js
+++ b/apps/qmsched/lib.js
@@ -19,5 +19,5 @@ exports.setMode = function(mode) {
     {quiet:mode}
   ));
   exports.applyOptions(mode);
-  if (WIDGETS && "qmsched" in WIDGETS) WIDGETS["qmsched"].draw();
+  if (typeof WIDGETS === "object" && "qmsched" in WIDGETS) WIDGETS["qmsched"].draw();
 };


### PR DESCRIPTION
Whoops, properly check WIDGETS is set before redrawing the widget.