### PR TITLE
[Nifty Clock A&B] Bug fix and improvements

### DIFF
--- a/apps/ffcniftya/ChangeLog
+++ b/apps/ffcniftya/ChangeLog
@@ -1,2 +1,4 @@
 0.01: New Clock Nifty A
-0.02: Shows the current week number (ISO8601), can be disabled via settings ""
+0.02: Shows the current week number (ISO8601), can be disabled via settings
+0.03: Call setUI before loading widgets
+      Improve settings page

--- a/apps/ffcniftya/README.md
+++ b/apps/ffcniftya/README.md
@@ -1,13 +1,12 @@
 # Nifty-A Clock
 
-Colors are black/white - photos have non correct camera color "blue"
+Colors are black/white - photos have non correct camera color "blue".
 
-## This is the clock
+This is the clock:
 
 ![](screenshot_nifty.png)
 
-## The week number (ISO8601) can be turned of in settings
-(default is **"On"**)
+The week number (ISO8601) can be turned off in settings (default is `On`)
 
 ![](screenshot_settings_nifty.png)
 

--- a/apps/ffcniftya/app.js
+++ b/apps/ffcniftya/app.js
@@ -1,6 +1,6 @@
 const locale = require("locale");
-const is12Hour = (require("Storage").readJSON("setting.json", 1) || {})["12hour"];
-const CFG = require('Storage').readJSON("ffcniftya.json", 1) || {showWeekNum: true};
+const is12Hour = Object.assign({ "12hour": false }, require("Storage").readJSON("setting.json", true))["12hour"];
+const showWeekNum = Object.assign({ showWeekNum: true }, require('Storage').readJSON("ffcniftya.json", true))["showWeekNum"];
 
 /* Clock *********************************************/
 const scale = g.getWidth() / 176;
@@ -17,16 +17,17 @@ const center = {
   y: Math.round(((viewport.height - widget) / 2) + widget),
 }
 
