### PR TITLE
[Alarms & Timers] Fix dow handling for new timers

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -28,3 +28,4 @@
 0.26: Add support for Monday as first day of the week (#1780)
 0.27: New UI!
 0.28: Fix bug with alarms not firing when configured to fire only once
+0.29: Fix wrong 'dow' handling in new timer if first day of week is Monday

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -37,8 +37,8 @@ function handleFirstDayOfWeek(dow) {
   return dow;
 }
 
-// Check the first day of week and update the dow field accordingly.
-alarms.forEach(alarm => alarm.dow = handleFirstDayOfWeek(alarm.dow));
+// Check the first day of week and update the dow field accordingly (alarms only!)
+alarms.filter(e => e.timer === undefined).forEach(a => a.dow = handleFirstDayOfWeek(a.dow));
 
 function showMainMenu() {
   const menu = {
@@ -158,14 +158,14 @@ function saveAlarm(alarm, alarmIndex, time) {
 }
 
 function saveAndReload() {
-  // Before saving revert the dow to the standard format
-  alarms.forEach(a => a.dow = handleFirstDayOfWeek(a.dow, firstDayOfWeek));
+  // Before saving revert the dow to the standard format (alarms only!)
+  alarms.filter(e => e.timer === undefined).forEach(a => a.dow = handleFirstDayOfWeek(a.dow));
 
   require("sched").setAlarms(alarms);
   require("sched").reload();
 
   // Fix after save
-  alarms.forEach(a => a.dow = handleFirstDayOfWeek(a.dow, firstDayOfWeek));
+  alarms.filter(e => e.timer === undefined).forEach(a => a.dow = handleFirstDayOfWeek(a.dow));
 }
 
 function decodeDOW(alarm) {

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.28",
+  "version": "0.29",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm,widget",


### PR DESCRIPTION
I just noticed that a timer is saved with a wrong value for `dow` (254 instead of 127) if first day of week is Monday. This PR fixes the bug.