### PR TITLE
HRM: Don't force screen to be on for Bangle 2.

### DIFF
--- a/apps/hrm/ChangeLog
+++ b/apps/hrm/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Tweaks for 'HRM-raw' handling
 0.06: Add widgets
 0.07: Update scaling for new firmware
+0.08: Don't force backlight on/watch unlocked on Bangle 2

--- a/apps/hrm/heartrate.js
+++ b/apps/hrm/heartrate.js
@@ -1,5 +1,8 @@
-Bangle.setLCDPower(1);
-Bangle.setLCDTimeout(0);
+if (process.env.HWVERSION == 1) {
+  Bangle.setLCDPower(1);
+  Bangle.setLCDTimeout(0);
+}
+
 Bangle.setHRMPower(1);
 var hrmInfo, hrmOffset = 0;
 var hrmInterval;

--- a/apps/hrm/metadata.json
+++ b/apps/hrm/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "hrm",
   "name": "Heart Rate Monitor",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Measure your heart rate and see live sensor data",
   "icon": "heartrate.png",
   "tags": "health",


### PR DESCRIPTION
The heart rate monitor app forces the backlight to be on and the screen not to lock.
There is no need on the Bangle 2, as the screen is readable with the backlight disabled.