### PR TITLE
Update fr_FR locales.js: dow not part of date?

### DIFF
--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -258,7 +258,7 @@ var locales = {
     temperature: "°C",
     ampm: { 0: "", 1: "" },
     timePattern: { 0: "%HH:%MM:%SS ", 1: "%HH:%MM" },
-    datePattern: { 0: "%A %d %B %Y", "1": "%d/%m/%Y" }, // dimanche 1 mars 2020 //  01/03/2020
+    datePattern: { 0: "%d %B %Y", "1": "%d/%m/%Y" }, // 1 mars 2020 //  01/03/2020
     abmonth: "janv,févr,mars,avril,mai,juin,juil,août,sept,oct,nov,déc",
     month: "janvier,février,mars,avril,mai,juin,juillet,août,septembre,octobre,novembre,décembre",
     abday: "dim,lun,mar,mer,jeu,ven,sam",


### PR DESCRIPTION
I think the day of week should not be part of the date in fr_FR as it is not in most of the other locales.


Fteacher suggested this in the forum: http://forum.espruino.com/comments/16389770/ as well.

**Note**: i am **not** a french speaker so i am not 100% sure about this change but in my opinion this should be changed.

