### PR TITLE
sched: Fix `getTimeToAlarm` for timers

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Fix scheduling of other alarms if there is a pending alarm from the past (fix #1667)
+0.03: Fix `getTimeToAlarm` for a timer already used at same day, don't set `last` for timers. 

--- a/apps/sched/README.md
+++ b/apps/sched/README.md
@@ -34,7 +34,7 @@ Alarms are stored in an array in `sched.json`, and take the form:
   date : "2022-04-04", // OPTIONAL date for the alarm, in YYYY-MM-DD format
                        // eg (new Date()).toISOString().substr(0,10)
   msg : "Eat food",    // message to display.
-  last : 0,            // last day of the month we alarmed on - so we don't alarm twice in one day!
+  last : 0,            // last day of the month we alarmed on - so we don't alarm twice in one day! (No change from 0 on timers)
   rp : true,           // repeat the alarm every day?
   vibrate : "...",     // OPTIONAL pattern of '.', '-' and ' ' to use for when buzzing out this alarm (defaults to '..' if not set)
   hidden : false,      // OPTIONAL if false, the widget should not show an icon for this alarm

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -33,7 +33,7 @@ exports.setAlarm = function(id, alarm) {
   }
   exports.setAlarms(alarms);
 };
-/// Get time until the given alarm (object). Return undefined if alarm not enabled, or if 86400000 or more, alarm could me *more* than a day in the future
+/// Get time until the given alarm (object). Return undefined if alarm not enabled, or if 86400000 or more, alarm could be *more* than a day in the future
 exports.getTimeToAlarm = function(alarm, time) {
   if (!alarm) return undefined;
   if (!time) time = new Date();

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -40,7 +40,7 @@ function showAlarm(alarm) {
       if(alarm.ot===undefined) alarm.ot = alarm.t;
       alarm.t += 10*60*1000; // 10 minutes
     } else {
-      alarm.last = (new Date()).getDate();
+      if (!alarm.timer) alarm.last = (new Date()).getDate();
       if (alarm.ot!==undefined) {
           alarm.t = alarm.ot;
           delete alarm.ot;


### PR DESCRIPTION
Only set `last` for alarms to prevent a wrong output of `getTimeToAlarm` for a timer already used at same day.