### PR TITLE
Added Norwegian Nynorsk translation

### DIFF
--- a/apps/fuzzyw/fuzzy_strings.json
+++ b/apps/fuzzyw/fuzzy_strings.json
@@ -114,6 +114,29 @@
     ],
     "text_scale":3.5
   },
+  "nn_NO":{
+    "hours":[
+      "tolv", "eitt", "to", "tre", "fire", "fem",
+      "seks", "sju", "åtte", "ni", "ti", "elleve",
+      "tolv", "eitt", "to", "tre", "fire", "fem",
+      "seks", "sju", "åtte", "ni", "ti", "elleve"
+    ],
+    "minutes":[
+      "klokka er *$1",
+      "fem over *$1",
+      "ti over *$1",
+      "kvart over *$1",
+      "ti på halv *$2",
+      "fem på halv *$2",
+      "halv *$2",
+      "fem over halv *$2",
+      "ti over halv *$2",
+      "kvart på *$2",
+      "ti på *$2",
+      "fem på *$2"
+    ],
+    "text_scale":3.5
+  },
   "sv_SE":{
     "hours":[
       "tolv", "ett", "två", "tre", "fyra", "fem",

--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -684,6 +684,24 @@ var locales = {
     day: "Pirmdiena,Otrdiena,Trešdiena,Ceturtdiena,Piektdiena,Sestdiena,Svētdiena",
     trans: { yes: "jā", Yes: "Jā", no: "nē", No: "Nē", ok: "labi", on: "Ieslēgt", off: "Izslēgt", "< Back": "< Atpakaļ" }
   },
+    "nn_NO": { // Using charfallbacks
+        lang: "nn_NO",
+        decimal_point: ",",
+        thousands_sep: " ",
+        currency_symbol: "kr",
+        int_curr_symbol: "NOK",
+        speed: "kmh",
+        distance: { 0: "m", 1: "km" },
+        temperature: "°C",
+        ampm: { 0: "", 1: "" },
+        timePattern: { 0: "%HH:%MM:%SS", 1: "%HH:%MM" },
+        datePattern: { 0: "%d. %b %Y", "1": "%d.%m.%Y" }, // 1. Mar 2020 // 01.03.20
+        abmonth: "Jan,Feb,Mar,Apr,Mai,Jun,Jul,Aug,Sep,Okt,Nov,Des",
+        month: "Januar,Februar,Mars,April,Mai,Juni,Juli,August,September,Oktober,November,Desember",
+        abday: "Su,Må,Ty,On,To,Fr,La",
+        day: "Sundag,Måndag,Tysdag,Onsdag,Torsdag,Fredag,Laurdag",
+        trans: { yes: "ja", Yes: "Ja", no: "nei", No: "Nei", ok: "ok", on: "på", off: "av", "< Back": "< Tilbake", "Delete": "Slett", "Mark Unread": "Merk som ulesen" }
+    },
     "no_NB": { // Using charfallbacks
       lang: "no_NB",
       decimal_point: ",",


### PR DESCRIPTION
Norway has two written languages, Bokmål and Nynorsk. This adds the Nynorsk variant.

I was uncertain which language code to use.

nn_NO is the POSIX identifier, used in Linux et.al. so this pull request uses that, however as mentioned in https://github.com/espruino/BangleApps/pull/1665 the language code that has been used for Norwegian Bokmål is "no_NB" (ie. the other way around, country_LANGUAGE rather than language_COUNTRY). Browsers similarly use "nn-NO" for nynorsk, and "nb-NO" for bokmål.