### PR TITLE
[NotAnalog Clock] Use Bangle.getHealthStatus("day").steps as fallback if no widget is installed.

### DIFF
--- a/apps/notanalog/ChangeLog
+++ b/apps/notanalog/ChangeLog
@@ -2,3 +2,4 @@
 0.02: 12k steps are 360 degrees - improves readability of steps.
 0.03: Battery improvements through sleep (no minute updates) and partial updates of drawing.
 0.04: Use alarm for timer instead of own alarm implementation.
+0.05: Use internal step counter if no widget is available.

--- a/apps/notanalog/metadata.json
+++ b/apps/notanalog/metadata.json
@@ -3,7 +3,7 @@
   "name": "Not Analog",
   "shortName":"Not Analog",
   "icon": "notanalog.png",
-  "version":"0.04",
+  "version":"0.05",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "An analog watch face for people that can not read analog watch faces.",

--- a/apps/notanalog/notanalog.app.js
+++ b/apps/notanalog/notanalog.app.js
@@ -88,20 +88,22 @@ Graphics.prototype.setNormalFont = function(scale) {
 };
 
 
-
 function getSteps() {
+    var steps = 0;
     try{
         if (WIDGETS.wpedom !== undefined) {
-            return WIDGETS.wpedom.getSteps();
+            steps = WIDGETS.wpedom.getSteps();
         } else if (WIDGETS.activepedom !== undefined) {
-            return WIDGETS.activepedom.getSteps();
+            steps = WIDGETS.activepedom.getSteps();
+        } else {
+          steps = Bangle.getHealthStatus("day").steps;
         }
     } catch(ex) {
         // In case we failed, we can only show 0 steps.
     }
 
-    return 0;
-  }
+    return steps;
+}
 
 
 function drawBackground() {

--- a/apps/notanalog/notanalog.app.js
+++ b/apps/notanalog/notanalog.app.js
@@ -291,6 +291,9 @@ function drawSleep(){
 
 
 function draw(fastUpdate){
+    // Queue draw in one minute
+    queueDraw();
+
     // Execute handlers
     handleState(fastUpdate);
 
@@ -322,9 +325,6 @@ function draw(fastUpdate){
     drawState();
     drawTime();
     drawData();
-
-    // Queue draw in one minute
-    queueDraw();
 }
 
 


### PR DESCRIPTION
As Bangle.getHealthStatus("day").steps is available, it is now used as fallback if no widget is installed.