### PR TITLE
android/gbridge: Include charging state in battery updates to phone

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -5,3 +5,4 @@
 0.04: Android icon now goes to settings page with 'find phone'
 0.05: Fix handling of message actions
 0.06: Option to keep messages after a disconnect (default false) (fix #1186)
+0.07: Include charging state in battery updates to phone

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -50,8 +50,9 @@
   };
 
   // Battery monitor
-  function sendBattery() { gbSend({ t: "status", bat: E.getBattery() }); }
+  function sendBattery() { gbSend({ t: "status", bat: E.getBattery(), chg: Bangle.isCharging()?1:0 }); }
   NRF.on("connect", () => setTimeout(sendBattery, 2000));
+  Bangle.on("charging", sendBattery);
   if (!settings.keep)
     NRF.on("disconnect", () => require("messages").clearAll()); // remove all messages on disconnect
   setInterval(sendBattery, 10*60*1000);

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",

--- a/apps/gbridge/ChangeLog
+++ b/apps/gbridge/ChangeLog
@@ -26,3 +26,4 @@
 0.24: tag HRM power requests to allow this to work alongside other widgets/apps (fix #799)
 0.25: workaround call notification
 	  Fix inflated step number
+0.26: Include charging status in battery updates to phone

--- a/apps/gbridge/PROTOCOL.md
+++ b/apps/gbridge/PROTOCOL.md
@@ -11,11 +11,12 @@ t can be one of "info", "warn", "error"
 ## report battery level
 
 ```
-{ "t": "status", "bat": 30, "volt": 30 }
+{ "t": "status", "bat": 30, "volt": 30, "chg": 0 }
 ```
 
 * bat is in range 0 to 100
 * volt is optional and should be greater than 0
+* chg is optional and should be either 0 or 1 to indicate the watch is charging
 
 ## find phone
 

--- a/apps/gbridge/metadata.json
+++ b/apps/gbridge/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "gbridge",
   "name": "Gadgetbridge",
-  "version": "0.25",
+  "version": "0.26",
   "description": "(NOT RECOMMENDED) Displays Gadgetbridge notifications from Android. Please use the 'Android' Bangle.js app instead.",
   "icon": "app.png",
   "type": "widget",

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -256,7 +256,7 @@
   }
 
   function sendBattery() {
-    gbSend({ t: "status", bat: E.getBattery() });
+    gbSend({ t: "status", bat: E.getBattery(), chg: Bangle.isCharging()?1:0 });
   }
 
   // Send a summary of activity to Gadgetbridge
@@ -268,6 +268,7 @@
 
   // Battery monitor
   NRF.on("connect", () => setTimeout(sendBattery, 2000));
+  Bangle.on("charging", sendBattery);
   setInterval(sendBattery, 10*60*1000);
   sendBattery();
   // Activity monitor


### PR DESCRIPTION
This seems like a useful thing to include for GadgetBridge: not only do you get the nice lightning bolt icon, but it also means the app knows to dismiss the "low battery" warning when the watch is connected to a charger.

Before you merge:
- `charging`:`true/false` seemed like the cleanest option, but I have no idea how frugal we need to be with bluetooth-bytes, does it really matter? Because then I guess `pow`:`1/0` (or `chrg` or even `c`...) would be better.   
  Asking because this will also need some changes in GadgetBridge and EspruinoDocs, so I'd like to get it right instead of amending 3 PRs later on ;-)
- I noticed we could also include `volt` (from `NRF.getBattery()`?), not sure if that has any added value over `bat`, but I'd be happy to work it in while I'm messing with this code anyway.