### PR TITLE
Option to keep or not the textual translations

### DIFF
--- a/apps/locale/locale.html
+++ b/apps/locale/locale.html
@@ -11,7 +11,7 @@
     </select>
     </div>
     <div class="form-group">
-      <input id="translations" type="checkbox" checked /> <label for="translations">Mark this option if you want translations for commont text like "Yes", "No", "On", "Off".</label>
+      <input id="translations" type="checkbox" checked /> <label for="translations">Mark this option if you want translations for common text like "Yes", "No", "On", "Off".</label>
     </div>
     <p>Then click <button id="upload" class="btn btn-primary">Upload</button></p>
 

--- a/apps/locale/locale.html
+++ b/apps/locale/locale.html
@@ -10,6 +10,9 @@
     <select id="languages" class="form-select">
     </select>
     </div>
+    <div class="form-group">
+      <input id="translations" type="checkbox" checked /> <label for="translations">Mark this option if you want translations for commont text like "Yes", "No", "On", "Off".</label>
+    </div>
     <p>Then click <button id="upload" class="btn btn-primary">Upload</button></p>
 
     <script src="../../core/lib/customize.js"></script>
@@ -106,11 +109,17 @@ exports = { name : "en_GB", currencySym:"£",
         const lang = languageSelector.options[languageSelector.selectedIndex].value;
         console.log(`Language ${lang}`);
 
+        const translations = document.getElementById('translations').checked;
+        console.log(`Translations: ${translations}`);
+
         const locale = locales[lang];
         if (!locale) {
           alert(`Language ${lang} not found!`);
           return;
         }
+
+        if (!translations)
+          locale.trans = null;
 
         const codePageName = "ISO8859-1";
         if (locale.codePage)


### PR DESCRIPTION
As most apps aren't translated, I found odd the mixed language on apps, so I thought it would be useful to have a locale with formatting but no translation. this way the apps language are all in english, but the format for numbers, dates, etc are in my locale.

As forum post: http://forum.espruino.com/conversations/371915/#comment16353541