-function ISO8601_week_no(date) { //copied from: https://gist.github.com/IamSilviu/5899269#gistcomment-3035480
-    var tdt = new Date(date.valueOf());
-    var dayn = (date.getDay() + 6) % 7;
-    tdt.setDate(tdt.getDate() - dayn + 3);
-    var firstThursday = tdt.valueOf();
-    tdt.setMonth(0, 1);
-    if (tdt.getDay() !== 4) {
-        tdt.setMonth(0, 1 + ((4 - tdt.getDay()) + 7) % 7);
-    }
-    return 1 + Math.ceil((firstThursday - tdt) / 604800000);
+// copied from: https://gist.github.com/IamSilviu/5899269#gistcomment-3035480
+function ISO8601_week_no(date) {
+  var tdt = new Date(date.valueOf());
+  var dayn = (date.getDay() + 6) % 7;
+  tdt.setDate(tdt.getDate() - dayn + 3);
+  var firstThursday = tdt.valueOf();
+  tdt.setMonth(0, 1);
+  if (tdt.getDay() !== 4) {
+    tdt.setMonth(0, 1 + ((4 - tdt.getDay()) + 7) % 7);
+  }
+  return 1 + Math.ceil((firstThursday - tdt) / 604800000);
 }
 
 function d02(value) {
@@ -59,7 +60,7 @@ function draw() {
   g.drawString(year, centerDatesScaleX, center.y - 62 * scale);
   g.drawString(month, centerDatesScaleX, center.y - 44 * scale);
   g.drawString(day, centerDatesScaleX, center.y - 26 * scale);
-  if (CFG.showWeekNum) g.drawString(d02(ISO8601_week_no(now)), centerDatesScaleX, center.y + 15 * scale);
+  if (showWeekNum) g.drawString(d02(ISO8601_week_no(now)), centerDatesScaleX, center.y + 15 * scale);
   g.drawString(monthName, centerDatesScaleX, center.y + 48 * scale);
   g.drawString(dayName, centerDatesScaleX, center.y + 66 * scale);
 }
@@ -79,7 +80,6 @@ function clearTickTimer() {
 function queueNextTick() {
   clearTickTimer();
   tickTimer = setTimeout(tick, 60000 - (Date.now() % 60000));
-  // tickTimer = setTimeout(tick, 3000);
 }
 
 function tick() {
@@ -91,15 +91,13 @@ function tick() {
 
 // Clear the screen once, at startup
 g.clear();
-// Start ticking
 tick();
 
-// Stop updates when LCD is off, restart when on
 Bangle.on('lcdPower', (on) => {
   if (on) {
-    tick(); // Start ticking
+    tick();
   } else {
-    clearTickTimer(); // stop ticking
+    clearTickTimer();
   }
 });
 

--- a/apps/ffcniftya/app.js
+++ b/apps/ffcniftya/app.js
@@ -103,9 +103,6 @@ Bangle.on('lcdPower', (on) => {
   }
 });
 
-// Load widgets
+Bangle.setUI("clock");
 Bangle.loadWidgets();
 Bangle.drawWidgets();
-
-// Show launcher when middle button pressed
-Bangle.setUI("clock");

--- a/apps/ffcniftya/app.js
+++ b/apps/ffcniftya/app.js
@@ -60,7 +60,7 @@ function draw() {
   g.drawString(year, centerDatesScaleX, center.y - 62 * scale);
   g.drawString(month, centerDatesScaleX, center.y - 44 * scale);
   g.drawString(day, centerDatesScaleX, center.y - 26 * scale);
-  if (showWeekNum) g.drawString(d02(ISO8601_week_no(now)), centerDatesScaleX, center.y + 15 * scale);
+  if (showWeekNum) g.drawString(weekNum, centerDatesScaleX, center.y + 15 * scale);
   g.drawString(monthName, centerDatesScaleX, center.y + 48 * scale);
   g.drawString(dayName, centerDatesScaleX, center.y + 66 * scale);
 }

--- a/apps/ffcniftya/metadata.json
+++ b/apps/ffcniftya/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "ffcniftya",
   "name": "Nifty-A Clock",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A nifty clock with time and date",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot_nifty.png"}],

--- a/apps/ffcniftya/settings.js
+++ b/apps/ffcniftya/settings.js
@@ -1,22 +1,14 @@
-(function(back) {
-  var FILE = "ffcniftya.json";
-  // Load settings
-  var cfg = require('Storage').readJSON(FILE, 1) || { showWeekNum: true };
+(function (back) {
+  const settings = Object.assign({ showWeekNum: true }, require("Storage").readJSON("ffcniftya.json", true));
 
-  function writeSettings() {
-    require('Storage').writeJSON(FILE, cfg);
-  }
-
-  // Show the menu
   E.showMenu({
-    "" : { "title" : "Nifty-A Clock" },
-    "< Back" : () => back(),
-    'week number?': {
-      value: cfg.showWeekNum,
-      format: v => v?"On":"Off",
+    "": { "title": "Nifty-A Clock" },
+    "< Back": () => back(),
+    /*LANG*/"Show Week Number": {
+      value: settings.showWeekNum,
       onchange: v => {
-        cfg.showWeekNum = v;
-        writeSettings();
+        settings.showWeekNum = v;
+        require("Storage").writeJSON("ffcniftya.json", settings);
       }
     }
   });

--- a/apps/ffcniftyb/ChangeLog
+++ b/apps/ffcniftyb/ChangeLog
@@ -1,2 +1,5 @@
 0.01: New Clock Nifty B
 0.02: Added configuration
+0.03: Call setUI before loading widgets
+      Fix bug with black being unselectable
+      Improve settings page

--- a/apps/ffcniftyb/README.md
+++ b/apps/ffcniftyb/README.md
@@ -1,9 +1,6 @@
 # Nifty Series B Clock
 
 - Display Time and Date
-- Color Configuration
-
-##
+- Colour Configuration
 
 ![](screenshot.png)
-

--- a/apps/ffcniftyb/app.js
+++ b/apps/ffcniftyb/app.js
@@ -112,7 +112,6 @@ Bangle.on('lcdPower', (on) => {
   }
 });
 
+Bangle.setUI("clock");
 Bangle.loadWidgets();
 Bangle.drawWidgets();
-
-Bangle.setUI("clock");

--- a/apps/ffcniftyb/app.js
+++ b/apps/ffcniftyb/app.js
@@ -1,9 +1,5 @@
-const locale = require("locale");
-const storage = require('Storage');
-
-const is12Hour = (storage.readJSON("setting.json", 1) || {})["12hour"];
-const color = (storage.readJSON("ffcniftyb.json", 1) || {})["color"] || 63488 /* red */;
-
+const is12Hour = Object.assign({ "12hour": false }, require("Storage").readJSON("setting.json", true))["12hour"];
+const color = Object.assign({ color: 63488 }, require("Storage").readJSON("ffcniftyb.json", true)).color; // Default to RED
 
 /* Clock *********************************************/
 const scale = g.getWidth() / 176;
@@ -19,7 +15,7 @@ const center = {
 };
 
 function d02(value) {
-  return ('0' + value).substr(-2);
+  return ("0" + value).substr(-2);
 }
 
 function renderEllipse(g) {
@@ -35,8 +31,8 @@ function renderText(g) {
   const month = d02(now.getMonth() + 1);
   const year = now.getFullYear();
 
-  const month2 = locale.month(now, 3);
-  const day2 = locale.dow(now, 3);
+  const month2 = require("locale").month(now, 3);
+  const day2 = require("locale").dow(now, 3);
 
   g.setFontAlign(1, 0).setFont("Vector", 90 * scale);
   g.drawString(hour, center.x + 32 * scale, center.y - 31 * scale);
@@ -96,7 +92,6 @@ function startTick(run) {
   stopTick();
   run();
   ticker = setTimeout(() => startTick(run), 60000 - (Date.now() % 60000));
-  // ticker = setTimeout(() => startTick(run), 3000);
 }
 
 /* Init **********************************************/
@@ -104,7 +99,7 @@ function startTick(run) {
 g.clear();
 startTick(draw);
 
-Bangle.on('lcdPower', (on) => {
+Bangle.on("lcdPower", (on) => {
   if (on) {
     startTick(draw);
   } else {

--- a/apps/ffcniftyb/metadata.json
+++ b/apps/ffcniftyb/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "ffcniftyb",
   "name": "Nifty-B Clock",
-  "version": "0.02",
-  "description": "A nifty clock (series B) with time, date and color configuration",
+  "version": "0.03",
+  "description": "A nifty clock (series B) with time, date and colour configuration",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],
   "type": "clock",

--- a/apps/ffcniftyb/settings.js
+++ b/apps/ffcniftyb/settings.js
@@ -1,49 +1,31 @@
 (function (back) {
-  const storage = require('Storage');
-  const SETTINGS_FILE = "ffcniftyb.json";
+  const settings = Object.assign({ color: 63488 }, require("Storage").readJSON("ffcniftyb.json", true));
 
   const colors = {
-    65535: 'White',
-    63488: 'Red',
-    65504: 'Yellow',
-    2047: 'Cyan',
-    2016: 'Green',
-    31: 'Blue',
-    0: 'Black',
+    65535: /*LANG*/"White",
+    63488: /*LANG*/"Red",
+    65504: /*LANG*/"Yellow",
+    2047: /*LANG*/"Cyan",
+    2016: /*LANG*/"Green",
+    31: /*LANG*/"Blue",
+    0: /*LANG*/"Black"
   }
 
-  function load(settings) {
-    return Object.assign(settings, storage.readJSON(SETTINGS_FILE, 1) || {});
-  }
+  const menu = {};
+  menu[""] = { title: "Nifty-B Clock" };
+  menu["< Back"] = back;
 
-  function save(settings) {
-    storage.write(SETTINGS_FILE, settings)
-  }
-
-  const settings = load({
-    color: 63488 /* red */,
+  Object.keys(colors).forEach(color => {
+    var label = colors[color];
+    menu[label] = {
+      value: settings.color == color,
+      onchange: () => {
+        settings.color = color;
+        require("Storage").write("ffcniftyb.json", settings);
+        setTimeout(load, 10);
+      }
+    };
   });
 
-  const saveColor = (color) => () => {
-    settings.color = color;
-    save(settings);
-    back();
-  };
-
-  function showMenu(items, opt) {
-    items[''] = opt || {};
-    items['< Back'] = back;
-    E.showMenu(items);
-  }
-
-  showMenu(
-    Object.keys(colors).reduce((menu, color) => {
-      menu[colors[color]] = saveColor(color);
-      return menu;
-    }, {}),
-    {
-      title: 'Color',
-      selected: Object.keys(colors).indexOf(settings.color)
-    }
-  );
+  E.showMenu(menu);
 });

--- a/lang/it_IT.json
+++ b/lang/it_IT.json
@@ -192,7 +192,15 @@
         "Notifications": "Notifiche",
         "Scheduler": "Schedulatore",
         "Stop": "Stop",
-        "Min Font": "Dimensione minima del font"
+        "Min Font": "Dimensione minima del font",
+        "White": "Bianco",
+        "Red": "Rosso",
+        "Yellow": "Giallo",
+        "Cyan": "Ciano",
+        "Green": "Verde",
+        "Blue": "Blu",
+        "Black": "Nero",
+        "Show Week Number": "Mostra numero settimana"
     },
     "//2": "App-specific overrides",
     "alarm": {


### PR DESCRIPTION
This PR fixes a couple of bugs in Nifty Clock A & B:

- Call setUI _before_ loading widgets (otherwise the "close widget" icon remains in the clock face)
- In Nifty Clock B there was a bug with black colour (the settings were read wrongly)

The PR also updates the clocks' Settings page.