### PR TITLE
Fixed Italian localization

### DIFF
--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -80,7 +80,7 @@ timePattern / datePattern:
     %S	second (00..60)
     %p	locale's equivalent of either AM or PM; blank if not known
     %P  like %p, but lower case
-*/
+*/ 
 
 var locales = {
   "en_GB": { // this is default
@@ -457,12 +457,12 @@ var locales = {
     distance: { "0": "m", "1": "km" },
     temperature: '°C',
     ampm: { 0: "", 1: "" },
-    timePattern: { 0: "%HH.%MM.%SS ", 1: "%HH.%MM" }, // 17.00.00  // 17.00
-    datePattern: { 0: "%A %B %d %Y", "1": "%d/%m/%Y" }, // sunnuntai 1. maaliskuuta 2020 // 1.3.2020
+    timePattern: { 0: "%HH:%MM.%SS ", 1: "%HH:%MM" }, // 17:00.00 // 17:00                 
+    datePattern: { 0: "%d %b %Y", "1": "%d/%m/%Y" }, // 1 marzo 2020 // 01/03/2020
     abmonth: "gen,feb,mar,apr,mag,giu,lug,ago,set,ott,nov,dic",
     month: "gennaio,febbraio,marzo,aprile,maggio,giugno,luglio,agosto,settembre,ottobre,novembre,dicembre",
     abday: "dom,lun,mar,mer,gio,ven,sab",
-    day: "domenica,lunedì,martedì,mercoledì,giovedì,venerdì, sabato",
+    day: "domenica,lunedì,martedì,mercoledì,giovedì,venerdì,sabato",
     trans: { yes: "sì", Yes: "Sì", no: "no", No: "No", ok: "ok", on: "on", off: "off" }
   },
   "it_IT": {
@@ -475,12 +475,12 @@ var locales = {
     distance: { "0": "m", "1": "km" },
     temperature: '°C',
     ampm: { 0: "", 1: "" },
-    timePattern: { 0: "%HH.%MM.%SS ", 1: "%HH.%MM" }, // 17.00.00  // 17.00
-    datePattern: { 0: "%A %B %d %Y", "1": "%d/%m/%Y" }, // sunnuntai 1. maaliskuuta 2020 // 1.3.2020
+    timePattern: { 0: "%HH:%MM.%SS ", 1: "%HH:%MM" }, // 17:00.00 // 17:00                 
+    datePattern: { 0: "%d %b %Y", "1": "%d/%m/%Y" }, // 1 marzo 2020 // 01/03/2020
     abmonth: "gen,feb,mar,apr,mag,giu,lug,ago,set,ott,nov,dic",
     month: "gennaio,febbraio,marzo,aprile,maggio,giugno,luglio,agosto,settembre,ottobre,novembre,dicembre",
     abday: "dom,lun,mar,mer,gio,ven,sab",
-    day: "domenica,lunedì,martedì,mercoledì,giovedì,venerdì, sabato",
+    day: "domenica,lunedì,martedì,mercoledì,giovedì,venerdì,sabato",
     trans: { yes: "sì", Yes: "Sì", no: "no", No: "No", ok: "ok", on: "on", off: "off" }
   },
   "wae_CH": {


### PR DESCRIPTION
I am providing small fixes for the Italian localization.

1. using : to separate hours from minutes, instead of .
2. datePattern: changed to the more usual way of representing dates in Italian.
3. datePattern: fixed so that clocks such as Anton Clock work fine
4. day: removed an extra space.