### PR TITLE
Antonclk fix calweek substring

### DIFF
--- a/apps/antonclk/ChangeLog
+++ b/apps/antonclk/ChangeLog
@@ -9,3 +9,4 @@
       when weekday name and calendar weeknumber are on then display is <weekday short> #<calweek>
       week is buffered until date or timezone changes
 0.07: align default settings with app.js (otherwise the initial displayed settings will be confusing to users)
+0.08: fixed calendar weeknumber not shortened to two digits

--- a/apps/antonclk/app.js
+++ b/apps/antonclk/app.js
@@ -99,7 +99,7 @@ function updateState() {
 }
 
 function isoStr(date) {
-  return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).substr(-2) + "-" + ("0" + date.getDate()).substr(-2);
+  return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).substr(-2);
 }
 
 var calWeekBuffer = [false,false,false]; //buffer tz, date, week no (once calculated until other tz or date is requested)
@@ -140,7 +140,7 @@ function draw() {
   g.setFontAlign(0, 0).setFont("Anton").drawString(timeStr, x, y); // draw time
   if (secondsScreen) {
     y += 65;
-    var secStr = (secondsWithColon ? ":" : "") + ("0" + date.getSeconds()).substr(-2);
+    var secStr = (secondsWithColon ? ":" : "") + ("0" + date.getSeconds()).slice(-2);
     if (doColor())
       g.setColor(0, 0, 1);
     g.setFont("AntonSmall");
@@ -193,7 +193,7 @@ function draw() {
     if (calWeek || weekDay) {
       var dowcwStr = "";
       if (calWeek)
-        dowcwStr = " #" + ("0" + ISO8601calWeek(date)).substring(-2);
+        dowcwStr = " #" + ("0" + ISO8601calWeek(date)).slice(-2);
       if (weekDay) 
         dowcwStr = require("locale").dow(date, calWeek ? 1 : 0) + dowcwStr;  //weekDay e.g. Monday or weekDayShort #<calWeek> e.g. Mon #01
       else //week #01

--- a/apps/antonclk/app.js
+++ b/apps/antonclk/app.js
@@ -99,7 +99,7 @@ function updateState() {
 }
 
 function isoStr(date) {
-  return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).substr(-2);
+  return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2);
 }
 
 var calWeekBuffer = [false,false,false]; //buffer tz, date, week no (once calculated until other tz or date is requested)

--- a/apps/antonclk/metadata.json
+++ b/apps/antonclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "antonclk",
   "name": "Anton Clock",
-  "version": "0.07",
+  "version": "0.08",
   "description": "A clock using the bold Anton font, optionally showing seconds and date in ISO-8601 format.",
   "readme":"README.md",
   "icon": "app.png",


### PR DESCRIPTION
bugfixed calendar week shown 3 digits (`substring` -> `slice`) furthermore replaced deprecated `substr` by `slice`