### PR TITLE
Allow quiet mode to optionally override message auto-open

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -44,3 +44,4 @@
 0.29: Fix message list overwrites on Bangle.js 1 (fix #1642)
 0.30: Add new Icons (Youtube, Twitch, MS TODO, Teams, Snapchat, Signal, Post & DHL, Nina, Lieferando, Kalender, Discord, Corona Warn, Bibel)
 0.31: Option to disable icon flashing
+0.32: Added an option to allow quiet mode to override message auto-open

--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -56,9 +56,16 @@ exports.pushMessage = function(event) {
   }
   // otherwise load messages/show widget
   var loadMessages = Bangle.CLOCK || event.important;
-  // first, buzz
   var quiet       = (require('Storage').readJSON('setting.json',1)||{}).quiet;
-  var unlockWatch = (require('Storage').readJSON('messages.settings.json',1)||{}).unlockWatch;
+  var appSettings = require('Storage').readJSON('messages.settings.json',1)||{};
+  var unlockWatch = appSettings.unlockWatch;
+  var quietNoAutOpn = appSettings.quietNoAutOpn;
+  delete appSettings;
+  // don't auto-open messages in quiet mode if quietNoAutOpn is true
+  if(quiet && quietNoAutOpn) {
+      loadMessages = false;
+  }
+  // first, buzz
   if (!quiet && loadMessages && global.WIDGETS && WIDGETS.messages){
       WIDGETS.messages.buzz();
       if(unlockWatch != false){

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.31",
+  "version": "0.32",
   "description": "App to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messages/settings.js
+++ b/apps/messages/settings.js
@@ -53,6 +53,11 @@
       format: v => v?/*LANG*/'Yes':/*LANG*/'No',
       onchange: v => updateSetting("flash", v)
     },
+    /*LANG*/'Quiet mode disables auto-open': {
+      value: !!settings().quietNoAutOpn,
+      format: v => v?/*LANG*/'Yes':/*LANG*/'No',
+      onchange: v => updateSetting("quietNoAutOpn", v)
+    },
   };
   E.showMenu(mainmenu);
 })


### PR DESCRIPTION
The messages app will auto-open messages (but not buzz) even when the watch is in quiet mode. This adds a setting that disables this behaviour.