### PR TITLE
stopwatch: Do not register as watch

### DIFF
--- a/apps/stopwatch/ChangeLog
+++ b/apps/stopwatch/ChangeLog
@@ -1,2 +1,3 @@
 0.01: first release
 0.02: Adjust for touch events outside of screen g dimensions
+0.03: Do not register as watch, manually start clock on button

--- a/apps/stopwatch/metadata.json
+++ b/apps/stopwatch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "stopwatch",
   "name": "Stopwatch Touch",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A touch based stop watch for Bangle JS 2",
   "icon": "stopwatch.png",
   "screenshots": [{"url":"screenshot1.png"},{"url":"screenshot2.png"},{"url":"screenshot3.png"}],

--- a/apps/stopwatch/stopwatch.app.js
+++ b/apps/stopwatch/stopwatch.app.js
@@ -227,4 +227,4 @@ g.fillRect(0,0,w,h);
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 draw();
-Bangle.setUI("clock"); // Show launcher when button pressed
+setWatch(() => load(), BTN, { repeat: false, edge: "falling" });


### PR DESCRIPTION
manually start clock on button, avoids conflict with quicklaunch which
otherwise believes that a clock is running and reacts on touch events

@hughbarney Are you ok with that?