### PR TITLE
Disable screen turn on on bluetooth status change

### DIFF
--- a/apps/widbt/ChangeLog
+++ b/apps/widbt/ChangeLog
@@ -4,3 +4,4 @@
 0.05: Make Bluetooth widget thinner, and when on a bright theme use light grey for disabled color
 0.06: Tweaking colors for dark/light themes and low bpp screens
 0.07: Memory usage improvements
+0.08: Disable LCD on, on bluetooth status change

--- a/apps/widbt/widget.js
+++ b/apps/widbt/widget.js
@@ -7,7 +7,6 @@ WIDGETS["bluetooth"]={area:"tr",width:15,draw:function() {
   g.drawImage(atob("CxQBBgDgFgJgR4jZMawfAcA4D4NYybEYIwTAsBwDAA=="),2+this.x,2+this.y);
 },changed:function() {
   WIDGETS["bluetooth"].draw();
-  Bangle.setLCDPower(1); // turn screen on
 }};
 NRF.on('connect',WIDGETS["bluetooth"].changed);
 NRF.on('disconnect',WIDGETS["bluetooth"].changed);


### PR DESCRIPTION
The bluetooth widget turns the screen on on bluetooth status change. For me at least, this is undesirable since I don't sleep in the same room as my phone, but close enough that it will, from time to time, connect or disconnect, disturbing my wife's sleep.