### PR TITLE
[Bordle] Fix bug in valid word detection

### DIFF
--- a/apps/bordle/ChangeLog
+++ b/apps/bordle/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App
 0.02: app keeps track of statistics now
+0.03: Fix bug in valid word detection

--- a/apps/bordle/bordle.app.js
+++ b/apps/bordle/bordle.app.js
@@ -110,7 +110,12 @@ class Wordle {
     }
   }
   addGuess(w) {
-    if ((this.words.indexOf(w.toLowerCase())%5)!=0) {
+    let idx = -1;
+    do{
+      idx = this.words.indexOf(w.toLowerCase(), idx+1);
+    }
+    while(idx !== -1 && idx%5 !== 0);
+    if(idx%5 !== 0) {
       E.showAlert(w+"\nis not a word", "Invalid word").then(function() { 
         layout = getKeyLayout("");
         wordle.render(true);

--- a/apps/bordle/metadata.json
+++ b/apps/bordle/metadata.json
@@ -2,7 +2,7 @@
   "name": "Bordle",
   "shortName":"Bordle",
   "icon": "app.png",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Bangle version of a popular word search game",
   "supports" : ["BANGLEJS2"],
   "readme": "README.md",


### PR DESCRIPTION
Update to @berkenbu's bordle app

The valid word detection did not account for the fact that a valid word
could exist twice in the list: once at a non-multiple-of-five index
because it is the end of one word and the start of another, and again at
a multiple-of-five index for the word itself. An example is aglow agony
contains wagon. This prevented wagon from being considered a valid word
(even though it could be selected as the target word).

This fix loops through all detections of the word in the dictionary to
see if any are at a multiple-of-five index.