### PR TITLE
Allow timeouts to run on the message list screen

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -45,3 +45,4 @@
 0.30: Add new Icons (Youtube, Twitch, MS TODO, Teams, Snapchat, Signal, Post & DHL, Nina, Lieferando, Kalender, Discord, Corona Warn, Bibel)
 0.31: Option to disable icon flashing
 0.32: Added an option to allow quiet mode to override message auto-open
+0.33: Timeout from the message list screen if the message being displayed is removed and there is a timer going

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -470,8 +470,6 @@ function checkMessages(options) {
   // no new messages - go to clock?
   if (options.clockIfAllRead && newMessages.length==0)
     return load();
-  // we don't have to time out of this screen...
-  cancelReloadTimeout();
   active = "main";
   // Otherwise show a menu
   E.showScroller({

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.32",
+  "version": "0.33",
   "description": "App to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
Currently, when a new message is delivered, the messages app starts a timeout timer that returns to the clock after a while. If the message being displayed is removed without user interaction (for instance by the user dismissing a notification on their phone), the app returns to the message list and stops the timer. The result is that if a message is received and then before the timeout is dismissed on the phone, the device will permanently display the message list until the user manually returns to the clock.

This change lets the timer keep on running as long as the user doesn't interact with the screen, restoring the clock as usual.

One possible improvement to this change (that I haven't attempted to write) could be to clear the timeout if the screen gets unlocked by the user while on the messages screen.