### PR TITLE
sched: `getTimeToAlarm` check next dow if t<now

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Fix scheduling of other alarms if there is a pending alarm from the past (fix #1667)
 0.03: Fix `getTimeToAlarm` for a timer already used at same day, don't set `last` for timers. 
+0.04: Fix `getTimeToAlarm` to check for next dow if alarm.t lower currentTime.

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -37,9 +37,9 @@ exports.setAlarm = function(id, alarm) {
 exports.getTimeToAlarm = function(alarm, time) {
   if (!alarm) return undefined;
   if (!time) time = new Date();
-  var active = alarm.on && (alarm.dow>>time.getDay())&1 && (!alarm.date || alarm.date==time.toISOString().substr(0,10));
-  if (!active) return undefined;
   var currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000);
+  var active = alarm.on && (alarm.dow>>(time.getDay()+(alarm.t<currentTime)))&1 && (!alarm.date || alarm.date==time.toISOString().substr(0,10));
+  if (!active) return undefined;
   var t = alarm.t-currentTime;
   if (alarm.last == time.getDate() || t < -60000) t += 86400000;
   return t;

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -38,7 +38,7 @@ exports.getTimeToAlarm = function(alarm, time) {
   if (!alarm) return undefined;
   if (!time) time = new Date();
   var currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000);
-  var active = alarm.on && (alarm.dow>>(time.getDay()+(alarm.t<currentTime)))&1 && (!alarm.date || alarm.date==time.toISOString().substr(0,10));
+  var active = alarm.on && (alarm.dow>>((time.getDay()+(alarm.t<currentTime))%7))&1 && (!alarm.date || alarm.date==time.toISOString().substr(0,10));
   if (!active) return undefined;
   var t = alarm.t-currentTime;
   if (alarm.last == time.getDate() || t < -60000) t += 86400000;

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
Fix undefined output of `getTimeToAlarm` on an alarm that is already in the past to check for the next dow instead of the actual dow.
 - if alarm.t < currentTime, (time.getDay() + 1) % 7