### PR TITLE
bthrm - Allow scanning for sensors in settings

### DIFF
--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -20,3 +20,4 @@
 0.07: Recorder icon only blue if values actually arive
       Adds some preset modes and a custom one
       Restructure the settings menu
+0.08: Allow scanning for devices in settings

--- a/apps/bthrm/metadata.json
+++ b/apps/bthrm/metadata.json
@@ -2,7 +2,7 @@
   "id": "bthrm",
   "name": "Bluetooth Heart Rate Monitor",
   "shortName": "BT HRM",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Overrides Bangle.js's build in heart rate monitor with an external Bluetooth one.",
   "icon": "app.png",
   "type": "app",

--- a/apps/bthrm/settings.js
+++ b/apps/bthrm/settings.js
@@ -17,54 +17,73 @@
   var settings;
   readSettings();
 
-  var mainmenu = {
-    '': { 'title': 'Bluetooth HRM' },
-    '< Back': back,
-    'Mode': {
-      value: 0 | settings.mode,
-      min: 0,
-      max: 3,
-      format: v => ["Off", "Default", "Both", "Custom"][v],
-      onchange: v => {
-        settings.mode = v;
-        switch (v){
-          case 0:
-            writeSettings("enabled",false);
-            break;
-          case 1:
-            writeSettings("enabled",true);
-            writeSettings("replace",true);
-            writeSettings("debuglog",false);
-            writeSettings("startWithHrm",true);
-            writeSettings("allowFallback",true);
-            writeSettings("fallbackTimeout",10);
-            break;
-          case 2:
-            writeSettings("enabled",true);
-            writeSettings("replace",false);
-            writeSettings("debuglog",false);
-            writeSettings("startWithHrm",false);
-            writeSettings("allowFallback",false);
-            break;
-          case 3:
-            writeSettings("enabled",true);
-            writeSettings("replace",settings.custom_replace);
-            writeSettings("debuglog",settings.custom_debuglog);
-            writeSettings("startWithHrm",settings.custom_startWithHrm);
-            writeSettings("allowFallback",settings.custom_allowFallback);
-            writeSettings("fallbackTimeout",settings.custom_fallbackTimeout);
-            break;
+  function buildMainMenu(){
+    var mainmenu = {
+      '': { 'title': 'Bluetooth HRM' },
+      '< Back': back,
+      'Mode': {
+        value: 0 | settings.mode,
+        min: 0,
+        max: 3,
+        format: v => ["Off", "Default", "Both", "Custom"][v],
+        onchange: v => {
+          settings.mode = v;
+          switch (v){
+            case 0:
+              writeSettings("enabled",false);
+              break;
+            case 1:
+              writeSettings("enabled",true);
+              writeSettings("replace",true);
+              writeSettings("debuglog",false);
+              writeSettings("startWithHrm",true);
+              writeSettings("allowFallback",true);
+              writeSettings("fallbackTimeout",10);
+              break;
+            case 2:
+              writeSettings("enabled",true);
+              writeSettings("replace",false);
+              writeSettings("debuglog",false);
+              writeSettings("startWithHrm",false);
+              writeSettings("allowFallback",false);
+              break;
+            case 3:
+              writeSettings("enabled",true);
+              writeSettings("replace",settings.custom_replace);
+              writeSettings("debuglog",settings.custom_debuglog);
+              writeSettings("startWithHrm",settings.custom_startWithHrm);
+              writeSettings("allowFallback",settings.custom_allowFallback);
+              writeSettings("fallbackTimeout",settings.custom_fallbackTimeout);
+              break;
+          }
+          writeSettings("mode",v);
         }
-        writeSettings("mode",v);
       }
-    },
-    'Custom Mode': function() { E.showMenu(submenu_custom); },
-    'Debug': function() { E.showMenu(submenu_debug); }
-  };
+    };
+
+    if (settings.btname){
+      var name = "Clear " + settings.btname;
+      mainmenu[name] = function() {
+      E.showPrompt("Clear current device name?").then((r)=>{
+          if (r) {
+            writeSettings("btname",undefined);
+          }
+          E.showMenu(buildMainMenu());
+        });
+      };
+    }
+
+    mainmenu["BLE Scan"] = ()=> createMenuFromScan();
+    mainmenu["Custom Mode"] = function() { E.showMenu(submenu_custom); };
+    mainmenu.Debug = function() { E.showMenu(submenu_debug); };
+    return mainmenu;
+  }
+  
+
   
   var submenu_debug = {
     '' : { title: "Debug"},
-    '< Back': function() { E.showMenu(mainmenu); },
+    '< Back': function() { E.showMenu(buildMainMenu()); },
     'Alert on disconnect': {
       value: !!settings.warnDisconnect,
       format: v => settings.warnDisconnect ? "On" : "Off",
@@ -81,10 +100,41 @@
     },
     'Grace periods': function() { E.showMenu(submenu_grace); }
   };
+
+  function createMenuFromScan(){
+    E.showMenu();
+    E.showMessage("Scanning");
+
+    var submenu_scan = {
+      '' : { title: "Scan"},
+      '< Back': function() { E.showMenu(buildMainMenu()); }
+    };
+    var packets=10;
+    var scanStart=Date.now();
+    NRF.setScan(function(d) {
+      packets--;
+      if (packets<=0 || Date.now() - scanStart > 5000){
+        NRF.setScan();
+        E.showMenu(submenu_scan);
+      } else if (d.name){
+        print("Found device", d);
+        submenu_scan[d.name] = function(){
+          E.showPrompt("Set "+d.name+"?").then((r)=>{
+          if (r) {
+            writeSettings("btname",d.name);
+          }
+          E.showMenu(buildMainMenu());
+        });
+        };
+      }
+    }, { filters: [{services: [ "180d" ]}]});
+  }
+  
+
   
   var submenu_custom = {
     '' : { title: "Custom mode"},
-    '< Back': function() { E.showMenu(mainmenu); },
+    '< Back': function() { E.showMenu(buildMainMenu()); },
     'Replace HRM': {
       value: !!settings.custom_replace,
       format: v => settings.custom_replace ? "On" : "Off",
@@ -165,7 +215,7 @@
   
   var submenu = {
     '' : { title: "Grace periods"},
-    '< Back': function() { E.showMenu(mainmenu); },
+    '< Back': function() { E.showMenu(buildMainMenu()); },
     'Request': {
       value: settings.gracePeriodRequest,
       min: 0,
@@ -208,5 +258,5 @@
     }
   };
   
-  E.showMenu(mainmenu);
+  E.showMenu(buildMainMenu());
 })


### PR DESCRIPTION
Set a specific sensor to use to prevent chaos when more than one is in range. Without a set sensor the old "connect to first found" behaviour is kept.