### PR TITLE
Fix Daisy Clock

### DIFF
--- a/apps/daisy/ChangeLog
+++ b/apps/daisy/ChangeLog
@@ -1,2 +1,3 @@
 0.01: first release
 0.02: added settings menu to change color
+0.03: fix metadata.json to allow setting as clock

--- a/apps/daisy/metadata.json
+++ b/apps/daisy/metadata.json
@@ -4,6 +4,7 @@
   "dependencies": {"mylocation":"app"},
   "description": "A clock based on the Pastel clock with large ring guage for steps",
   "icon": "app.png",
+  "type": "clock",
   "tags": "clock",
   "supports" : ["BANGLEJS2"],
   "screenshots": [{"url":"screenshot_daisy2.jpg"}],

--- a/apps/daisy/metadata.json
+++ b/apps/daisy/metadata.json
@@ -1,6 +1,6 @@
 { "id": "daisy",
   "name": "Daisy",
-  "version":"0.02",
+  "version":"0.03",
   "dependencies": {"mylocation":"app"},
   "description": "A clock based on the Pastel clock with large ring guage for steps",
   "icon": "app.png",


### PR DESCRIPTION
The new `daisy` clock was missing a line in `metadata.json` to make is actually usable as a clock, as it stands you can only open it as an app from the launcher but not set it as a clock in the settings.