### PR TITLE
Seiko-5actus: shrunk hand images to save memory

### DIFF
--- a/apps/seiko-5actus/ChangeLog
+++ b/apps/seiko-5actus/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial Release
+0.02: Shrink hand images to save memory

--- a/apps/seiko-5actus/app.js
+++ b/apps/seiko-5actus/app.js
@@ -7,17 +7,17 @@ var imgBg = {
 /* Set hour hand image */
 
 var imgHour = {
-  width : 16, height : 176, bpp : 2,
+  width : 14, height : 114, bpp : 2,
   transparent : 0,
-  buffer : require("heatshrink").decompress(atob("AH4A/AH4A/AEk//gDp///gEDAYPAh4DB+E/AYP8AaYbDEYYrDLdgD/Af4DXh/wAYIA/AGwA="))
+  buffer : require("heatshrink").decompress(atob("AH4A/AB8P/4DB//wAz8D//8BIIKBn4DB54CBACPzAQP8EoImBD4PAJkQG/A34GIgbUBA"))
 };
 
 /* Set minute hand image */
 
 var imgMin = {
-  width : 8, height : 176, bpp : 2,
+  width : 4, height : 168, bpp : 2,
   transparent : 0,
-  buffer : require("heatshrink").decompress(atob("AH4A/AB8P+AB/AP4B/AIcA4DPHA="))
+  buffer : require("heatshrink").decompress(atob("AH4AE/4A/AEI"))
 };
 
 /* Set second hand image */

--- a/apps/seiko-5actus/metadata.json
+++ b/apps/seiko-5actus/metadata.json
@@ -3,7 +3,7 @@
     "shortName":"5actus",
     "icon": "seiko-5actus.png",
     "screenshots": [{"url":"screenshot.png"}],
-    "version":"0.01",
+    "version":"0.02",
     "description": "A watch designed after then Seiko 5actus from the 1970's",
     "tags": "clock",
     "type": "clock",


### PR DESCRIPTION
Your response in my last pull request made me realize how simple it would be to keep the hands centered and shrink the image size down so there wasn't a bunch of extra transparency around each image.

I've shrunk the minute and hour down so that the point I need centered stays centered but removes all the whitespace around the images. The second hand isn't able to be changed due to already being at the max size it can be.

Hopefully this improves memory utilization a little