### PR TITLE
Fix run notifications bugs and improve accuracy

### DIFF
--- a/apps/recorder/ChangeLog
+++ b/apps/recorder/ChangeLog
@@ -17,3 +17,4 @@
 0.11: Fix KML and GPX export when there is no GPS data
 0.12: Fix 'Back' label positioning on track/graph display, make translateable
 0.13: Fix for when widget is used before app
+0.14: Remove unneeded variable assignment

--- a/apps/recorder/metadata.json
+++ b/apps/recorder/metadata.json
@@ -2,7 +2,7 @@
   "id": "recorder",
   "name": "Recorder",
   "shortName": "Recorder",
-  "version": "0.13",
+  "version": "0.14",
   "description": "Record GPS position, heart rate and more in the background, then download to your PC.",
   "icon": "app.png",
   "tags": "tool,outdoors,gps,widget",

--- a/apps/recorder/widget.js
+++ b/apps/recorder/widget.js
@@ -248,7 +248,7 @@
       }
       var buttons={Yes:"yes",No:"no"};
       if (newFileName) buttons["New"] = "new";
-      var prompt = E.showPrompt("Overwrite\nLog " + settings.file.match(/\d+/)[0] + "?",{title:"Recorder",buttons:buttons}).then(selection=>{
+      return E.showPrompt("Overwrite\nLog " + settings.file.match(/\d+/)[0] + "?",{title:"Recorder",buttons:buttons}).then(selection=>{
         if (selection==="no") return false; // just cancel
         if (selection==="yes") {
           require("Storage").open(settings.file,"r").erase();
@@ -259,7 +259,6 @@
         }
         return WIDGETS["recorder"].setRecording(1);
       });
-      return prompt;
     }
     settings.recording = isOn;
     updateSettings(settings);

--- a/apps/run/ChangeLog
+++ b/apps/run/ChangeLog
@@ -9,3 +9,4 @@
 0.08: Added support for notifications from exstats. Support all stats from exstats
 0.09: Fix broken start/stop if recording not enabled (fix #1561)
 0.10: Don't allow the same setting to be chosen for 2 boxes (fix #1578)
+0.11: Notifications fixes

--- a/apps/run/app.js
+++ b/apps/run/app.js
@@ -59,7 +59,7 @@ function onStartStop() {
           layout.render();
         })
       );
