### PR TITLE
Fix typo in Time and Life shortName

### DIFF
--- a/apps/timeandlife/metadata.json
+++ b/apps/timeandlife/metadata.json
@@ -1,18 +1,26 @@
 {
   "id": "timeandlife",
   "name": "Time and Life",
-  "shortName":"Time and Lfie",
+  "shortName": "Time and Life",
   "icon": "app.png",
-  "version":"0.01",
+  "version": "0.01",
   "description": "A simple watchface which displays the time when the screen is tapped and decay according to the rules of Conway's game of life.",
   "type": "clock",
   "tags": "clock",
-  "supports": ["BANGLEJS2"],
-  "allow_emulator":true,
+  "supports": [
+    "BANGLEJS2"
+  ],
+  "allow_emulator": true,
   "readme": "README.md",
   "storage": [
-    {"name":"timeandlife.app.js","url":"app.js"},
-    {"name":"timeandlife.img","url":"app-icon.js","evaluate":true}
+    {
+      "name": "timeandlife.app.js",
+      "url": "app.js"
+    },
+    {
+      "name": "timeandlife.img",
+      "url": "app-icon.js",
+      "evaluate": true
+    }
   ]
 }
-


### PR DESCRIPTION
The shortName for the Time and Life app was misspelled in the metadata, so it showed in the menu as "Time and Lfie". This PR fixes that.