### PR TITLE
[r2d2clk] Add screenshot to metadata.json

### DIFF
--- a/apps/r2d2clk/metadata.json
+++ b/apps/r2d2clk/metadata.json
@@ -4,6 +4,7 @@
   "version":"0.01",
   "description": "A clock with R2D2's shiny metal face on it. :)",
   "icon": "app.png",
+  "screenshots": [{"url":"screenshot.png"}],
   "type": "clock",
   "tags": "clock",
   "supports" : ["BANGLEJS2"],  


### PR DESCRIPTION
The screenshot was missing from the metadata in the app store initially, so this just adds the screenshot in so it will show up.