### PR TITLE
menuwheel: override Bangle.setUI to clear up touch handler

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4805,7 +4805,7 @@
   {
     "id": "menuwheel",
     "name": "Wheel Menus",
-    "version": "0.01",
+    "version": "0.02",
     "description": "Replace Bangle.js 2's menus with a version that contains variable-size text and a back button",
     "readme": "README.md",
     "icon": "icon.png",

--- a/apps/menuwheel/ChangeLog
+++ b/apps/menuwheel/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New menu!
+0.02: Clean up touch handler in setUI

--- a/apps/menuwheel/boot.js
+++ b/apps/menuwheel/boot.js
@@ -1,8 +1,5 @@
 E.showMenu = function(items) {
   g.clearRect(Bangle.appRect); // clear screen if no menu supplied
-  // clean up back button listener
-  if (Bangle.backHandler) Bangle.removeListener('touch', Bangle.backHandler)
-  delete Bangle.backHandler;
   if (!items) {
     Bangle.setUI();
     return;
@@ -206,8 +203,13 @@ E.showMenu = function(items) {
         if (b===1) back();
       }
     }
-    // note: backHandler is cleaned up at the top of this file
     Bangle.on('touch', Bangle.backHandler);
   }
   return l;
 };
+// setUI now also needs to clear up our back button touch handler
+Bangle.setUI = (old => function() {
+  if (Bangle.backHandler) Bangle.removeListener("touch", Bangle.backHandler);
+  delete Bangle.backHandler;
+  return old.apply(this, arguments);
+})(Bangle.setUI);


### PR DESCRIPTION
Because apps/libraries expect setUI to clean up touch handlers.

(I spend hours wondering why my `E.showScroller` was broken, turns out it was because I opened a menu :-()