### PR TITLE
Recorder webinterface: Catch some errors

### DIFF
--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -73,6 +73,11 @@ ${track.map(pt=>`            <gx:value>${0|pt.Skin}</gx:value>\n`).join("")}
 }
 
 function saveGPX(track, title) {
+  if (!track || !track[0] || !"Time" in track[0]) {
+    showToast("Error in trackfile.", "toast-error");
+    return;
+  }
+
   var gpx = `<?xml version="1.0" encoding="UTF-8"?>
 <gpx creator="Bangle.js" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
   <metadata>
@@ -172,6 +177,10 @@ function getTrackList() {
   return {headers:headers,l:data};
 })(${JSON.stringify(filename)})`, trackInfo=>{
           console.log(filename," => ",trackInfo);
+          if (!trackInfo || !"headers" in trackInfo) {
+            showToast("Error loading track list.", "toast-error");
+            resolve();
+          }
           trackInfo.headers = trackInfo.headers.split(",");
           trackList.push({
             filename : filename,

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -4,6 +4,7 @@
   </head>
   <body>
     <div id="tracks"></div>
+    <div class="container"  id="toastcontainer">
 
     <script src="../../core/lib/interface.js"></script>
     <script src="../../core/js/ui.js"></script>

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -4,7 +4,7 @@
   </head>
   <body>
     <div id="tracks"></div>
-    <div class="container"  id="toastcontainer">
+    <div class="container" id="toastcontainer" stlye="position:fixed; bottom:8px; left:0px; right:0px; z-index: 100;">
 
     <script src="../../core/lib/interface.js"></script>
     <script src="../../core/js/ui.js"></script>
@@ -73,6 +73,7 @@ ${track.map(pt=>`            <gx:value>${0|pt.Skin}</gx:value>\n`).join("")}
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
   }, 0);
+  showToast("Download finished.", "toast-success");
 }
 
 function saveGPX(track, title) {
@@ -117,6 +118,7 @@ function saveGPX(track, title) {
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
   }, 0);
+  showToast("Download finished.", "toast-success");
 }
 
 function saveCSV(track, title) {
@@ -129,6 +131,7 @@ function saveCSV(track, title) {
     }).join(",")+"\n";
   });
   Util.saveCSV(title, csv);
+  showToast("Download finished.", "toast-success");
 }
 
 function trackLineToObject(headers, l) {
@@ -148,7 +151,6 @@ function downloadTrack(filename, callback) {
     var headers = lines.shift().split(",");
     var track = lines.map(l=>trackLineToObject(headers, l));
     callback(track);
-    showToast("Download finished.", "toast-success");
   });
 }
 

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -6,6 +6,7 @@
     <div id="tracks"></div>
 
     <script src="../../core/lib/interface.js"></script>
+    <script src="../../core/js/ui.js"></script>
     <script>
 var domTracks = document.getElementById("tracks");
 

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -4,7 +4,7 @@
   </head>
   <body>
     <div id="tracks"></div>
-    <div class="container" id="toastcontainer" stlye="position:fixed; bottom:8px; left:0px; right:0px; z-index: 100;">
+    <div class="container" id="toastcontainer" stlye="position:fixed; bottom:8px; left:0px; right:0px; z-index: 100;"></div>
 
     <script src="../../core/lib/interface.js"></script>
     <script src="../../core/js/ui.js"></script>
@@ -73,12 +73,12 @@ ${track.map(pt=>`            <gx:value>${0|pt.Skin}</gx:value>\n`).join("")}
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
   }, 0);
-  showToast("Download finished.", "toast-success");
+  showToast("Download finished.", "success");
 }
 
 function saveGPX(track, title) {
   if (!track || !track[0] || !"Time" in track[0] || !track[0].Time) {
-    showToast("Error in trackfile.", "toast-error");
+    showToast("Error in trackfile.", "error");
     return;
   }
 
@@ -118,7 +118,7 @@ function saveGPX(track, title) {
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
   }, 0);
-  showToast("Download finished.", "toast-success");
+  showToast("Download finished.", "success");
 }
 
 function saveCSV(track, title) {
@@ -131,7 +131,7 @@ function saveCSV(track, title) {
     }).join(",")+"\n";
   });
   Util.saveCSV(title, csv);
-  showToast("Download finished.", "toast-success");
+  showToast("Download finished.", "success");
 }
 
 function trackLineToObject(headers, l) {
@@ -183,7 +183,7 @@ function getTrackList() {
 })(${JSON.stringify(filename)})`, trackInfo=>{
           console.log(filename," => ",trackInfo);
           if (!trackInfo || !"headers" in trackInfo) {
-            showToast("Error loading track list.", "toast-error");
+            showToast("Error loading track list.", "error");
             resolve();
           }
           trackInfo.headers = trackInfo.headers.split(",");

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -74,7 +74,7 @@ ${track.map(pt=>`            <gx:value>${0|pt.Skin}</gx:value>\n`).join("")}
 }
 
 function saveGPX(track, title) {
-  if (!track || !track[0] || !"Time" in track[0]) {
+  if (!track || !track[0] || !"Time" in track[0] || !track[0].Time) {
     showToast("Error in trackfile.", "toast-error");
     return;
   }

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -140,6 +140,7 @@ function downloadTrack(filename, callback) {
     var headers = lines.shift().split(",");
     var track = lines.map(l=>trackLineToObject(headers, l));
     callback(track);
+    showToast("Download finished.", "toast-success");
   });
 }
 

--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -7,6 +7,7 @@
 
     <script src="../../core/lib/interface.js"></script>
     <script src="../../core/js/ui.js"></script>
+    <script src="../../core/js/utils.js"></script>
     <script>
 var domTracks = document.getElementById("tracks");
 


### PR DESCRIPTION
I had a broken recorder track which causes errors downloading the GPX file.
I was not able to see the errors except in the web console.
So here are changes which make the errors visible if they happen.