-    } else {
+    } else if (!settings.record && WIDGETS["recorder"]) {
       prepPromises.push(
         WIDGETS["recorder"].setRecording(false)
       );
@@ -124,7 +124,7 @@ function configureNotification(stat) {
 }
 
 Object.keys(settings.notify).forEach((statType) => {
-  if (settings.notify[statType].increment > 0) {
+  if (settings.notify[statType].increment > 0 && exs.stats[statType]) {
       configureNotification(exs.stats[statType]);
   }
 });

--- a/apps/run/metadata.json
+++ b/apps/run/metadata.json
@@ -1,6 +1,6 @@
 { "id": "run",
   "name": "Run",
-  "version":"0.10",
+  "version":"0.11",
   "description": "Displays distance, time, steps, cadence, pace and more for runners.",
   "icon": "app.png",
   "tags": "run,running,fitness,outdoors,gps",

--- a/apps/run/settings.js
+++ b/apps/run/settings.js
@@ -90,8 +90,8 @@
     [[300, 1],[300, 0],[300, 1],[300, 0],[300, 1]],
   ];
   notificationsMenu[/*LANG*/"Dist Pattern"] = {
-    value: Math.max(0,vibPatterns.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.dist.notifications))),
-      min: 0, max: vibPatterns.length,
+    value: Math.max(0,vibTimes.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.dist.notifications))),
+      min: 0, max: vibTimes.length,
       format: v => vibPatterns[v]||/*LANG*/"Off",
       onchange: v => {
         settings.notify.dist.notifications = vibTimes[v];
@@ -100,8 +100,8 @@
       }
   }
   notificationsMenu[/*LANG*/"Step Pattern"] = {
-    value: Math.max(0,vibPatterns.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.step.notifications))),
-      min: 0, max: vibPatterns.length,
+    value: Math.max(0,vibTimes.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.step.notifications))),
+      min: 0, max: vibTimes.length,
       format: v => vibPatterns[v]||/*LANG*/"Off",
       onchange: v => {
         settings.notify.step.notifications = vibTimes[v];
@@ -110,8 +110,8 @@
       }
   }
   notificationsMenu[/*LANG*/"Time Pattern"] = {
-    value: Math.max(0,vibPatterns.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.time.notifications))),
-      min: 0, max: vibPatterns.length,
+    value: Math.max(0,vibTimes.findIndex((p) => JSON.stringify(p) === JSON.stringify(settings.notify.time.notifications))),
+      min: 0, max: vibTimes.length,
       format: v => vibPatterns[v]||/*LANG*/"Off",
       onchange: v => {
         settings.notify.time.notifications = vibTimes[v];

--- a/modules/exstats.js
+++ b/modules/exstats.js
@@ -139,9 +139,9 @@ Bangle.on("GPS", function(fix) {
   if (stats["pacea"]) stats["pacea"].emit("changed",stats["pacea"]);
   if (stats["pacec"]) stats["pacec"].emit("changed",stats["pacec"]);
   if (stats["speed"]) stats["speed"].emit("changed",stats["speed"]);
-  if (state.notify.dist.increment > 0 && state.notify.dist.next <= stats["dist"]) {
+  if (state.notify.dist.increment > 0 && state.notify.dist.next <= state.distance) {
     stats["dist"].emit("notify",stats["dist"]);
-    state.notify.dist.next = stats["dist"] + state.notify.dist.increment;
+    state.notify.dist.next = state.notify.dist.next + state.notify.dist.increment;
   }
 });
 
@@ -152,7 +152,7 @@ Bangle.on("step", function(steps) {
   state.lastStepCount = steps;
   if (state.notify.step.increment > 0 && state.notify.step.next <= steps) {
     stats["step"].emit("notify",stats["step"]);
-    state.notify.step.next = steps + state.notify.step.increment;
+    state.notify.step.next = state.notify.step.next + state.notify.step.increment;
   }
 });
 Bangle.on("HRM", function(h) {
@@ -285,7 +285,7 @@ exports.getStats = function(statIDs, options) {
     }
     if (state.notify.time.increment > 0 && state.notify.time.next <= now) {
       stats["time"].emit("notify",stats["time"]);
-      state.notify.time.next = now + state.notify.time.increment;
+      state.notify.time.next = state.notify.time.next + state.notify.time.increment;
     }
   }, 1000);
   function reset() {
@@ -299,6 +299,8 @@ exports.getStats = function(statIDs, options) {
     state.curSpeed = 0;
     state.BPM = 0;
     state.BPMage = 0;
+    state.thisGPS = {};
+    state.lastGPS = {};
     state.notify = options.notify;
     if (options.notify.dist.increment > 0) {
       state.notify.dist.next = state.distance + options.notify.dist.increment;
@@ -338,7 +340,7 @@ exports.appendMenuItems = function(menu, settings, saveSettings) {
 }
 exports.appendNotifyMenuItems = function(menu, settings, saveSettings) {
   var distNames = ['Off', "1000m","1 mile","1/2 Mthn", "Marathon",];
-  var distAmts = [0, 1000,1609,21098,42195];
+  var distAmts = [0, 1000, 1609, 21098, 42195];
   menu['Ntfy Dist'] = {
     min: 0, max: distNames.length-1,
     value: Math.max(distAmts.indexOf(settings.notify.dist.increment),0),


### PR DESCRIPTION
This fixes a few issues with the `run` app, mostly ones I introduced with the notifications, but not exclusively. It also removes an unnecessary variable assignment in the `recorder` app.

* Don't try and enable/disable recording if the `recorder` widget is unavailable
* Don't configure notifications for stats which do not have a box enabled
* Look up the `vibTimes` rather than the `vibPatterns` to determine the current notification configuration
* Use the previous notification state to determine the next state, rather than the current stat (decreases notification drift)
* Reset GPS state in `reset` to prevent distance miscalculation when stopping one run and starting another