### PR TITLE
bledetect: BangleJs2 compatible

### DIFF
--- a/apps/bledetect/ChangeLog
+++ b/apps/bledetect/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Fixed issue with wrong device informations
 0.03: Ensure manufacturer:undefined doesn't overflow screen
+0.04: Set Bangle.js 2 compatible, show widgets

--- a/apps/bledetect/bledetect.js
+++ b/apps/bledetect/bledetect.js
@@ -5,6 +5,7 @@ let menu = {
 
 function showMainMenu() {
   menu["< Back"] =  () => load();
+  Bangle.drawWidgets();
   return E.showMenu(menu);
 }
 
@@ -55,5 +56,6 @@ function waitMessage() {
   E.showMessage("scanning");
 }
 
+Bangle.loadWidgets();
 scan();
 waitMessage();

--- a/apps/bledetect/metadata.json
+++ b/apps/bledetect/metadata.json
@@ -2,11 +2,11 @@
   "id": "bledetect",
   "name": "BLE Detector",
   "shortName": "BLE Detector",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Detect BLE devices and show some informations.",
   "icon": "bledetect.png",
   "tags": "app,bluetooth,tool",
-  "supports": ["BANGLEJS"],
+  "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",
   "storage": [
     {"name":"bledetect.app.js","url":"bledetect.js"},

--- a/apps/sleepphasealarm/app.js
+++ b/apps/sleepphasealarm/app.js
@@ -29,11 +29,11 @@ function calc_ess(val) {
     if (nonmot) {
       slsnds+=1;
       if (slsnds >= sleepthresh) {
-        return true; // awake
+        return true; // sleep
       }
     } else {
       slsnds=0;
-      return false; // sleep
+      return false; // awake
     }
   }
 }


### PR DESCRIPTION
Set bledetect BangleJs2 compatible and show Widgets. Bledetect works on BangleJs2 without any changes.

Also fix a typo in a comment of sleepphasealarm