### PR TITLE
messages improvements

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -77,7 +77,7 @@
   {
     "id": "messages",
     "name": "Messages",
-    "version": "0.17",
+    "version": "0.18",
     "description": "App to display notifications from iOS and Gadgetbridge",
     "icon": "app.png",
     "type": "app",

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -24,3 +24,4 @@
 0.15: Don't buzz when Quiet Mode is active
 0.16: Fix text wrapping so it fits the screen even if title is big (fix #1147)
 0.17: Fix: Get dynamic dimensions of notify icon, fixed notification font
+0.18: Use app-specific icon colors

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -26,3 +26,4 @@
 0.17: Fix: Get dynamic dimensions of notify icon, fixed notification font
 0.18: Use app-specific icon colors
       Spread message action buttons out
+      Back button now goes back to list of messages

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -25,3 +25,4 @@
 0.16: Fix text wrapping so it fits the screen even if title is big (fix #1147)
 0.17: Fix: Get dynamic dimensions of notify icon, fixed notification font
 0.18: Use app-specific icon colors
+      Spread message action buttons out

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -249,7 +249,7 @@ function showMessage(msgid) {
     {type:"btn", src:getBackImage(), cb:()=>{
       msg.new = false; saveMessages(); // read mail
       cancelReloadTimeout(); // don't auto-reload to clock now
-      checkMessages({clockIfNoMsg:1,clockIfAllRead:0,showMsgIfUnread:1});
+      checkMessages({clockIfNoMsg:1,clockIfAllRead:0,showMsgIfUnread:0});
     }} // back
   ];
   if (msg.positive) {

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -253,6 +253,7 @@ function showMessage(msgid) {
     }} // back
   ];
   if (msg.positive) {
+    buttons.push({fillx:1});
     buttons.push({type:"btn", src:getPosImage(), cb:()=>{
       msg.new = false; saveMessages();
       cancelReloadTimeout(); // don't auto-reload to clock now
@@ -261,6 +262,7 @@ function showMessage(msgid) {
     }});
   }
   if (msg.negative) {
+    buttons.push({fillx:1});
     buttons.push({type:"btn", src:getNegImage(), cb:()=>{
       msg.new = false; saveMessages();
       cancelReloadTimeout(); // don't auto-reload to clock now

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -101,6 +101,31 @@ function getMessageImage(msg) {
   if (msg.id=="back") return getBackImage();
   return getNotificationImage();
 }
+function getMessageImageCol(msg,def) {
+  return {
+    // generic colors, using B2-safe colors
+    "calendar": "#f00",
+    "mail": "#ff0",
+    "music": "#f0f",
+    "phone": "#0f0",
+    "sms message": "#0ff",
+    // brands, according to https://www.schemecolor.com/?s (picking one for multicolored logos)
+    // all dithered on B2, but we only use the color for the icons.  (Could maybe pick the closest 3-bit color for B2?)
+    "facebook": "#4267b2",
+    "gmail": "#ea4335",
+    "google home": "#fbbc05",
+    "hangouts": "#1ba261",
+    "instagram": "#dd2a7b",
+    "messenger": "#0078ff",
+    "outlook mail": "#0072c6",
+    "skype": "#00aff0",
+    "slack": "#e51670",
+    "telegram": "#0088cc",
+    "twitter": "#1da1f2",
+    "whatsapp": "#4fce5d",
+    "wordfeud": "#dcc8bd",
+  }[(msg.src||"").toLowerCase()]||(def !== undefined?def:g.theme.fg);
+}
 
 function showMapMessage(msg) {
   var m;
@@ -248,7 +273,7 @@ function showMessage(msgid) {
   var body = (lines.length>4) ? lines.slice(0,4).join("\n")+"..." : lines.join("\n");
   layout = new Layout({ type:"v", c: [
     {type:"h", fillx:1, bgCol:colBg,  c: [
-      { type:"btn", src:getMessageImage(msg), pad: 3, cb:()=>{
+      { type:"btn", src:getMessageImage(msg), col:getMessageImageCol(msg), pad: 3, cb:()=>{
         cancelReloadTimeout(); // don't auto-reload to clock now
         showMessageSettings(msg);
       }},
@@ -310,7 +335,9 @@ function checkMessages(options) {
         body = msg.track;
       }
       if (img) {
-        g.drawImage(img, x+24, r.y+24, {rotate:0}); // force centering
+        var fg = g.getColor();
+        g.setColor(getMessageImageCol(msg,fg)).drawImage(img, x+24, r.y+24, {rotate:0}) // force centering
+         .setColor(fg); // only color the icon
         x += 50;
       }
       var m = msg.title+"\n"+msg.body;


### PR DESCRIPTION
- Use theme colors and app-specific icon colors
- Spread message action buttons out
- Back button now goes back to list of messages

Still draft, because:
Haven't had a proper look at B1 yet, maybe it's better to stick with custom colors instead of theme there?
I'm not entirely sure if `fg/fg2`+`bg/bg2` are supposed to be used in this way (as alternating rows)    

Also: is it me, or is the Instagram icon broken?