### PR TITLE
3 Clock-Apps: Removed "wake LCD on face-up"

### DIFF
--- a/apps/crowclk/ChangeLog
+++ b/apps/crowclk/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Removed "wake LCD on face-up"-feature: A watch-face should not set things like "wake LCD on face-up". 

--- a/apps/crowclk/crow_clock.js
+++ b/apps/crowclk/crow_clock.js
@@ -133,15 +133,6 @@ Bangle.on('lcdPower', (on) => {
     clearTimers();
   }
 });
-Bangle.on('faceUp',function(up){
-  //console.log("faceUp: " + up + " LCD: " + Bangle.isLCDOn());
-  if (up && !Bangle.isLCDOn()) {
-    //console.log("faceUp and LCD off");
-    clearTimers();
-    Bangle.setLCDPower(true);
-  }
-});
-
 g.clear();
 
 

--- a/apps/crowclk/metadata.json
+++ b/apps/crowclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "crowclk",
   "name": "Crow Clock",
-  "version": "0.01",
+  "version": "0.02",
   "description": "A simple clock based on Bold Clock that has MST3K's Crow T. Robot for a face",
   "icon": "crow_clock.png",
   "screenshots": [{"url":"screenshot_crow.png"}],

--- a/apps/matrixclock/ChangeLog
+++ b/apps/matrixclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial Release
 0.02: Support for Bangle 2
 0.03: Keep the date from being overwritten, use correct colour from theme for clearing
+0.04: Removed "wake LCD on face-up"-feature: A watch-face should not set things like "wake LCD on face-up". 

--- a/apps/matrixclock/matrixclock.js
+++ b/apps/matrixclock/matrixclock.js
@@ -239,15 +239,6 @@ Bangle.on('lcdPower', (on) => {
   }
 });
 
-Bangle.on('faceUp',function(up){
-  //console.log("faceUp: " + up + " LCD: " + Bangle.isLCDOn());
-  if (up && !Bangle.isLCDOn()) {
-    //console.log("faceUp and LCD off");
-    clearTimers();
-    Bangle.setLCDPower(true);
-  }
-});
-
 g.clear();
 Bangle.loadWidgets();
 Bangle.drawWidgets();

--- a/apps/matrixclock/metadata.json
+++ b/apps/matrixclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "matrixclock",
   "name": "Matrix Clock",
-  "version": "0.03",
+  "version": "0.04",
   "description": "inspired by The Matrix, a clock of the same style",
   "icon": "matrixclock.png",
   "screenshots": [{"url":"screenshot_matrix.png"}],

--- a/apps/slidingtext/ChangeLog
+++ b/apps/slidingtext/ChangeLog
@@ -5,3 +5,4 @@
 0.05: BUGFIX: pedometer widget interfered with the clock Font Alignment
 0.06: Use Bangle.setUI for button/launcher handling
 0.07: Support for Bangle.js 2 and themes
+0.08: Removed "wake LCD on face-up"-feature: A watch-face should not set things like "wake LCD on face-up". 

--- a/apps/slidingtext/metadata.json
+++ b/apps/slidingtext/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "slidingtext",
   "name": "Sliding Clock",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Inspired by the Pebble sliding clock, old times are scrolled off the screen and new times on. You are also able to change language on the fly so you can see the time written in other languages using button 1. Currently English, French, Japanese, Spanish and German are supported",
   "icon": "slidingtext.png",
   "type": "clock",

--- a/apps/slidingtext/slidingtext.js
+++ b/apps/slidingtext/slidingtext.js
@@ -623,15 +623,6 @@ Bangle.on('lcdPower', (on) => {
   }
 });
 
-Bangle.on('faceUp',function(up){
-  //console.log("faceUp: " + up + " LCD: " + Bangle.isLCDOn());
-  if (up && !Bangle.isLCDOn()) {
-    //console.log("faceUp and LCD off");
-    clearTimers();
-    Bangle.setLCDPower(true);
-  }
-});
-
 g.clear();
 load_settings();
 Bangle.loadWidgets();


### PR DESCRIPTION
Removed "wake LCD on face-up"-feature of MatrixClock, Crow-Clock and SlidingText-Clock: A watch-face should not set things like "wake LCD on face-up".
If you want, that the LCD get activated when facing up, go to Settings > System > LCD > Wake on FaceUp. 

This pull-request is a successor of my previous pull-request number 1490 ( [https://github.com/espruino/BangleApps/pull/1490](https://github.com/espruino/BangleApps/pull/1490) ), where Gordon Williams mentioned, that other watch-faces might also contain this code. 