### PR TITLE
[dtlaunch, b2] Change swipe direction to UpDown

### DIFF
--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -9,4 +9,4 @@
 0.09: fix the trasparent widget bar if there are no widgets for Bangle 2
 0.10: added "one click exit" setting  for Bangle 2
 0.11: Fix bangle.js 1 white icons not displaying
-0.12: Change to swiping up/down to move between pages to match page indicator. Swiping from left to right now loads the clock.
+0.12: Change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.

--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -9,4 +9,4 @@
 0.09: fix the trasparent widget bar if there are no widgets for Bangle 2
 0.10: added "one click exit" setting  for Bangle 2
 0.11: Fix bangle.js 1 white icons not displaying
-0.12: Change to swiping up/down to move between pages. Swiping left-to-right now loads the clock.
+0.12: Change to swiping up/down to move between pages to match page indicator. Swiping from left to right now loads the clock.

--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -9,3 +9,4 @@
 0.09: fix the trasparent widget bar if there are no widgets for Bangle 2
 0.10: added "one click exit" setting  for Bangle 2
 0.11: Fix bangle.js 1 white icons not displaying
+0.12: Change to swiping up/down to move between pages. Swiping left-to-right now loads the clock.

--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -9,4 +9,4 @@
 0.09: fix the trasparent widget bar if there are no widgets for Bangle 2
 0.10: added "one click exit" setting  for Bangle 2
 0.11: Fix bangle.js 1 white icons not displaying
-0.12: Change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.
+0.12: On Bangle 2 change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.

--- a/apps/dtlaunch/app-b2.js
+++ b/apps/dtlaunch/app-b2.js
@@ -85,17 +85,24 @@ function drawPage(p){
     g.flip();
 }
 
-Bangle.on("swipe",(dir)=>{
+Bangle.on("swipe",(dirLeftRight, dirUpDown)=>{
     selected = 0;
     oldselected=-1;
-    if (dir<0){
+    if (dirUpDown==-1){
         ++page; if (page>maxPage) page=0;
         drawPage(page);
-    } else {
+    } else if (dirUpDown==1){
         --page; if (page<0) page=maxPage;
         drawPage(page);
-    }  
+    }
+    if (dirLeftRight==1) showClock();
 });
+
+function showClock(){
+  var app = require("Storage").readJSON('setting.json', 1).clock;
+  if (app) load(app);
+  else E.showMessage("clock\nnot found");
+}
 
 function isTouched(p,n){
     if (n<0 || n>3) return false;

--- a/apps/dtlaunch/metadata.json
+++ b/apps/dtlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "dtlaunch",
   "name": "Desktop Launcher",
-  "version": "0.11",
+  "version": "0.12",
   "description": "Desktop style App Launcher with six (four for Bangle 2) apps per page - fast access if you have lots of apps installed.",
   "screenshots": [{"url":"shot1.png"},{"url":"shot2.png"},{"url":"shot3.png"}],
   "icon": "icon.png",


### PR DESCRIPTION
@jeffmer

On bangle 2 change swipe directions to move between pages from **_LeftRight_** to **_UpDown_**, as to match the page indicators. Implemented like 'natural scrolling'.

Also added function **_showClock()_** which is called on **_'left-to-right' swipe_**.  Here I imagine the clock to be to the left of the launcher, if you do that then this also follows the natural scrolling principle.