### PR TITLE
GPS Info App: Added number of satellites in view and fixed crash with GPS time

### DIFF
--- a/apps/gpsinfo/gps-info.js
+++ b/apps/gpsinfo/gps-info.js
@@ -113,8 +113,8 @@ function onGPSraw(nmea) {
   var nofGP = 0;
   if (nmea.slice(3,6) == "GSV") {
     // console.log(nmea);
-    if (nmea.slice(0,7) == "$BDGSV,") nofBD = nmea.slice(11,13);
-    if (nmea.slice(0,7) == "$GPGSV,") nofGP = nmea.slice(11,13);
+    if (nmea.slice(0,7) == "$BDGSV,") nofBD = Number(nmea.slice(11,13));
+    if (nmea.slice(0,7) == "$GPGSV,") nofGP = Number(nmea.slice(11,13));
     SATinView = nofBD + nofGP;
   }
 }

--- a/apps/gpsinfo/gps-info.js
+++ b/apps/gpsinfo/gps-info.js
@@ -17,6 +17,8 @@ var lastFix = {
   satellites: 0
 };
 var SATinView = 0;
+var nofBD = 0;
+var nofGP = 0;
 
 function formatTime(now) {
   if (now == undefined) {
@@ -109,8 +111,6 @@ function onGPS(fix) {
 }
 
 function onGPSraw(nmea) {
-  var nofBD = 0;
-  var nofGP = 0;
   if (nmea.slice(3,6) == "GSV") {
     // console.log(nmea);
     if (nmea.slice(0,7) == "$BDGSV,") nofBD = Number(nmea.slice(11,13));

--- a/apps/gpsinfo/gps-info.js
+++ b/apps/gpsinfo/gps-info.js
@@ -109,8 +109,13 @@ function onGPS(fix) {
 }
 
 function onGPSraw(nmea) {
+  var nofBD = 0;
+  var nofGP = 0;
   if (nmea.slice(3,6) == "GSV") {
-    SATinView = nmea.slice(11,13);
+    // console.log(nmea);
+    if (nmea.slice(0,7) == "$BDGSV,") nofBD = nmea.slice(11,13);
+    if (nmea.slice(0,7) == "$GPGSV,") nofGP = nmea.slice(11,13);
+    SATinView = nofBD + nofGP;
   }
 }
 


### PR DESCRIPTION
1. (bugfix) Workaround for a crash in toUTCString() if fix.time has the value "undefined", see https://github.com/espruino/BangleApps/issues/1155
2. (improvement) The 4-dot progress indicator is replaced by the number of satellites in view.
Tested on Bangle.js 2 with firmware 2v11