### PR TITLE
boot - Sort *.boot.js files

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -45,3 +45,4 @@
 0.39: Fix passkey support (fix https://github.com/espruino/Espruino/issues/2035)
 0.40: Bootloader now rebuilds for new firmware versions
 0.41: Add Keyboard and Mouse Bluetooth HID option
+0.42: Sort *.boot.js files lexically and by optional numeric priority, e.g. appname.<priority>.boot.js

--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -195,7 +195,19 @@ if (!Bangle.appRect) { // added in 2v11 - polyfill for older firmwares
 
 // Append *.boot.js files
 // These could change bleServices/bleServiceOptions if needed
-require('Storage').list(/\.boot\.js/).forEach(bootFile=>{
+var getPriority = /.*\.(\d+)\.boot\.js$/;
+require('Storage').list(/\.boot\.js/).sort((a,b)=>{
+  var aPriority = a.match(getPriority);
+  var bPriority = b.match(getPriority);
+  if (aPriority && bPriority){
+    return parseInt(aPriority[1]) - parseInt(bPriority[1]);
+  } else if (aPriority && !bPriority){
+    return -1;
+  } else if (!aPriority && bPriority){
+    return 1;
+  }
+  return a > b;
+}).forEach(bootFile=>{
   // we add a semicolon so if the file is wrapped in (function(){ ... }()
   // with no semicolon we don't end up with (function(){ ... }()(function(){ ... }()
   // which would cause an error!

--- a/apps/boot/metadata.json
+++ b/apps/boot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boot",
   "name": "Bootloader",
-  "version": "0.41",
+  "version": "0.42",
   "description": "This is needed by Bangle.js to automatically load the clock, menu, widgets and settings",
   "icon": "bootloader.png",
   "type": "bootloader",


### PR DESCRIPTION
Sorts the *.boot.js files during bootupdate.js and allows an optional priority with the following scheme: 
`name.<optional_priority>.boot.js`

The resulting order would be like this:
```
xyz.0.boot.js
xyz.3.boot.js
abc.boot.js
xyz.boot.js
```