### PR TITLE
settings: Add some Bangle 1 colours to theme customizer

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -45,3 +45,4 @@
 0.40: Moved off into Utils, put System after Apps
 0.41: Stop users disabling all wake-up methods and locking themselves out (fix #1272)
 0.42: Fix theme customizer on new Bangle 2 firmware
+0.43: Add some Bangle 1 colours to theme customizer

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.42",
+  "version": "0.43",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -251,11 +251,15 @@ function showThemeMenu() {
       }
       upd(th);
     }
-    const rgb = {
+    let rgb = {
       black: "#000", white: "#fff",
       red: "#f00", green: "#0f0", blue: "#00f",
       cyan: "#0ff", magenta: "#f0f", yellow: "#ff0",
     };
+    if (!BANGLEJS2) Object.assign(rgb, {
+      // these would cause dithering, which is not great for e.g. text
+      orange: "#ff7f00", purple: "#7f00ff", grey: "#7f7f7f",
+    });
     let colors = [], names = [];
     for(const c in rgb) {
       names.push(c);


### PR DESCRIPTION
Orange, purple and grey seemed distinct enough to be nice additions

(Just in time for [King's Day](https://en.wikipedia.org/wiki/Koningsdag) ;-)