### PR TITLE
Messages: Use large font for message body when message < 2 lines 

### DIFF
--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -270,11 +270,11 @@ function showMessage(msgid) {
       checkMessages({clockIfNoMsg:1,clockIfAllRead:1,showMsgIfUnread:1});
     }});
   }
-  // If body of message is only one line, use large font.
+  // If body of message is only two lines long w/ large font, use large font.
   var body=msg.body, bodyFont = fontLarge, lines;
   if (body) {
     var w = g.getWidth()-48;
-    if (g.setFont(bodyFont).stringWidth(body) > w)
+    if (g.setFont(bodyFont).stringWidth(body) > w * 2)
       bodyFont = fontMedium;
     if (g.setFont(bodyFont).stringWidth(body) > w) {
       lines = g.setFont(bodyFont).wrapString(msg.body, g.getWidth()-10);

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -270,9 +270,18 @@ function showMessage(msgid) {
       checkMessages({clockIfNoMsg:1,clockIfAllRead:1,showMsgIfUnread:1});
     }});
   }
-  var bodyFont = fontMedium;
-  lines = g.setFont(bodyFont).wrapString(msg.body, g.getWidth()-10);
-  var body = (lines.length>4) ? lines.slice(0,4).join("\n")+"..." : lines.join("\n");
+  // If body of message is only one line, use large font.
+  var body=msg.body, bodyFont = fontLarge, lines;
+  if (body) {
+    var w = g.getWidth()-48;
+    if (g.setFont(bodyFont).stringWidth(body) > w)
+      bodyFont = fontMedium;
+    if (g.setFont(bodyFont).stringWidth(body) > w) {
+      lines = g.setFont(bodyFont).wrapString(msg.body, g.getWidth()-10);
+      body = (lines.length>4) ? lines.slice(0,4).join("\n")+"..." : lines.join("\n");
+    }
+  }
+     
   layout = new Layout({ type:"v", c: [
     {type:"h", fillx:1, bgCol:colBg,  c: [
       { type:"btn", src:getMessageImage(msg), col:getMessageImageCol(msg), pad: 3, cb:()=>{


### PR DESCRIPTION
In: https://github.com/espruino/BangleApps/issues/1294#issuecomment-1012921003, @gfwilliams said: 
"Right now the message title font does change dynamically depending on how much text there is, so doing the same for the body text is probably no big deal."

This mirrors the implementation used for the message title in the message body. 

I can see there are other issues open related to controlling font size globally. But I think the main need for most users will be in the messages app, where the ability to choose a larger font for body text would be useful even in the short term, IMHO. Perhaps getting rid of the buttons in favor of labels to view next / previous via swipe direction would leave more screen real estate for larger text as well. The buttons do not work for me most of the time.
As always - thanks for making this great ecosystem!