### PR TITLE
[locale] dow/dowAll

### DIFF
--- a/apps/locale/ChangeLog
+++ b/apps/locale/ChangeLog
@@ -19,3 +19,4 @@
 0.16: Remove global variables that used RAM
       Add second 'dp' argument for decimal places in distance/speed/temp (fix #1523)
 0.17: Fix regression where long month names were 'undefined' (fix #1641)
+0.18: Add function dowAll(), update function dow()

--- a/apps/locale/README.md
+++ b/apps/locale/README.md
@@ -1,25 +1,34 @@
-# Languages (locale)
+Languages (locale)
+==================
 
 Country-specific app internationalisation.
 
 This is not an app, but instead it is a library that can be used by
-other applications or widgets to display messages.
+other applications or widgets to provide locale-friendly
 
-## Usage
+- Dates
+- Time (12h/24h)
+- Days of the Week
+- Months
+- Currency values
+- Distances/Lengths/Speed (metric/imperial)
+- Temperature (°C/°F)
 
-Some menus that pop up are translated automatically, but if you're
-writing an application you can use the `locale` library to
+Usage
+-----
+
+If you're writing an application you can use the `locale` library to
 do all the translation for you.
 
 See https://www.espruino.com/Bangle.js+Locale for full examples.
 
 ```JS
 // Date to date string (long)
->require('locale').date(new Date())
+>require("locale").date(new Date())
 ="Donnerstag, 02. April 2020"
 
 // Date to date string (short)
->require('locale').date(new Date(),1)
+>require("locale").date(new Date(), 1)
 ="02.04.2020"
 ```
 

--- a/apps/locale/locale.html
+++ b/apps/locale/locale.html
@@ -198,7 +198,8 @@ function getHours(d) {
 exports = {
   name: ${js(locale.lang)},
   currencySym: ${js(locale.currency_symbol)},
-  dow: (d,short) => ${js(locale.day + ',' + locale.abday)}.split(',')[d.getDay() + (short ? 7 : 0)],
+  dow: (d,short) => ${js(locale.day + ',' + locale.abday + ',' + locale.abday.split(',').map(e => e.charAt(0).toUpperCase()).join(','))}.split(',')[d.getDay() + ((short || 0) * 7)],
+  dowAll: (short) => ${js(locale.day + ',' + locale.abday + ',' + locale.abday.split(',').map(e => e.charAt(0).toUpperCase()).join(','))}.split(',').slice((short || 0) * 7, ((short || 0) + 1) * 7),
   month: (d,short) => ${js(locale.month + ',' + locale.abmonth)}.split(',')[d.getMonth() + (short ? 12 : 0)],
   number: (n, dec) => {
     if (dec == null) dec = 2;

--- a/apps/locale/metadata.json
+++ b/apps/locale/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "locale",
   "name": "Languages",
-  "version": "0.17",
+  "version": "0.18",
   "description": "Translations for different countries",
   "icon": "locale.png",
   "type": "locale",


### PR DESCRIPTION
This PR adds a new function `dowAll` to the `locale` module. It returns *all* the days of the week in 3 versions: long, short, first char only.

The PR also updates the `dow` function to add the _first char only_ version. 