### PR TITLE
Add 12h support, auto-cycle control to Rebble Clock

### DIFF
--- a/apps/rebble/ChangeLog
+++ b/apps/rebble/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Added dependancy on Pedometer Widget
 0.04: Fixed icon and png to 48x48 pixels
 0.05: added charging icon
+0.06: Add 12h support and autocycle control

--- a/apps/rebble/metadata.json
+++ b/apps/rebble/metadata.json
@@ -2,7 +2,7 @@
   "id": "rebble",
   "name": "Rebble Clock",
   "shortName": "Rebble",
-  "version": "0.05",
+  "version": "0.06",
   "description": "A Pebble style clock, with configurable background, three sidebars including steps, day, date, sunrise, sunset, long live the rebellion",
   "readme": "README.md",
   "icon": "rebble.png",

--- a/apps/rebble/rebble.app.js
+++ b/apps/rebble/rebble.app.js
@@ -35,7 +35,7 @@ function loadLocation() {
 }
 
 function loadSettings() {
-  settings = require("Storage").readJSON(SETTINGS_FILE,1)|| {'bg': '#0f0', 'color': 'Green'};
+  settings = require("Storage").readJSON(SETTINGS_FILE,1)|| {'bg': '#0f0', 'color': 'Green', 'autoCycle': true};
   is12Hour = (require("Storage").readJSON(GLOBAL_SETTINGS, 1) || {})["12hour"] || false;
 }
 

--- a/apps/rebble/rebble.app.js
+++ b/apps/rebble/rebble.app.js
@@ -1,8 +1,10 @@
 var SunCalc = require("https://raw.githubusercontent.com/mourner/suncalc/master/suncalc.js");
 const SETTINGS_FILE = "rebble.json";
 const LOCATION_FILE = "mylocation.json";
+const GLOBAL_SETTINGS = "setting.json";
 let settings;
 let location;
+let is12Hour;
 
 Graphics.prototype.setFontLECO1976Regular22 = function(scale) {
   // Actual height 22 (21 - 0)
@@ -34,11 +36,25 @@ function loadLocation() {
 
 function loadSettings() {
   settings = require("Storage").readJSON(SETTINGS_FILE,1)|| {'bg': '#0f0', 'color': 'Green'};
+  is12Hour = (require("Storage").readJSON(GLOBAL_SETTINGS, 1) || {})["12hour"] || false;
+}
+
+function formatHours(hh) {
+  if (is12Hour) {
+    let hours = parseInt(hh,10);
+    if (hours == 0) {
+      hours = 12;
+    } else if (hours >= 12) {
+      if (hours>12) hours -= 12;
+    }
+    hh = (" "+hours).substr(-2);
+  }
+  return hh;
 }
 
 function extractTime(d){
   var h = d.getHours(), m = d.getMinutes();
-  return(("0"+h).substr(-2) + ":" + ("0"+m).substr(-2));
+  return(formatHours(("0"+h).substr(-2)) + ":" + ("0"+m).substr(-2));
 }
 
 function updateSunRiseSunSet(lat, lon){
@@ -81,6 +97,9 @@ function draw() {
   let da = date.toString().split(" ");
   let hh = da[4].substr(0,2);
   let mm = da[4].substr(3,2);
+  
+  hh = formatHours(hh);
+  
   //const t = 6;
 
   if (drawCount % 60 == 0)
@@ -260,7 +279,9 @@ function queueDraw() {
   if (drawTimeout) clearTimeout(drawTimeout);
   drawTimeout = setTimeout(function() {
     drawTimeout = undefined;
-    nextSidebar();
+    if (!settings.autoCycle) {
+        nextSidebar();
+    }
     draw();
   }, 60000 - (Date.now() % 60000));
 }

--- a/apps/rebble/rebble.settings.js
+++ b/apps/rebble/rebble.settings.js
@@ -2,7 +2,7 @@
   const SETTINGS_FILE = "rebble.json";
 
   // initialize with default settings...
-  let s = {'bg': '#0f0', 'color': 'Green'}
+  let s = {'bg': '#0f0', 'color': 'Green', 'autoCycle': true}
 
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -33,6 +33,14 @@
         s.bg = bg_code[v];
         save();
       },
+    },
+    'Auto Cycle': {
+      value: "autoCycle" in s ? s.autoCycle : true,
+      format: () => (s.autoCycle ? 'Yes' : 'No'),
+      onchange: () => {
+        s.autoCycle = !s.autoCycle;
+        save();
+      }
     }
   });
 })

--- a/apps/rebble/rebble.settings.js
+++ b/apps/rebble/rebble.settings.js
@@ -2,19 +2,19 @@
   const SETTINGS_FILE = "rebble.json";
 
   // initialize with default settings...
-  let s = {'bg': '#0f0', 'color': 'Green', 'autoCycle': true}
+  let localSettings = {'bg': '#0f0', 'color': 'Green', 'autoCycle': true}
 
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
   const storage = require('Storage')
-  let settings = storage.readJSON(SETTINGS_FILE, 1) || s;
+  let settings = storage.readJSON(SETTINGS_FILE, 1) || localSettings;
   const saved = settings || {}
   for (const key in saved) {
-    s[key] = saved[key]
+    localSettings[key] = saved[key]
   }
 
   function save() {
-    settings = s
+    settings = localSettings
     storage.write(SETTINGS_FILE, settings)
   }
 
@@ -25,20 +25,20 @@
     '': { 'title': 'Rebble Clock' },
     '< Back': back,
     'Colour': {
-      value: 0 | color_options.indexOf(s.color),
+      value: 0 | color_options.indexOf(localSettings.color),
       min: 0, max: 5,
       format: v => color_options[v],
       onchange: v => {
-        s.color = color_options[v];
-        s.bg = bg_code[v];
+        localSettings.color = color_options[v];
+        localSettings.bg = bg_code[v];
         save();
       },
     },
     'Auto Cycle': {
-      value: "autoCycle" in s ? s.autoCycle : true,
-      format: () => (s.autoCycle ? 'Yes' : 'No'),
+      value: "autoCycle" in localSettings ? localSettings.autoCycle : true,
+      format: () => (localSettings.autoCycle ? 'Yes' : 'No'),
       onchange: () => {
-        s.autoCycle = !s.autoCycle;
+        localSettings.autoCycle = !localSettings.autoCycle;
         save();
       }
     }


### PR DESCRIPTION
I was annoyed by the lack of 12h support and the inability to turn off the auto-cycling of the right bar, so I added those features.

I also ran into a bug with the settings app where the 's' variable was being overwritten by something else which caused issues. It must be a global variable or is used internally somewhere. Because it was only used for one setting and immediately saved, the desired settings were always saved there successfully (sometimes along with other stuff from the global variable), but with a second setting the pervious settings could be lost. Changing it to 'localSettings' fixed it.