### PR TITLE
[Alarms & Timers / Scheduler] Fix bug with alarms not firing when repeat is set to "once"

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -27,3 +27,4 @@
 0.25: Fix redrawing selected Alarm/Timer entry inside edit submenu
 0.26: Add support for Monday as first day of the week (#1780)
 0.27: New UI!
+0.28: Fix bug with alarms not firing when configured to fire only once

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.27",
+  "version": "0.28",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm,widget",

--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -6,6 +6,7 @@
 0.06: Refactor some methods to library
 0.07: Update settings
       Correct `decodeTime(t)` to return a more likely expected time
-0.08: add day of week check to getActiveAlarms()
+0.08: Add day of week check to getActiveAlarms()
 0.09: Move some functions to new time_utils module
 0.10: Default to sched.js if custom js not found
+0.11: Fix default dow

--- a/apps/sched/boot.js
+++ b/apps/sched/boot.js
@@ -8,12 +8,12 @@
   var time = new Date();
   var currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000);
   var d = time.getDate();
-  var active = alarms.filter(
-    a=>a.on &&  // enabled
-    a.last!=d && // not already fired today
-    a.t+60000>currentTime && // is not in the past by >1 minute
-    (a.dow>>time.getDay())&1 && // is allowed on this day of the week
-    (!a.date || a.date==time.toISOString().substr(0,10)) // is allowed on this date
+  var active = alarms.filter(a =>
+    a.on // enabled
+    && (a.last != d) // not already fired today
+    && (a.t + 60000 > currentTime) // is not in the past by >1 minute
+    && (a.dow >> time.getDay() & 1) // is allowed on this day of the week
+    && (!a.date || a.date == time.toISOString().substr(0, 10)) // is allowed on this date
   );
   if (active.length) {
     active = active.sort((a,b)=>a.t-b.t); // sort by time

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -11,16 +11,19 @@ exports.getAlarm = function(id) {
   return exports.getAlarms().find(a=>a.id==id);
 };
 // Given a list of alarms from getAlarms, return a list of active alarms for the given time (or current time if time not specified)
-exports.getActiveAlarms = function(alarms, time) {
+exports.getActiveAlarms = function (alarms, time) {
   if (!time) time = new Date();
-  var currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000)
-                    +10000;// get current time - 10s in future to ensure we alarm if we've started the app a tad early
-  return alarms.filter(a=>a.on
-          &&(a.t<currentTime)
-          &&(a.last!=time.getDate())
-          && (!a.date || a.date==time.toISOString().substr(0,10))
-          && a.dow >> (time).getDay() & 1)
-        .sort((a,b)=>a.t-b.t);
+  // get current time 10s in future to ensure we alarm if we've started the app a tad early
+  var currentTime = (time.getHours() * 3600000) + (time.getMinutes() * 60000) + (time.getSeconds() * 1000) + 10000;
+  return alarms
+    .filter(a =>
+      a.on // enabled
+      && (a.last != time.getDate()) // not already fired today
+      && (a.t < currentTime)
+      && (a.dow >> time.getDay() & 1) // is allowed on this day of the week
+      && (!a.date || a.date == time.toISOString().substr(0, 10)) // is allowed on this date
+    )
+    .sort((a, b) => a.t - b.t);
 }
 // Set an alarm object based on ID. Leave 'alarm' undefined to remove it
 exports.setAlarm = function(id, alarm) {

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -69,7 +69,7 @@ exports.newDefaultAlarm = function () {
     on: true,
     rp: settings.defaultRepeat,
     as: settings.defaultAutoSnooze,
-    dow: settings.defaultRepeat ? 0b1111111 : 0b0000000,
+    dow: 0b1111111,
     last: 0,
     vibrate: settings.defaultAlarmPattern,
   };

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.10",
+  "version": "0.11",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
In #1822 I merged the "repeat (Y/N)" and "days" menus. Before my PR a "repeat _once_ alarm" inherited a dow = 127 (_every day_) but in my updated app I allow a free customization of the days of the week so if the user select none of them then dow = 0 and the app assumes that the alarm will fire _once_.

I didn't noticed that an alarm with dow = 0 will never fire because the filter will discard it!

This PR fixes that (I also changed the filter conditions to be in the same order so they are easier to read)

---

Anyway, could the `rp `attribute be removed? The dow alone should be enough to understand if an alarm will run multiple times (dow > 0) or once (dow = 0). What do you think?