### PR TITLE
[AppLoader] New categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,11 +75,14 @@
         <div class="filter-nav">
           <label class="chip active" filterid="">Default</label>
           <label class="chip" filterid="clock">Clocks</label>
+          <label class="chip" filterid="launch">Launchers</label>
           <label class="chip" filterid="game">Games</label>
           <label class="chip" filterid="tool">Tools</label>
+          <label class="chip" filterid="textinput">Keyboards</label>
           <label class="chip" filterid="widget">Widgets</label>
           <label class="chip" filterid="bluetooth">Bluetooth</label>
           <label class="chip" filterid="outdoors">Outdoors</label>
+          <label class="chip" filterid="ram">Apps Without Installation</label>
           <label class="chip" filterid="favourites">Favourites</label>
         </div>
         <div class="sort-nav hidden">


### PR DESCRIPTION
This PR adds 3 new categories to the app loader:

![image](https://user-images.githubusercontent.com/2331798/164945661-d9be9523-eb58-49a3-b4f2-b4acfa3b9765.png)

Not sure about the label for "Apps Without Installations" (aka: apps with `type: RAM`) - does anyone have a better name?

---

Companion PR: https://github.com/espruino/EspruinoAppLoaderCore/pull/20
