### PR TITLE
Add mouse keyboard combination HID to Banglejs settings and boot.

### DIFF
--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -18,6 +18,7 @@ boot += `var bleServices = {}, bleServiceOptions = { uart : true};\n`;
 if (s.ble!==false) {
   if (s.HID) { // Human interface device
     if (s.HID=="joy") boot += `Bangle.HID = E.toUint8Array(atob("BQEJBKEBCQGhAAUJGQEpBRUAJQGVBXUBgQKVA3UBgQMFAQkwCTEVgSV/dQiVAoECwMA="));`;
+    else if (s.HID=="com") boot += `Bangle.HID = E.toUint8Array(atob("BQEJAqEBhQEJAaEABQkZASkFFQAlAZUFdQGBApUBdQOBAwUBCTAJMQk4FYElf3UIlQOBBgUMCjgCFYElf3UIlQGBBsDABQEJBqEBhQIFBxngKecVACUBdQGVCIECdQiVAYEBGQApcxUAJXOVBXUIgQDA"));`
     else if (s.HID=="kb") boot += `Bangle.HID = E.toUint8Array(atob("BQEJBqEBBQcZ4CnnFQAlAXUBlQiBApUBdQiBAZUFdQEFCBkBKQWRApUBdQORAZUGdQgVACVzBQcZAClzgQAJBRUAJv8AdQiVArECwA=="));`
     else /*kbmedia*/boot += `Bangle.HID = E.toUint8Array(atob("BQEJBqEBhQIFBxngKecVACUBdQGVCIEClQF1CIEBlQV1AQUIGQEpBZEClQF1A5EBlQZ1CBUAJXMFBxkAKXOBAAkFFQAm/wB1CJUCsQLABQwJAaEBhQEVACUBdQGVAQm1gQIJtoECCbeBAgm4gQIJzYECCeKBAgnpgQIJ6oECwA=="));`;
     boot += `bleServiceOptions.hid=Bangle.HID;\n`;

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -154,8 +154,8 @@ function showAlertsMenu() {
 
 
 function showBLEMenu() {
-  var hidV = [false, "kbmedia", "kb", "joy"];
-  var hidN = ["Off", "Kbrd & Media", "Kbrd","Joystick"];
+  var hidV = [false, "kbmedia", "kb", "com", "joy"];
+  var hidN = ["Off", "Kbrd & Media", "Kbrd", "Kbrd & Mouse" ,"Joystick"];
   E.showMenu({
     '': { 'title': 'Bluetooth' },
     '< Back': ()=>showMainMenu(),


### PR DESCRIPTION
As discussed in [https://github.com/espruino/BangleApps/pull/1199](https://github.com/espruino/BangleApps/pull/1199).
This adds the combination possibility HID as an option in the settings to be advertised on boot as well.