### PR TITLE
[ClockFace] Fix setUI/Bangle.loadWidgets order, new option "loadWidgets"

### DIFF
--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -8,6 +8,7 @@ function ClockFace(options) {
   Object.keys(options).forEach(k => {
     if (![
       "precision",
+      "loadWidgets",
       "init", "draw", "update",
       "pause", "resume",
       "up", "down", "upDown"
@@ -33,6 +34,7 @@ function ClockFace(options) {
   };
   if (options.upDown) this._upDown = options.upDown;
 
+  this.loadWidgets = !!options.loadWidgets;
   this.is12Hour = !!(require("Storage").readJSON("setting.json", 1) || {})["12hour"];
 }
 
@@ -46,7 +48,8 @@ ClockFace.prototype.tick = function() {
   };
   if (!this._last) {
     g.clear(true);
-    Bangle.drawWidgets();
+    if (this.loadWidgets)
+      Bangle.drawWidgets();
     g.reset();
     this.draw.apply(this, [time, {d: true, h: true, m: true, s: true}]);
   } else {
@@ -69,7 +72,8 @@ ClockFace.prototype.start = function() {
   if (this.init) this.init.apply(this);
   if (this._upDown) Bangle.setUI("clockupdown", d=>this._upDown.apply(this,[d]));
   else Bangle.setUI("clock");
-  Bangle.loadWidgets();
+  if (this.loadWidgets)
+    Bangle.loadWidgets();
   delete this._last;
   this.paused = false;
   this.tick();

--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -66,10 +66,10 @@ ClockFace.prototype.tick = function() {
 };
 
 ClockFace.prototype.start = function() {
-  Bangle.loadWidgets();
   if (this.init) this.init.apply(this);
   if (this._upDown) Bangle.setUI("clockupdown", d=>this._upDown.apply(this,[d]));
   else Bangle.setUI("clock");
+  Bangle.loadWidgets();
   delete this._last;
   this.paused = false;
   this.tick();

--- a/modules/ClockFace.md
+++ b/modules/ClockFace.md
@@ -52,6 +52,7 @@ Complete Usage
 var ClockFace = require("ClockFace");
 var clock = new ClockFace({
     precision: 1,   // optional, defaults to 60: how often to call update(), in seconds
+    loadWidgets: true, // optional, defaults to true
     init: function() {    // optional
       // called only once before starting the clock, but after setting up the 
       // screen/widgets, so you can use Bangle.appRect 


### PR DESCRIPTION
I moved the Bangle.loadWidgets call *after* the setUI so CLOCK gets defined (so widclose won't be shown in the clock). I also add a new option "loadWidgets" (default true) so a developer can easily enable/disable the widgets in their clock.

@rigrig I took the liberty of making a couple of changes, hopefully that's not a problem! I'm working on a custom clock and your ClockFace is really cool, thanks!