### PR TITLE
boot: fix alphabetic sorting of *.boot.js files

### DIFF
--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -196,7 +196,7 @@ if (!Bangle.appRect) { // added in 2v11 - polyfill for older firmwares
 // Append *.boot.js files
 // These could change bleServices/bleServiceOptions if needed
 var getPriority = /.*\.(\d+)\.boot\.js$/;
-require('Storage').list(/\.boot\.js/).sort((a,b)=>{
+require('Storage').list(/\.boot\.js$/).sort((a,b)=>{
   var aPriority = a.match(getPriority);
   var bPriority = b.match(getPriority);
   if (aPriority && bPriority){
@@ -206,7 +206,7 @@ require('Storage').list(/\.boot\.js/).sort((a,b)=>{
   } else if (!aPriority && bPriority){
     return 1;
   }
-  return a > b;
+  return a==b ? 0 : (a>b ? 1 : -1);
 }).forEach(bootFile=>{
   // we add a semicolon so if the file is wrapped in (function(){ ... }()
   // with no semicolon we don't end up with (function(){ ... }()(function(){ ... }()


### PR DESCRIPTION
No version bump: assuming that where it really matters we already set a priority, which worked fine.