### PR TITLE
OpenStreepMap custom: Add leaflet geosearch control

### DIFF
--- a/apps/openstmap/custom.html
+++ b/apps/openstmap/custom.html
@@ -2,6 +2,7 @@
   <head>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
     <link rel="stylesheet" href="../../css/spectre.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-geosearch@3.6.0/dist/geosearch.css"/>
   </head>
     <style>
       body {
@@ -44,6 +45,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
     <script src="../../core/lib/heatshrink.js"></script>
     <script src="../../core/lib/imageconverter.js"></script>
+    <script src="https://unpkg.com/leaflet-geosearch@3.6.0/dist/bundle.min.js"></script>
 
     <script>
     /*
@@ -78,6 +80,19 @@ TODO:
         attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors</a>'
       });
       // Could optionally overlay trails: https://wiki.openstreetmap.org/wiki/Tiles
+
+      // Search box:
+      const searchProvider = new window.GeoSearch.OpenStreetMapProvider();
+      const searchControl = new GeoSearch.GeoSearchControl({
+        provider: searchProvider,
+        style: 'button',
+        updateMap: true,
+        autoClose: true,
+        showMarker: false,
+        keepResult: true,
+        autoComplete: false
+      });
+      map.addControl(searchControl);
 
       function onInit(device) {
         if (device && device.info && device.info.g) {


### PR DESCRIPTION
Added leaflet geosearch control to OpenStreetMap custom HTML page.

https://github.com/smeijer/leaflet-geosearch MIT License


# Screenshots

## Desktop

![image](https://user-images.githubusercontent.com/1397377/149153695-05120fa7-6133-419e-96d1-8aef7fcd64fc.png)

## Mobile

![image](https://user-images.githubusercontent.com/1397377/149153966-ff7fb7da-29b9-49b0-9dfb-bc4d755746d4.png)

![image](https://user-images.githubusercontent.com/1397377/149153809-72d39e31-ce6c-47ec-bc52-9c5047ad44f3.png)
