### PR TITLE
[NeonX & IO X] Added optional settings to show the lock status.

### DIFF
--- a/apps/neonx/ChangeLog
+++ b/apps/neonx/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial release
 0.02: Optional fullscreen mode
+0.03: Optional show lock status via color

--- a/apps/neonx/README.md
+++ b/apps/neonx/README.md
@@ -22,3 +22,8 @@ Shows the current date as DD MM on touch and reverts back to time after 5 second
 ### Fullscreen
 Shows the watchface in fullscreen mode.
 Note: In fullscreen mode, widgets are hidden, but still loaded.
+
+### Show lock status
+In fullscreen mode it can be useful to detect, whether the BangleJs is locked or not.
+If these settings are enabled, the first digit is shown red if the BangleJs is locked
+and purple otherwise.

--- a/apps/neonx/README.md
+++ b/apps/neonx/README.md
@@ -24,6 +24,4 @@ Shows the watchface in fullscreen mode.
 Note: In fullscreen mode, widgets are hidden, but still loaded.
 
 ### Show lock status
-In fullscreen mode it can be useful to detect, whether the BangleJs is locked or not.
-If these settings are enabled, the first digit is shown red if the BangleJs is locked
-and purple otherwise.
+If enabled, color changes when unlocked to detect the lock state easily.

--- a/apps/neonx/metadata.json
+++ b/apps/neonx/metadata.json
@@ -2,7 +2,7 @@
   "id": "neonx",
   "name": "Neon X & IO X Clock",
   "shortName": "Neon X Clock",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Pebble Neon X & Neon IO X for Bangle.js",
   "icon": "neonx.png",
   "type": "clock",

--- a/apps/neonx/neonx.app.js
+++ b/apps/neonx/neonx.app.js
@@ -82,7 +82,7 @@ function drawClock(num){
       const current = ((y + 1) * 2 + x - 1);
       let newScale = scale;
 
-      let xc = settings.showLock && Bangle.isLocked() ? Math.abs(x-1) : x;
+      let xc = settings.showLock && !Bangle.isLocked() ? Math.abs(x-1) : x;
       let c = colors[settings.io ? 'io' : 'x'][y][xc];
       g.setColor(c);
 

--- a/apps/neonx/neonx.app.js
+++ b/apps/neonx/neonx.app.js
@@ -50,7 +50,7 @@ const screenWidth = g.getWidth();
 const screenHeight = g.getHeight();
 const halfWidth = screenWidth / 2;
 const scale = screenWidth / 240;
-const REFRESH_RATE = 30E3;
+const REFRESH_RATE = 10E3;
 
 let interval = 0;
 let showingDate = false;

--- a/apps/neonx/neonx.app.js
+++ b/apps/neonx/neonx.app.js
@@ -50,7 +50,7 @@ const screenWidth = g.getWidth();
 const screenHeight = g.getHeight();
 const halfWidth = screenWidth / 2;
 const scale = screenWidth / 240;
-const REFRESH_RATE = 60E3;
+const REFRESH_RATE = 30E3;
 
 let interval = 0;
 let showingDate = false;

--- a/apps/neonx/neonx.app.js
+++ b/apps/neonx/neonx.app.js
@@ -45,8 +45,6 @@ const colors = {
     ["#00FF00", "#00FFFF"]
   ]
 };
-const unlockColor = "#FF0000";
-
 const is12hour = (require("Storage").readJSON("setting.json",1)||{})["12hour"]||false;
 const screenWidth = g.getWidth();
 const screenHeight = g.getHeight();
@@ -84,14 +82,12 @@ function drawClock(num){
       const current = ((y + 1) * 2 + x - 1);
       let newScale = scale;
 
-      let c = colors[settings.io ? 'io' : 'x'][y][x];
-      if(x == 0 && y == 0 && settings.showLock){
-        c = Bangle.isLocked() ? c : unlockColor;
-      }
+      let xc = settings.showLock && Bangle.isLocked() ? Math.abs(x-1) : x;
+      let c = colors[settings.io ? 'io' : 'x'][y][xc];
       g.setColor(c);
 
       if (!settings.io) {
-        newScale *= settings.fullscreen ? 1.18 : 1.0;
+        newScale *= settings.fullscreen ? 1.20 : 1.0;
         let dx = settings.fullscreen ? 0 : 18
         tx = (x * 100 + dx) * newScale;
         ty = (y * 100 + dx*2) * newScale;

--- a/apps/neonx/neonx.settings.js
+++ b/apps/neonx/neonx.settings.js
@@ -9,6 +9,7 @@
       io: 0,
       showDate: 1,
       fullscreen: false,
+      showLock: false,
     };
 
     updateSettings();
@@ -55,6 +56,14 @@
       format: () => (neonXSettings.fullscreen ? 'Yes' : 'No'),
       onchange: () => {
         neonXSettings.fullscreen = !neonXSettings.fullscreen;
+        updateSettings();
+      },
+    },
+    'Show lock': {
+      value: false | neonXSettings.showLock,
+      format: () => (neonXSettings.showLock ? 'Yes' : 'No'),
+      onchange: () => {
+        neonXSettings.showLock = !neonXSettings.showLock;
         updateSettings();
       },
     },


### PR DESCRIPTION
I added optional settings to switch colors whenever the bangle is unlocked. Per default, those settings are off to keep the standard behavior and design. This especially helps in full-screen mode to easily detect the lock state while not changing the cool design of this watch face.

Also, I found that the watch face is updated every 10 seconds - wouldn't it be enough to do it every 60 seconds in order to save some battery? What do you think about this PR @bundyo?