### PR TITLE
messages: Remove left-over debug statement

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -36,3 +36,4 @@
       Also gave the widget a pixel more room to the right
 0.23: Change message colors to match current theme instead of using green
       Now attempt to use Large/Big/Medium fonts, and allow minimum font size to be configured         
+0.24: Remove left-over debug statement

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.23",
+  "version": "0.24",
   "description": "App to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messages/widget.js
+++ b/apps/messages/widget.js
@@ -6,7 +6,6 @@ draw:function() {
   g.reset().clearRect(this.x, this.y, this.x+this.width, this.y+this.iconwidth);
   g.drawImage((c&1) ? atob("GBiBAAAAAAAAAAAAAAAAAAAAAB//+DAADDAADDAADDwAPD8A/DOBzDDn/DA//DAHvDAPvjAPvjAPvjAPvh///gf/vAAD+AAB8AAAAA==") : atob("GBiBAAAAAAAAAAAAAAAAAAAAAB//+D///D///A//8CP/xDj/HD48DD+B8D/D+D/3vD/vvj/vvj/vvj/vvh/v/gfnvAAD+AAB8AAAAA=="), this.x, this.y);
   let settings = require('Storage').readJSON("messages.settings.json", true) || {};
-  console.log("dingen ", typeof(settings.repeat), settings.repeat)
   if (settings.repeat===undefined) settings.repeat = 4;
   if (c<120 && (Date.now()-this.l)>settings.repeat*1000) {
     this.l = Date.now();


### PR DESCRIPTION
Not sure if this warrants a version bump, but I suspect unexpected output might confuse the App Loader?