### PR TITLE
qmsched: support new bangle.js 2 menu, add /*LANG*/ hints

### DIFF
--- a/apps/qmsched/ChangeLog
+++ b/apps/qmsched/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Fix: don't try to redraw widget when widgets not loaded
 0.07: Option to switch theme
       Changed time selection to 5-minute intervals
+0.08: Support new Bangle.js 2 menu

--- a/apps/qmsched/app.js
+++ b/apps/qmsched/app.js
@@ -1,7 +1,7 @@
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
-const modeNames = ["Off", "Alarms", "Silent"];
+const modeNames = [/*LANG*/"Off", /*LANG*/"Alarms", /*LANG*/"Silent"];
 const B2 = process.env.HWVERSION===2;
 // load global settings
 let bSettings = require('Storage').readJSON('setting.json',true)||{};
@@ -109,10 +109,9 @@ function setAppQuietMode(mode) {
 
 let m;
 function showMainMenu() {
-  let menu = {"": {"title": "Quiet Mode"},};
-  menu[B2 ? "< Back" : "< Exit"] = () => {load();};
-  // "Current Mode""Silent" won't fit on Bangle.js 2
-  menu["Current"+((process.env.HWVERSION===2) ? "" : " Mode")] = {
+  let menu = {"": {"title": /*LANG*/"Quiet Mode"},};
+  menu[B2 ? /*LANG*/"< Back" : /*LANG*/"< Exit"] = () => {load();};
+  menu[/*LANG*/"Current Mode"] = {
     value: current,
     min:0, max:2, wrap: true,
     format: v => modeNames[v],
@@ -123,13 +122,13 @@ function showMainMenu() {
     menu[formatTime(sched.hr)] = () => { showEditMenu(idx); };
     menu[formatTime(sched.hr)].format = () => modeNames[sched.mode]+' >'; // this does nothing :-(
   });
-  menu["Add Schedule"] = () => showEditMenu(-1);
-  menu["Switch Theme"] = {
+  menu[/*LANG*/"Add Schedule"] = () => showEditMenu(-1);
+  menu[/*LANG*/"Switch Theme"] = {
     value: !!get("switchTheme"),
     format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
     onchange: v => v ? set("switchTheme", v) : unset("switchTheme"),
   };
-  menu["LCD Settings"] = () => showOptionsMenu();
+  menu[/*LANG*/"LCD Settings"] = () => showOptionsMenu();
   m = E.showMenu(menu);
 }
 
@@ -143,19 +142,19 @@ function showEditMenu(index) {
     mins = Math.round((s.hr-hrs)*60);
     mode = s.mode;
   }
-  let menu = {"": {"title": (isNew ? "Add" : "Edit")+" Schedule"}};
-  menu[B2 ? "< Back" : "< Cancel"] =  () => showMainMenu();
-  menu["Hours"] = {
+  let menu = {"": {"title": (isNew ? /*LANG*/"Add Schedule" : /*LANG*/"Edit Schedule")}};
+  menu[B2 ? /*LANG*/"< Back" : /*LANG*/"< Cancel"] =  () => showMainMenu();
+  menu[/*LANG*/"Hours"] = {
     value: hrs,
     min:0, max:23, wrap:true,
     onchange: v => {hrs = v;},
   };
-  menu["Minutes"] = {
+  menu[/*LANG*/"Minutes"] = {
     value: mins,
     min:0, max:55, step:5, wrap:true,
     onchange: v => {mins = v;},
   };
-  menu["Switch to"] = {
+  menu[/*LANG*/"Switch to"] = {
     value: mode,
     min:0, max:2, wrap:true,
     format: v => modeNames[v],
@@ -167,7 +166,7 @@ function showEditMenu(index) {
       mode: mode,
     };
   }
-  menu[B2 ? "Save" : "> Save"] = function() {
+  menu[B2 ? /*LANG*/"Save" : /*LANG*/"> Save"] = function() {
     if (isNew) {
       scheds.push(getSched());
     } else {
@@ -177,7 +176,7 @@ function showEditMenu(index) {
     showMainMenu();
   };
   if (!isNew) {
-    menu[B2 ? "Delete" : "> Delete"] = function() {
+    menu[B2 ? /*LANG*/"Delete" : /*LANG*/"> Delete"] = function() {
       scheds.splice(index, 1);
       save();
       showMainMenu();
@@ -187,7 +186,7 @@ function showEditMenu(index) {
 }
 
 function showOptionsMenu() {
-  const disabledFormat = v => v ? "Off" : "-";
+  const disabledFormat = v => v ? /*LANG*/"Off" : "-";
   function toggle(option) {
     // we disable wakeOn* events by setting them to `false` in options
     // not disabled = not present in options at all
@@ -200,9 +199,9 @@ function showOptionsMenu() {
   }
   let resetTimeout;
   const oMenu = {
-    "": {"title": "LCD Settings"},
-    "< Back": () => showMainMenu(),
-    "LCD Brightness": {
+    "": {"title": /*LANG*/"LCD Settings"},
+    /*LANG*/"< Back": () => showMainMenu(),
+    /*LANG*/"LCD Brightness": {
       value: get("brightness", 0),
       min: 0, // 0 = use default
       max: 1,
@@ -224,7 +223,7 @@ function showOptionsMenu() {
         }
       },
     },
-    "LCD Timeout": {
+    /*LANG*/"LCD Timeout": {
       value: get("timeout", 0),
       min: 0, // 0 = use default  (no constant on for quiet mode)
       max: 60,
@@ -237,17 +236,17 @@ function showOptionsMenu() {
     },
     // we disable wakeOn* events by overwriting them as false in options
     // not disabled = not present in options at all
-    "Wake on FaceUp": {
+    /*LANG*/"Wake on FaceUp": {
       value: "wakeOnFaceUp" in options,
       format: disabledFormat,
       onchange: () => {toggle("wakeOnFaceUp");},
     },
-    "Wake on Touch": {
+    /*LANG*/"Wake on Touch": {
       value: "wakeOnTouch" in options,
       format: disabledFormat,
       onchange: () => {toggle("wakeOnTouch");},
     },
-    "Wake on Twist": {
+    /*LANG*/"Wake on Twist": {
       value: "wakeOnTwist" in options,
       format: disabledFormat,
       onchange: () => {toggle("wakeOnTwist");},

--- a/apps/qmsched/metadata.json
+++ b/apps/qmsched/metadata.json
@@ -2,7 +2,7 @@
   "id": "qmsched",
   "name": "Quiet Mode Schedule and Widget",
   "shortName": "Quiet Mode",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Automatically turn Quiet Mode on or off at set times, change theme and LCD options while Quiet Mode is active.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot_b1_main.png"},{"url":"screenshot_b1_edit.png"},{"url":"screenshot_b1_lcd.png"},


### PR DESCRIPTION
Whoops, this app was quite broken with the new menu, because of how it abused `format`.