### PR TITLE
Update apps/kbswipe/lib.js (Swipe keyboard)

### DIFF
--- a/apps/kbswipe/ChangeLog
+++ b/apps/kbswipe/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Now keeps user input trace intact by changing how the screen is updated.

--- a/apps/kbswipe/lib.js
+++ b/apps/kbswipe/lib.js
@@ -45,11 +45,39 @@ exports.getStrokes( (id,s) => Bangle.strokes[id] = Unistroke.new(s) );
 
   var flashToggle = false;
   const R = Bangle.appRect;
+  var Rx1;
+  var Rx2;
+  var Ry1;
+  var Ry2;
+
+  function findMarker(strArr) {
+    if (strArr.length == 0) {
+      Rx1 = 4;
+      Rx2 = 6*4;
+      Ry1 = 8*4;
+      Ry2 = 8*4 + 3;
+    } else if (strArr.length <= 4) {
+      Rx1 = (strArr[strArr.length-1].length)%7*6*4 + 4 ;
+      Rx2 = (strArr[strArr.length-1].length)%7*6*4 + 6*4;
+      Ry1 = (strArr.length)*(8*4) + Math.floor((strArr[strArr.length-1].length)/7)*(8*4);
+      Ry2 = (strArr.length)*(8*4) + Math.floor((strArr[strArr.length-1].length)/7)*(8*4) + 3;
+    } else {
+      Rx1 = (strArr[strArr.length-1].length)%7*6*4 + 4 ;
+      Rx2 = (strArr[strArr.length-1].length)%7*6*4 + 6*4;
+      Ry1 = (4)*(8*4) + Math.floor((strArr[strArr.length-1].length)/7)*(8*4);
+      Ry2 = (4)*(8*4) + Math.floor((strArr[strArr.length-1].length)/7)*(8*4) + 3;
+    }
+    //print(Rx1,Rx2,Ry1, Ry2);
+    return {x:Rx1,y:Ry1,x2:Rx2,y2:Ry2};
+  }
 
   function draw(noclear) {
     g.reset();
-    if (!noclear) g.clearRect(R);
-    var l = g.setFont("6x8:4").wrapString(text+(flashToggle?"_":" "), R.w-8);
+    var l = g.setFont("6x8:4").wrapString(text+' ', R.w-8);
+    if (!l) l = [];
+    //print(text+':');
+    //print(l);
+    if (!noclear) (flashToggle?(g.fillRect(findMarker(l))):(g.clearRect(findMarker(l))));
     if (l.length>4) l=l.slice(-4);
     g.drawString(l.join("\n"),R.x+4,R.y+4);
   }
@@ -80,6 +108,7 @@ exports.getStrokes( (id,s) => Bangle.strokes[id] = Unistroke.new(s) );
       var ch = o.stroke;
       if (ch=="\b") text = text.slice(0,-1);
       else text += ch;
+    g.clearRect(R);
     }
     flashToggle = true;
     draw();
@@ -87,7 +116,7 @@ exports.getStrokes( (id,s) => Bangle.strokes[id] = Unistroke.new(s) );
   Bangle.on('stroke',strokeHandler);
   g.reset().clearRect(R);
   show();
-  draw(true);
+  draw(false);
   var flashInterval;
 
   return new Promise((resolve,reject) => {

--- a/apps/kbswipe/metadata.json
+++ b/apps/kbswipe/metadata.json
@@ -1,6 +1,6 @@
 { "id": "kbswipe",
   "name": "Swipe keyboard",
-  "version":"0.01",
+  "version":"0.02",
   "description": "A library for text input via PalmOS style swipe gestures (beta!)",
   "icon": "app.png",
   "type":"textinput",


### PR DESCRIPTION
@gfwilliams

Change the way the display is updated as to keep user input trace intact until they lift their finger from the screen. 

Now only the marker is updated every second as opposed to the whole screen. To achieve this the marker is reimplemented outside the wrapString-method with g.fillRect() and g.clearRect() as well as a newly introduced function findMarker().