### PR TITLE
[dtlaunch]  Don't change page if doing swipe-to-exit

### DIFF
--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -11,3 +11,4 @@
 0.11: Fix bangle.js 1 white icons not displaying
 0.12: On Bangle 2 change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.
 0.13: Added swipeExit setting so that left-right to exit is an option
+0.14: Don't move pages when doing exit swipe.

--- a/apps/dtlaunch/README.md
+++ b/apps/dtlaunch/README.md
@@ -29,6 +29,6 @@ Bangle 2:
 
 **Touch** - icon to select, scond touch launches app
 
-**Swipe Left** -  move to next page of app icons
+**Swipe Left/Up** -  move to next page of app icons
 
-**Swipe Right** - move to previous page of app icons
+**Swipe Right/Down** - move to previous page of app icons

--- a/apps/dtlaunch/app-b2.js
+++ b/apps/dtlaunch/app-b2.js
@@ -93,7 +93,7 @@ Bangle.on("swipe",(dirLeftRight, dirUpDown)=>{
     if (dirUpDown==-1||dirLeftRight==-1){
         ++page; if (page>maxPage) page=0;
         drawPage(page);
-    } else if (dirUpDown==1||dirLeftRight==1){
+    } else if (dirUpDown==1||(dirLeftRight==1 && !settings.swipeExit)){
         --page; if (page<0) page=maxPage;
         drawPage(page);
     }

--- a/apps/dtlaunch/metadata.json
+++ b/apps/dtlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "dtlaunch",
   "name": "Desktop Launcher",
-  "version": "0.13",
+  "version": "0.14",
   "description": "Desktop style App Launcher with six (four for Bangle 2) apps per page - fast access if you have lots of apps installed.",
   "screenshots": [{"url":"shot1.png"},{"url":"shot2.png"},{"url":"shot3.png"}],
   "icon": "icon.png",


### PR DESCRIPTION
@jeffmer @hughbarney 

When doing a swipe to exit on v0.13 dtlaunch moves pages the instance before exiting. The changes in this PR (v0.14) makes it so that doesn't happen - but still respect left and right swipes when swipe to exit is turned off in settings.