### PR TITLE
[buzz] Add support for new patterns

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -10,3 +10,6 @@
 0.09: Move some functions to new time_utils module
 0.10: Default to sched.js if custom js not found
 0.11: Fix default dow
+0.12: Update default buzz patterns to new values
+      Improve timer message using formatDuration
+      Fix wrong fallback for buzz pattern

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -106,8 +106,8 @@ exports.getSettings = function () {
       defaultRepeat: false,
       buzzCount: 10,
       buzzIntervalMillis: 3000, // 3 seconds
-      defaultAlarmPattern: "..",
-      defaultTimerPattern: ".."
+      defaultAlarmPattern: "::",
+      defaultTimerPattern: "::"
     },
     require("Storage").readJSON("sched.settings.json", true) || {}
   );

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.11",
+  "version": "0.12",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -50,7 +50,8 @@ function showAlarm(alarm) {
       Bangle.setLocked(false);
     }
 
-    require("buzz").pattern(alarm.vibrate === undefined ? ".." : alarm.vibrate).then(() => {
+    const pattern = alarm.vibrate || (alarm.timer ? settings.defaultTimerPattern : settings.defaultAlarmPattern);
+    require("buzz").pattern(pattern).then(() => {
       if (buzzCount--) {
         setTimeout(buzz, settings.buzzIntervalMillis);
       } else if (alarm.as) { // auto-snooze

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -9,7 +9,7 @@ function showAlarm(alarm) {
   const settings = require("sched").getSettings();
 
   let msg = "";
-  msg += require("time_utils").formatTime(alarm.timer ? alarm.timer : alarm.t);
+  msg += alarm.timer ? require("time_utils").formatDuration(alarm.timer) : require("time_utils").formatTime(alarm.t);
   if (alarm.msg) {
     msg += "\n"+alarm.msg;
   } else {

--- a/apps/sched/settings.js
+++ b/apps/sched/settings.js
@@ -29,7 +29,7 @@
       min: 5,
       max: 30,
       step: 5,
-      format: v => v + /*LANG*/" min",
+      format: v => v + /*LANG*/"m",
       onchange: v => {
         settings.defaultSnoozeMillis = v * 60000;
         require("sched").setSettings(settings);

--- a/modules/buzz.js
+++ b/modules/buzz.js
@@ -1,14 +1,32 @@
-/* Call this with a pattern like '.-.', '.. .' or '..' to buzz that pattern
-out on the internal vibration motor. use buzz_menu to display a menu
-where the patterns can be chosen. */
+const BUZZ_WEAK = 0.25;
+const BUZZ_STRONG = 1;
+const SHORT_MS = 100;
+const LONG_MS = 500;
+
+/**
+ * Buzz the passed `pattern` out on the internal vibration motor.
+ *
+ * A pattern is a sequence of `.`, `:`, `-` and `=` where
+ * - `:` is one short and strong vibration
+ * - `.` is one short and weak vibration
+ * - `=` is one long and strong vibration
+ * - `-` is one long and weak vibration
+ *
+ * You can use the `buzz_menu` module to display a menu where some common patterns can be chosen.
+ *
+ * @param {string} pattern A string like `.-.`, `..=`, `:.:`, `..`, etc.
+ * @returns a Promise
+ */
 exports.pattern = pattern => new Promise(resolve => {
-  function b() {
-    if (pattern=="") resolve();
+  function doBuzz() {
+    if (pattern == "") resolve();
     var c = pattern[0];
     pattern = pattern.substr(1);
-    if (c==".") Bangle.buzz().then(()=>setTimeout(b,100));
-    else if (c=="-") Bangle.buzz(500).then(()=>setTimeout(b,100));
-    else setTimeout(b,100);
+    if (c == ".") Bangle.buzz(SHORT_MS, BUZZ_WEAK).then(() => setTimeout(doBuzz, 100));
+    else if (c == "-") Bangle.buzz(LONG_MS, BUZZ_WEAK).then(() => setTimeout(doBuzz, 100));
+    else if (c == ":") Bangle.buzz(SHORT_MS, BUZZ_STRONG).then(() => setTimeout(doBuzz, 100));
+    else if (c == "=") Bangle.buzz(LONG_MS, BUZZ_STRONG).then(() => setTimeout(doBuzz, 100));
+    else setTimeout(doBuzz, 100);
   }
-  b();
+  doBuzz();
 });

--- a/modules/buzz.js
+++ b/modules/buzz.js
@@ -1,16 +1,16 @@
-const BUZZ_WEAK = 0.25;
-const BUZZ_STRONG = 1;
-const SHORT_MS = 100;
-const LONG_MS = 500;
+const BUZZ_WEAK = 0.25, BUZZ_STRONG = 1;
+const SHORT_MS = 100, MEDIUM_MS = 200, LONG_MS = 500;
 
 /**
  * Buzz the passed `pattern` out on the internal vibration motor.
  *
- * A pattern is a sequence of `.`, `:`, `-` and `=` where
- * - `:` is one short and strong vibration
+ * A pattern is a sequence of `.`, `,`, `-`, `:`, `;` and `=` where
  * - `.` is one short and weak vibration
- * - `=` is one long and strong vibration
+ * - `,` is one medium and weak vibration
  * - `-` is one long and weak vibration
+ * - `:` is one short and strong vibration
+ * - `;` is one medium and strong vibration
+ * - `=` is one long and strong vibration
  *
  * You can use the `buzz_menu` module to display a menu where some common patterns can be chosen.
  *
@@ -23,8 +23,10 @@ exports.pattern = pattern => new Promise(resolve => {
     var c = pattern[0];
     pattern = pattern.substr(1);
     if (c == ".") Bangle.buzz(SHORT_MS, BUZZ_WEAK).then(() => setTimeout(doBuzz, 100));
+    else if (c == ",") Bangle.buzz(MEDIUM_MS, BUZZ_WEAK).then(() => setTimeout(doBuzz, 100));
     else if (c == "-") Bangle.buzz(LONG_MS, BUZZ_WEAK).then(() => setTimeout(doBuzz, 100));
     else if (c == ":") Bangle.buzz(SHORT_MS, BUZZ_STRONG).then(() => setTimeout(doBuzz, 100));
+    else if (c == ";") Bangle.buzz(MEDIUM_MS, BUZZ_STRONG).then(() => setTimeout(doBuzz, 100));
     else if (c == "=") Bangle.buzz(LONG_MS, BUZZ_STRONG).then(() => setTimeout(doBuzz, 100));
     else setTimeout(doBuzz, 100);
   }

--- a/modules/buzz_menu.js
+++ b/modules/buzz_menu.js
@@ -5,7 +5,7 @@
  * @param {*} callback A function called with the user selected pattern
  */
 exports.pattern = function (value, callback) {
-  var patterns = ["", ".", ":", "..", "::", "-", "=", "--", "==", "=.=", "---"];
+  var patterns = ["", ".", ":", "..", "::", ",", ";", ",,", ";;", "-", "=", "--", "==", "...", ":::", "---", ";;;", "==="];
   return {
     value: Math.max(0, patterns.indexOf(value)),
     min: 0,

--- a/modules/buzz_menu.js
+++ b/modules/buzz_menu.js
@@ -1,14 +1,19 @@
-/* Display a menu to select from various vibration patterns for use with buzz.js */
-
-exports.pattern = function(value, callback) {
-  var vibPatterns = ["", ".", "..", "-", "--", "-.-", "---"];
+/**
+ * Display a menu to select from various common vibration patterns for use with buzz.js.
+ * 
+ * @param {string} value The pre-selected pattern
+ * @param {*} callback A function called with the user selected pattern
+ */
+exports.pattern = function (value, callback) {
+  var patterns = ["", ".", ":", "..", "::", "-", "=", "--", "==", "=.=", "---"];
   return {
-    value: Math.max(0,vibPatterns.indexOf(value)),
-    min: 0, max: vibPatterns.length-1,
-    format: v => vibPatterns[v]||/*LANG*/"Off",
+    value: Math.max(0, patterns.indexOf(value)),
+    min: 0,
+    max: patterns.length - 1,
+    format: v => patterns[v] || /*LANG*/"Off",
     onchange: v => {
-      require("buzz").pattern(vibPatterns[v]);
-      callback(vibPatterns[v]);
+      require("buzz").pattern(patterns[v]);
+      callback(patterns[v]);
     }
   };
 }


### PR DESCRIPTION
As discussed in #1873 this PR adds two new vibration patterns: `:` and `=`.

`.` now is a "short and weak" vibration and `:` is a "short and strong" vibration. Similarly `-` is "long and weak" and `=` is "long and strong" where 
- "strong" means that the Bangle.buzz() is called with strength = 1 and 
- "weak" means the function is called with strength = 0.25.

Feel free to propose some common patterns for `buzz_menu`!

Current values are  `var patterns = ["", ".", ":", "..", "::", "-", "=", "--", "==", "=.=", "---"];`