### PR TITLE
Bold Clock: Removed "wake LCD on face-up"

### DIFF
--- a/apps/boldclk/ChangeLog
+++ b/apps/boldclk/ChangeLog
@@ -2,3 +2,4 @@
 0.03: Tweak for more efficient rendering, and firmware 2v06
 0.04: Work with themes, smaller screens
 0.05: Adjust hand lengths to be within 'tick' points
+0.06: Removed "wake LCD on face-up"-feature: A watch-face should not set things like "wake LCD on face-up". 

--- a/apps/boldclk/bold_clock.js
+++ b/apps/boldclk/bold_clock.js
@@ -129,14 +129,6 @@ Bangle.on('lcdPower', (on) => {
     clearTimers();
   }
 });
-Bangle.on('faceUp',function(up){
-  //console.log("faceUp: " + up + " LCD: " + Bangle.isLCDOn());
-  if (up && !Bangle.isLCDOn()) {
-    //console.log("faceUp and LCD off");
-    clearTimers();
-    Bangle.setLCDPower(true);
-  }
-});
 
 g.clear();
 Bangle.loadWidgets();

--- a/apps/boldclk/metadata.json
+++ b/apps/boldclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boldclk",
   "name": "Bold Clock",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Simple, readable and practical clock",
   "icon": "bold_clock.png",
   "screenshots": [{"url":"screenshot_bold.png"}],


### PR DESCRIPTION
Removed "wake LCD on face-up"-feature of Bold Clock: A watch-face should not set things like "wake LCD on face-up". 
If you want, that the LCD get activated when facing up, go to Settings > System > LCD > Wake on FaceUp. 