### PR TITLE
[exstats/run] Include maxbpm as a stat that can be tracked

### DIFF
--- a/apps/run/README.md
+++ b/apps/run/README.md
@@ -14,7 +14,8 @@ the red `STOP` in the bottom right turns to a green `RUN`.
   shown will increase, even if you are standing still.
 * `TIME` - the elapsed time for your run
 * `PACE` - the number of minutes it takes you to run a given distance, configured in settings (default 1km) **based on your run so far**
-* `HEART` - Your heart rate
+* `HEART (BPM)` - Your current heart rate
+* `Max BPM` - Your maximum heart rate reached during the run
 * `STEPS` - Steps since you started exercising
 * `CADENCE` - Steps per second based on your step rate *over the last minute*
 * `GPS` - this is green if you have a GPS lock. GPS is turned on automatically
@@ -35,7 +36,7 @@ Under `Settings` -> `App` -> `Run` you can change settings for this app.
 record GPS/HRM/etc data every time you start a run?
 * `Pace` is the distance that pace should be shown over - 1km, 1 mile, 1/2 Marathon or 1 Marathon
 * `Boxes` leads to a submenu where you can configure what is shown in each of the 6 boxes on the display.
- Available stats are "Time", "Distance", "Steps", "Heart (BPM)", "Pace (avg)", "Pace (curr)", "Speed", and "Cadence".
+ Available stats are "Time", "Distance", "Steps", "Heart (BPM)", "Max BPM", "Pace (avg)", "Pace (curr)", "Speed", and "Cadence".
  Any box set to "-" will display no information.
     * Box 1 is the top left (defaults to "Distance")
     * Box 2 is the top right (defaults to "Time")

--- a/modules/exstats.js
+++ b/modules/exstats.js
@@ -15,6 +15,7 @@ print(ExStats.getList());
   {name: "Distance", id:"dist"},
   {name: "Steps", id:"step"},
   {name: "Heart (BPM)", id:"bpm"},
+  {name: "Max BPM", id:"maxbpm"},
   {name: "Pace (avr)", id:"pacea"},
   {name: "Pace (current)", id:"pacec"},
   {name: "Cadence", id:"caden"},
@@ -72,6 +73,7 @@ var state = {
   // cadence // steps per minute adjusted if <1 minute
   // BPM // beats per minute
   // BPMage // how many seconds was BPM set?
+  // maxBPM // The highest BPM reached while active
   // Notifies: 0 for disabled, otherwise how often to notify in meters, seconds, or steps
   notify: {
       dist: {
@@ -159,6 +161,10 @@ Bangle.on("HRM", function(h) {
   if (h.confidence>=60) {
     state.BPM = h.bpm;
     state.BPMage = 0;
+    if (state.maxBPM < h.bpm) {
+      state.maxBPM = h.bpm;
+      if (stats["maxbpm"]) stats["maxbpm"].emit("changed",stats["maxbpm"]);
+    }
     if (stats["bpm"]) stats["bpm"].emit("changed",stats["bpm"]);
   }
 });
@@ -170,6 +176,7 @@ exports.getList = function() {
     {name: "Distance", id:"dist"},
     {name: "Steps", id:"step"},
     {name: "Heart (BPM)", id:"bpm"},
+    {name: "Max BPM", id:"maxbpm"},
     {name: "Pace (avg)", id:"pacea"},
     {name: "Pace (curr)", id:"pacec"},
     {name: "Speed", id:"speed"},
@@ -228,6 +235,14 @@ exports.getStats = function(statIDs, options) {
       title : "BPM",
       getValue : function() { return state.BPM; },
       getString : function() { return state.BPM||"--" },
+    };
+  }
+  if (statIDs.includes("bpm")) {
+    needHRM = true;
+    stats["maxbpm"]={
+      title : "Max BPM",
+      getValue : function() { return state.maxBPM; },
+      getString : function() { return state.maxBPM||"--" },
     };
   }
   if (statIDs.includes("pacea")) {
@@ -299,6 +314,7 @@ exports.getStats = function(statIDs, options) {
     state.curSpeed = 0;
     state.BPM = 0;
     state.BPMage = 0;
+    state.maxBPM = 0;
     state.notify = options.notify;
     if (options.notify.dist.increment > 0) {
       state.notify.dist.next = state.distance + options.notify.dist.increment;

--- a/modules/exstats.js
+++ b/modules/exstats.js
@@ -237,7 +237,7 @@ exports.getStats = function(statIDs, options) {
       getString : function() { return state.BPM||"--" },
     };
   }
-  if (statIDs.includes("bpm")) {
+  if (statIDs.includes("maxbpm")) {
     needHRM = true;
     stats["maxbpm"]={
       title : "Max BPM",


### PR DESCRIPTION
This has `exstats` keep track of the maximum BPM reached while active and emit a `changed` event every time it goes up. `run` makes this one of the options available to put in a box.