### PR TITLE
use the correct key to check for translations

### DIFF
--- a/bin/language_scan.js
+++ b/bin/language_scan.js
@@ -168,7 +168,7 @@ languages.forEach(language => {
   log("==========");
   var translations = JSON.parse(fs.readFileSync(BASEDIR+"/lang/"+language.url).toString());
   translatedStrings.forEach(str => {
-    if (!translations.GLOBAL[str])
+    if (!translations.GLOBAL[str.str])
       console.log(`Missing translation for ${JSON.stringify(str)}`);
   });
   log("");


### PR DESCRIPTION
I'm working on the Italian translation and I noticed that `language_scan.js` prints *Missing translation* for existing translations.

This commit fix the issue.