### PR TITLE
sleepphasealarm: Compatibility to Bangle.js 2 and new firmware

### DIFF
--- a/apps/sleepphasealarm/ChangeLog
+++ b/apps/sleepphasealarm/ChangeLog
@@ -1,3 +1,3 @@
 0.01: New App!
 0.02: Respect Quiet Mode
-0.03: Add compatibility for Bangle.js 2, added "Alarm at " for the alarm time
+0.03: Add compatibility for Bangle.js 2 and new firmware, added "Alarm at " for the alarm time

--- a/apps/sleepphasealarm/ChangeLog
+++ b/apps/sleepphasealarm/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Respect Quiet Mode
+0.03: Add compatibility for Bangle.js 2, added "Alarm at " for the alarm time

--- a/apps/sleepphasealarm/app.js
+++ b/apps/sleepphasealarm/app.js
@@ -1,3 +1,4 @@
+const BANGLEJS2 = process.env.HWVERSION == 2; //# check for bangle 2
 const alarms = require("Storage").readJSON("alarm.json",1)||[];
 const active = alarms.filter(a=>a.on);
 
@@ -52,21 +53,21 @@ active.forEach(alarm => {
   }
 });
 
-function drawString(s, x, y) {
-  g.clearRect(0,y-15,239,y+15);
-  g.reset();
-  g.setFont("Vector",20);
-  g.setFontAlign(0,0); // align right bottom
-  g.drawString(s, x, y);
+function drawString(s, y) { //# replaced x: always centered
+  g.reset(); //# moved up to prevent blue background
+  g.clearRect(0, y - 12, 239, y + 8); //# minimized upper+lower clearing
+  g.setFont("Vector", 20);
+  g.setFontAlign(0, 0); // align centered
+  g.drawString(s, g.getWidth() / 2, y); //# set x to center
 }
 
 function drawApp() {
-  g.clearRect(0,24,239,215);
+  g.clearRect(0,24,239,215); //# no problem
   var alarmHour = nextAlarm.getHours();
   var alarmMinute = nextAlarm.getMinutes();
   if (alarmHour < 10) alarmHour = "0" + alarmHour;
   if (alarmMinute < 10) alarmMinute = "0" + alarmMinute;
-  const s = alarmHour + ":" + alarmMinute + "\n\n";
+  const s = "Alarm at " + alarmHour + ":" + alarmMinute + "\n\n"; //# make distinct to time
   E.showMessage(s, "Sleep Phase Alarm");
 
   function drawTime() {
@@ -78,12 +79,20 @@ function drawApp() {
       if (nowHour < 10) nowHour = "0" + nowHour;
       if (nowMinute < 10) nowMinute = "0" + nowMinute;
       if (nowSecond < 10) nowSecond = "0" + nowSecond;
-      const time = nowHour + ":" + nowMinute + ":" + nowSecond;
-      drawString(time, 120, 140);
+      const time = nowHour + ":" + nowMinute + (BANGLEJS2 ? "" : ":" + nowSecond); //# hide seconds on bangle 2
+      drawString(time, BANGLEJS2 ? 85 : 140); //# remove x, adjust height
     }
   }
 
-  setInterval(drawTime, 500); // 2Hz
+  if (BANGLEJS2) {
+    drawTime();
+    setTimeout(_ => {
+      drawTime();
+      setInterval(drawTime, 60000);
+    }, 60000 - Date.now() % 60000); //# every new minute on bangle 2
+  } else {
+    setInterval(drawTime, 500); // 2Hz
+  }
 }
 
 var buzzCount = 19;
@@ -104,8 +113,8 @@ function buzz() {
 var minAlarm = new Date();
 var measure = true;
 if (nextAlarm !== undefined) {
+  Bangle.loadWidgets(); //# correct widget load draw order
   Bangle.drawWidgets();
-  Bangle.loadWidgets();
 
   // minimum alert 30 minutes early
   minAlarm.setTime(nextAlarm.getTime() - (30*60*1000));
@@ -116,7 +125,7 @@ if (nextAlarm !== undefined) {
 
     if (swest !== undefined) {
       if (Bangle.isLCDOn()) {
-        drawString(swest ? "Sleep" : "Awake", 120, 180);
+        drawString(swest ? "Sleep" : "Awake", BANGLEJS2 ? 150 : 180); //# remove x, adjust height
       }
     }
 
@@ -133,6 +142,6 @@ if (nextAlarm !== undefined) {
   E.showMessage('No Alarm');
   setTimeout(load, 1000);
 }
-// BTN2 to menu, BTN3 to main
-setWatch(Bangle.showLauncher, BTN2, { repeat: false, edge: "falling" });
-setWatch(() => load(), BTN3, { repeat: false, edge: "falling" });
+// BTN2 to menu, BTN3 to main # on bangle 2 only BTN to main
+if (!BANGLEJS2) setWatch(Bangle.showLauncher, BTN2, { repeat: false, edge: "falling" });
+setWatch(() => load(), BANGLEJS2 ? BTN : BTN3, { repeat: false, edge: "falling" });

--- a/apps/sleepphasealarm/app.js
+++ b/apps/sleepphasealarm/app.js
@@ -80,7 +80,7 @@ function drawApp() {
       if (nowMinute < 10) nowMinute = "0" + nowMinute;
       if (nowSecond < 10) nowSecond = "0" + nowSecond;
       const time = nowHour + ":" + nowMinute + (BANGLEJS2 ? "" : ":" + nowSecond); //# hide seconds on bangle 2
-      drawString(time, BANGLEJS2 ? 85 : 140); //# remove x, adjust height
+      drawString(time, BANGLEJS2 ? 85 : 105); //# remove x, adjust height for bangle 2 an newer firmware
     }
   }
 

--- a/apps/sleepphasealarm/metadata.json
+++ b/apps/sleepphasealarm/metadata.json
@@ -2,11 +2,11 @@
   "id": "sleepphasealarm",
   "name": "SleepPhaseAlarm",
   "shortName": "SleepPhaseAlarm",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Uses the accelerometer to estimate sleep and wake states with the principle of Estimation of Stationary Sleep-segments (ESS, see https://ubicomp.eti.uni-siegen.de/home/datasets/ichi14/index.html.en). This app will read the next alarm from the alarm application and will wake you up to 30 minutes early at the best guessed time when you are almost already awake.",
   "icon": "app.png",
   "tags": "alarm",
-  "supports": ["BANGLEJS"],
+  "supports": ["BANGLEJS","BANGLEJS2"],
   "storage": [
     {"name":"sleepphasealarm.app.js","url":"app.js"},
     {"name":"sleepphasealarm.img","url":"app-icon.js","evaluate":true}


### PR DESCRIPTION
Make app compatible with Bangle.js 2:
- check hardware
- _drawString(s, x, y)_: removed _x_, always centered
- _drawString(s, y)_: _g.reset()_ before _g.clearRect(...)_
- adjust heights for Bangle.js 2 for each _drawString(s, y)_ call
- _drawApp()_: on Bangle.js 2's always on display save energy by drawing time only at every next minute
- _drawTime()_: hide seconds on Bangle.js 2 (only refreshed every minute)
- _drawApp()_: add _"Alarm at "_ to distinct from actual time (no difference in seconds)
- execute _load()_ on Bangle.js 2's BTN

Make app compatible with _E.showMessage(...)_ on new firmware:
- adjust actual time height to be drawn above the alarm time from _E.showMessage(...)_