### PR TITLE
[alarm] Fix redrawing entry inside its submenu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/Layout/bin/tmp.*
 tests/Layout/testresult.bmp
 apps.local.json
 _site
+._sync_*.db*

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ tests/Layout/bin/tmp.*
 tests/Layout/testresult.bmp
 apps.local.json
 _site
-._sync_*.db*

--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -24,3 +24,4 @@
 0.23: Fix regression with Days of Week (#1735)
 0.24: Automatically save the alarm/timer when the user returns to the main menu using the back arrow
       Add "Enable All", "Disable All" and "Remove All" actions
+0.25: Fix redrawing selected Alarm/Timer entry inside edit submenu

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -45,7 +45,7 @@ function showMainMenu() {
     } else txt = type+txt;
     // add to menu
     menu[txt] = {
-      value : alarm.on,
+      value : "\0"+atob(alarm.on?"EhKBAH//v/////////////5//x//j//H+eP+Mf/A//h//z//////////3//g":"EhKBAH//v//8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA///3//g"),
       onchange : function() {
         setTimeout(alarm.timer ? editTimer : editAlarm, 10, idx, alarm);
       }
@@ -75,6 +75,7 @@ function editDOW(dow, onchange) {
     let dayOfWeek = require("locale").dow({ getDay: () => i });
     menu[dayOfWeek] = {
       value: !!(dow&(1<<i)),
+      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => v ? dow |= 1<<i : dow &= ~(1<<i),
     };
   })(i);
@@ -104,10 +105,12 @@ function editAlarm(alarmIndex, alarm) {
     },
     /*LANG*/'Enabled': {
       value: a.on,
+      format: v => v ? /*LANG*/"On" : /*LANG*/"Off",
       onchange: v=>a.on=v
     },
     /*LANG*/'Repeat': {
       value: a.rp,
+      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => a.rp = v
     },
     /*LANG*/'Days': {
@@ -121,6 +124,7 @@ function editAlarm(alarmIndex, alarm) {
     /*LANG*/'Vibrate': require("buzz_menu").pattern(a.vibrate, v => a.vibrate=v ),
     /*LANG*/'Auto Snooze': {
       value: a.as,
+      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => a.as = v
     }
   };
@@ -174,6 +178,7 @@ function editTimer(alarmIndex, alarm) {
     },
     /*LANG*/'Enabled': {
       value: a.on,
+      format: v => v ? /*LANG*/"On" : /*LANG*/"Off",
       onchange: v => a.on = v
     },
     /*LANG*/'Vibrate': require("buzz_menu").pattern(a.vibrate, v => a.vibrate=v ),

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -112,7 +112,7 @@ function editAlarm(alarmIndex, alarm) {
     },
     /*LANG*/'Days': {
       value: "SMTWTFS".split("").map((d,n)=>a.dow&(1<<n)?d:".").join(""),
-      onchange: () => editDOW(a.dow, d => {
+      onchange: () => setTimeout(editDOW, 10, a.dow, d => {
         a.dow = d;
         a.t = require("sched").encodeTime(t);
         editAlarm(alarmIndex, a);

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -112,7 +112,7 @@ function editAlarm(alarmIndex, alarm) {
     },
     /*LANG*/'Days': {
       value: "SMTWTFS".split("").map((d,n)=>a.dow&(1<<n)?d:".").join(""),
-      onchange: () => setTimeout(editDOW, 10, a.dow, d => {
+      onchange: () => setTimeout(editDOW, 100, a.dow, d => {
         a.dow = d;
         a.t = require("sched").encodeTime(t);
         editAlarm(alarmIndex, a);

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -45,10 +45,9 @@ function showMainMenu() {
     } else txt = type+txt;
     // add to menu
     menu[txt] = {
-      value : "\0"+atob(alarm.on?"EhKBAH//v/////////////5//x//j//H+eP+Mf/A//h//z//////////3//g":"EhKBAH//v//8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA8AA///3//g"),
+      value : alarm.on,
       onchange : function() {
-        if (alarm.timer) editTimer(idx, alarm);
-        else editAlarm(idx, alarm);
+        setTimeout(alarm.timer ? editTimer : editAlarm, 10, idx, alarm);
       }
     };
   });
@@ -76,7 +75,6 @@ function editDOW(dow, onchange) {
     let dayOfWeek = require("locale").dow({ getDay: () => i });
     menu[dayOfWeek] = {
       value: !!(dow&(1<<i)),
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => v ? dow |= 1<<i : dow &= ~(1<<i),
     };
   })(i);
@@ -106,12 +104,10 @@ function editAlarm(alarmIndex, alarm) {
     },
     /*LANG*/'Enabled': {
       value: a.on,
-      format: v => v ? /*LANG*/"On" : /*LANG*/"Off",
       onchange: v=>a.on=v
     },
     /*LANG*/'Repeat': {
       value: a.rp,
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => a.rp = v
     },
     /*LANG*/'Days': {
@@ -125,7 +121,6 @@ function editAlarm(alarmIndex, alarm) {
     /*LANG*/'Vibrate': require("buzz_menu").pattern(a.vibrate, v => a.vibrate=v ),
     /*LANG*/'Auto Snooze': {
       value: a.as,
-      format: v => v ? /*LANG*/"Yes" : /*LANG*/"No",
       onchange: v => a.as = v
     }
   };
@@ -179,7 +174,6 @@ function editTimer(alarmIndex, alarm) {
     },
     /*LANG*/'Enabled': {
       value: a.on,
-      format: v => v ? /*LANG*/"On" : /*LANG*/"Off",
       onchange: v => a.on = v
     },
     /*LANG*/'Vibrate': require("buzz_menu").pattern(a.vibrate, v => a.vibrate=v ),

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.24",
+  "version": "0.25",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm,widget",


### PR DESCRIPTION
1. Fix redrawing selected Alarm/Timer entry inside its edit submenu through opening the menu after a short timeout.
2. Apply redrawing fix to dow submenu, too.
3. Removing the obsolete check-mark images.
4. Removing format on boolean values to use new check-marks.

---

5. Missed to ignore the _.gitignore_ file, should I remove the entry or can it stay?