### PR TITLE
Circlesclock: Minor fix

### DIFF
--- a/apps/circlesclock/app.js
+++ b/apps/circlesclock/app.js
@@ -136,8 +136,10 @@ function getCirclePosition(type) {
     if (setting == type) return circlePosX[i - 1];
   }
   for (let i = 0; i < defaultCircleTypes.length; i++) {
-    if (type == defaultCircleTypes[i]) return circlePosX[i];
-  }
+   if (type == defaultCircleTypes[i] && (!settings || settings['circle' + (i + 1)] == undefined)) {
+     return circlePosX[i];
+   }
+ }
   return undefined;
 }
 


### PR DESCRIPTION
Just a minor bugfix:
* Do not overwrite circle on event (e.g. charging) if there is a circle configured for that place


I did not increase the version number as this is just a very minor fix and the current version of the clock was released yesterday.
