### PR TITLE
Update calendar weekend colors for start on Sunday

### DIFF
--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -110,10 +110,19 @@ function drawCalendar(date) {
   g.clearRect(0, 0, maxX, maxY);
   g.setBgColor(bgColorMonth);
   g.clearRect(0, 0, maxX, headerH);
-  g.setBgColor(bgColorDow);
-  g.clearRect(0, headerH, maxX, headerH + rowH);
-  g.setBgColor(bgColorWeekend);
-  g.clearRect(colW * 5, headerH + rowH, maxX, maxY);
+  if (settings.startOnSun){
+    g.setBgColor(bgColorWeekend);
+    g.clearRect(0, headerH + rowH, colW, maxY);
+    g.setBgColor(bgColorDow);
+    g.clearRect(0, headerH, maxX, headerH + rowH);
+    g.setBgColor(bgColorWeekend);
+    g.clearRect(colW * 6, headerH + rowH, maxX, maxY);
+  } else {
+    g.setBgColor(bgColorDow);
+    g.clearRect(0, headerH, maxX, headerH + rowH);
+    g.setBgColor(bgColorWeekend);
+    g.clearRect(colW * 5, headerH + rowH, maxX, maxY);
+  }
   for (let y = headerH; y < maxY; y += rowH) {
     g.drawLine(0, y, maxX, y);
   }


### PR DESCRIPTION
If week is set to start on Sunday, make Saturday (last row) and Sunday (first row) have weekend colors.