### PR TITLE
[Sched & Multitimer] small fixes and updates (again)

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial version
+0.02: Update for time_utils module

--- a/apps/multitimer/alarm.js
+++ b/apps/multitimer/alarm.js
@@ -73,7 +73,7 @@ function showAlarm(alarm) {
   const settings = require("sched").getSettings();
 
   let msg = "";
-  msg += require("time_utils").formatTime(alarm.timer);
+  if (alarm.timer) msg += require("time_utils").formatTime(alarm.timer);
   if (alarm.msg) {
     msg += "\n"+alarm.msg;
   }

--- a/apps/multitimer/alarm.js
+++ b/apps/multitimer/alarm.js
@@ -73,7 +73,7 @@ function showAlarm(alarm) {
   const settings = require("sched").getSettings();
 
   let msg = "";
-  msg += require("sched").formatTime(alarm.timer);
+  msg += require("time_utils").formatTime(alarm.timer);
   if (alarm.msg) {
     msg += "\n"+alarm.msg;
   }
@@ -84,9 +84,9 @@ function showAlarm(alarm) {
 
   let buzzCount = settings.buzzCount;
 
-  if (alarm.data.hm && alarm.data.hm == true) {
+  if (alarm.data.hm == true) {
     //hard mode extends auto-snooze time
-    buzzCount = buzzCount * 2;
+    buzzCount = buzzCount * 3;
     startHM();
   }
 

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [

--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -10,3 +10,4 @@
 0.09: Move some functions to new time_utils module
 0.10: Default to sched.js if custom js not found
 0.11: Fix default dow
+0.12: Fix for loading custom js

--- a/apps/sched/boot.js
+++ b/apps/sched/boot.js
@@ -24,7 +24,7 @@
     will then clearInterval() to get rid of this call so it can proceed
     normally.
     If active[0].js is defined, just run that code as-is and not alarm.js */
-    Bangle.SCHED = setTimeout(require("Storage").read(active[0].js)!==undefined ? active[0].js : 'load("sched.js")',t);
+    Bangle.SCHED = setTimeout(require("Storage").read(active[0].js.slice(6, -2))!==undefined ? active[0].js : 'load("sched.js")',t);
   } else { // check for new alarms at midnight (so day of week works)
     Bangle.SCHED = setTimeout('eval(require("Storage").read("sched.boot.js"))', 86400000 - (Date.now()%86400000));
   }

--- a/apps/sched/boot.js
+++ b/apps/sched/boot.js
@@ -24,7 +24,8 @@
     will then clearInterval() to get rid of this call so it can proceed
     normally.
     If active[0].js is defined, just run that code as-is and not alarm.js */
-    Bangle.SCHED = setTimeout(require("Storage").read(active[0].js.slice(6, -2))!==undefined ? active[0].js : 'load("sched.js")',t);
+    if (active[0].js && require("Storage").read(active[0].js.slice(6, -2))!==undefined) Bangle.SCHED = setTimeout(active[0].js,t);
+    else Bangle.SCHED = setTimeout('load("sched.js")',t);
   } else { // check for new alarms at midnight (so day of week works)
     Bangle.SCHED = setTimeout('eval(require("Storage").read("sched.boot.js"))', 86400000 - (Date.now()%86400000));
   }

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.11",
+  "version": "0.12",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
Sched.boot.js didn't check for an alarm's custom js correctly so it always defaulted to sched.js - it SHOULD do so correctly this time, but that's what I thought it did during testing last time....

Multi Timer is updated for the time_utils module.