### PR TITLE
Fix backup when event listeners are active

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -9,6 +9,7 @@ function bangleDownload() {
   console.log("Listing normal files...");
   Comms.reset()
   .then(() => Comms.showMessage("Backing up..."))
+  .then(() => Comms.write("\x10Bangle.removeAllListeners()\n"))
   .then(() => Comms.listFiles({sf:false}))
   .then(f => {
     normalFiles = f;


### PR DESCRIPTION
I noticed that the backup script stopped running for me. 
Further analysis showed that the event `Bangle.on('accel', ...)` was the cause.

Excerpt from the Debug.Log:
```
<BLE> Sending "\nfor (var i=0;i<s.length;i+=384) Bluetooth.print(btoa(s.substr(i,384)));\nBluetooth.print(\"ÿ\");\n})()\n"
puck.js:406 <BLE> Received "Execution Interrupted during event processing.\r\n"
puck.js:406 <BLE> Sent
comms.js:435 <COMMS> readTextBlock read started...
puck.js:406 <BLE> Received "416\r\nKKooKXujKCFCYW5nbGUuaXNMb2NrZWQpqztCYW5nbGUub24oImxvY2siLKoob24pe1dJREdFVFNbImxvY2siXS53aWR0aD1CYW5nbGUuaXNMb2NrZWQoKT8xNjo"
puck.js:406 <BLE> Received "wO0JhbmdsZS5kcmF3V2lkZ2V0cygpO30pO1dJREdFVFNbImxvY2siXT17YXJlYToidGwiLHNvcnRvcmRlcjoxMCx3aWR0aDpCYW5nbGUuaXNMb2NrZWQoKT8xNjowLGR"
puck.js:406 <BLE> Received "yYXc6qih3KXujKEJhbmdsZS5pc0xvY2tlZCgpKWcucmVzZXQoKS5kcmF3SW1hZ2UoYXRvYigiRGhBQkgrRC93d01NRERBd3dNZi92Ly80ZitIL2gvOC8vUC96Ly8vZi9"
puck.js:406 <BLE> Received "nPT0iKSx3LngrMSx3LnkrNCk7fX07fSkoKQ==ÿ"
ui.js:86 <TOAST>[error] Backup failed, InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.
```
the line `puck.js:406 <BLE> Received "Execution Interrupted during event processing.\r\n"` causes an error in the calculation of the file length.

You can reproduce it if you install the `sleeplog` app and move your wrist a little while backing up.

Removing all listeners solves the problem for me.

Perhaps there is also a more elegant way?