### PR TITLE
after 2v14 release: [Scheduler] UI improvements

### DIFF
--- a/apps/sched/settings.js
+++ b/apps/sched/settings.js
@@ -4,11 +4,10 @@
   E.showMenu({
     "": { "title": /*LANG*/"Scheduler" },
 
-    /*LANG*/"< Back": () => back(),
+    "< Back": () => back(),
 
     /*LANG*/"Unlock at Buzz": {
       value: settings.unlockAtBuzz,
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => {
         settings.unlockAtBuzz = v;
         require("sched").setSettings(settings);
@@ -17,7 +16,6 @@
 
     /*LANG*/"Default Auto Snooze": {
       value: settings.defaultAutoSnooze,
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => {
         settings.defaultAutoSnooze = v;
         require("sched").setSettings(settings);
@@ -38,7 +36,6 @@
 
     /*LANG*/"Default Repeat": {
       value: settings.defaultRepeat,
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => {
         settings.defaultRepeat = v;
         require("sched").setSettings(settings);


### PR DESCRIPTION
This PR removes the custom boolean formatter since the new menu system handles the booleans better.

![image](https://user-images.githubusercontent.com/2331798/165163854-eb1bdb46-acf2-4bdc-8653-1960a6dc2209.png)
