### PR TITLE
Anton-Clock can optionally show ISO-8601 calendar weeknumber

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -4242,7 +4242,7 @@
   {
     "id": "antonclk",
     "name": "Anton Clock",
-    "version": "0.04",
+    "version": "0.05",
     "description": "A clock using the bold Anton font, optionally showing seconds and date in ISO-8601 format.",
     "readme":"README.md",
     "icon": "app.png",

--- a/apps/antonclk/ChangeLog
+++ b/apps/antonclk/ChangeLog
@@ -2,3 +2,6 @@
 0.02: Load widgets after setUI so widclk knows when to hide
 0.03: Clock now shows day of week under date.
 0.04: Clock can optionally show seconds, date optionally in ISO-8601 format, weekdays and uppercase configurable, too.
+0.05: Clock can optionally show ISO-8601 calendar weeknumber (default: Off)
+      when weekday name "Off": week #:<num>
+      when weekday name "On": weekday name is cut at 6th position and .#<week num> is added

--- a/apps/antonclk/README.md
+++ b/apps/antonclk/README.md
@@ -40,8 +40,7 @@ The main menu contains several settings covering Anton clock in general.
 * **Show Weekday** - Weekday is shown in the time presentation without seconds.
 Weekday name depends on the current locale.
 If seconds are shown, the weekday is never shown as there is not enough space on the watch face.
-* **Uppercase** - Weekday name and month name in the long format are converted to upper case letters.
-This can improve readability.
+**Show Weeknumber** - Weeknumber (ISO-8601) is shown.
 * **Vector font** - Use the built-in vector font for dates and weekday.
 This can improve readability.
 Otherwise, a scaled version of the built-in 6x8 pixels font is used.

--- a/apps/antonclk/app.js
+++ b/apps/antonclk/app.js
@@ -19,6 +19,7 @@ var secondsWithColon;
 var dateOnMain;
 var dateOnSecs;
 var weekDay;
+var calWeek;
 var upperCase;
 var vectorFont;
 
@@ -29,22 +30,25 @@ var secondsScreen = true;
 
 var isBangle1 = (g.getWidth() == 240);
 
-/* For development purposes
+//For development purposes
+/*
 require('Storage').writeJSON(SETTINGSFILE, {
-  secondsMode: "Always", // "Never", "Unlocked", "Always"
+  secondsMode: "Unlocked", // "Never", "Unlocked", "Always"
   secondsColoured: true,
   secondsWithColon: true,
   dateOnMain: "Long", // "Short", "Long", "ISO8601"
   dateOnSecs: "Year", // "No", "Year", "Weekday", LEGACY: true/false
   weekDay: true,
+  calWeek: true,
   upperCase: true,
   vectorFont: true,
 });
-/* */
+*/
 
-/* OR (also for development purposes)
+// OR (also for development purposes)
+/*
 require('Storage').erase(SETTINGSFILE);
-/* */
+*/ 
 
 // Helper method for loading the settings
 function def(value, def) {
@@ -60,6 +64,7 @@ function loadSettings() {
   dateOnMain = def(settings.dateOnMain, "Long");
   dateOnSecs = def(settings.dateOnSecs, "Year");
   weekDay = def(settings.weekDay, true);
+  calWeek = def(settings.calWeek, false);
   upperCase = def(settings.upperCase, true);
   vectorFont = def(settings.vectorFont, false);
 
@@ -97,6 +102,18 @@ function updateState() {
 
 function isoStr(date) {
   return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).substr(-2) + "-" + ("0" + date.getDate()).substr(-2);
+}
+
+function ISO8601calWeek(date) { //copied from: https://gist.github.com/IamSilviu/5899269#gistcomment-3035480
+  var tdt = new Date(date.valueOf());
+  var dayn = (date.getDay() + 6) % 7;
+  tdt.setDate(tdt.getDate() - dayn + 3);
+  var firstThursday = tdt.valueOf();
+  tdt.setMonth(0, 1);
+  if (tdt.getDay() !== 4) {
+      tdt.setMonth(0, 1 + ((4 - tdt.getDay()) + 7) % 7);
+  }
+  return 1 + Math.ceil((firstThursday - tdt) / 604800000);
 }
 
 function doColor() {
@@ -169,11 +186,14 @@ function draw() {
     else
       g.setFont("6x8", 2);
     g.drawString(dateStr, x, y);
-    if (weekDay) {
-      var dowStr = require("locale").dow(date);
+    if (weekDay || calWeek) {
+      var dowwumStr = require("locale").dow(date);
+      dowwumStr = "thursday";
+      if (calWeek)
+        dowwumStr = (weekDay ? dowwumStr.substr(0,Math.min(dowwumStr.length,6)) + (dowwumStr.length>=6 ? "." : "") : "week ") + "#" + ISO8601calWeek(date);
       if (upperCase)
-        dowStr = dowStr.toUpperCase();
-      g.drawString(dowStr, x, y + (vectorFont ? 26 : 16));
+        dowwumStr = dowwumStr.toUpperCase();
+      g.drawString(dowwumStr, x, y + (vectorFont ? 26 : 16));
     }
   }
 

--- a/apps/antonclk/settings.js
+++ b/apps/antonclk/settings.js
@@ -47,6 +47,14 @@
         writeSettings();
       }
     },
+    "Show Weeknumber": {
+      value: (settings.weekNum !== undefined ? settings.weekNum : true),
+      format: v => v ? "On" : "Off",
+      onchange: v => {
+        settings.weekNum = v;
+        writeSettings();
+      }
+    },
     "Uppercase": {
       value: (settings.upperCase !== undefined ? settings.upperCase : false),
       format: v => v ? "On" : "Off",


### PR DESCRIPTION
The ISO-8601 calendar weeknumber added as or behind weekday.
The "display with seconds " mode was untouched.
No "core" update this time ;)
PS: copied GIST for ISO-Week # is als "MIT-license"