### PR TITLE
[Sched] Correct decodeTime(t) rounding

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Fix `getTimeToAlarm` to check for next dow if alarm.t lower currentTime.
 0.05: Export new functions (`newDefaultAlarm/Timer`), add Settings page
 0.06: Refactor some methods to library
+0.07: Correct `decodeTime(t)` to return a more likely expected time

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -112,7 +112,7 @@ exports.setSettings = function(settings) {
 exports.decodeTime = function(t) {
   t = Math.ceil(t / 60000); // sanitise to full minutes
   let hrs = 0 | (t / 60);
-  return { hrs: hrs, mins: t - hrs * 60;
+  return { hrs: hrs, mins: t - hrs * 60 };
 }
 
 // time in { hrs, mins } -> ms

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -110,9 +110,9 @@ exports.setSettings = function(settings) {
 
 // time in ms -> { hrs, mins }
 exports.decodeTime = function(t) {
-  t = 0 | t; // sanitise
-  let hrs = 0 | (t / 3600000);
-  return { hrs: hrs, mins: Math.round((t - hrs * 3600000) / 60000) };
+  t = Math.ceil(t / 60000); // sanitise to full minutes
+  let hrs = 0 | (t / 60);
+  return { hrs: hrs, mins: t - hrs * 60;
 }
 
 // time in { hrs, mins } -> ms

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
Correct `decodeTime(t)` to return a more likely expected time:
- before:  
  ```
  >require("sched").decodeTime(60*60*1000-1)
  ={ hrs: 0, mins: 60 }
  ```
- after:   
  ```
  >require("sched").decodeTime(60*60*1000-1)
  ={ hrs: 1, mins: 0 }
  ```