### PR TITLE
Calibration - Scale the inputs to account for linear variation

### DIFF
--- a/apps/calibration/ChangeLog
+++ b/apps/calibration/ChangeLog
@@ -1,0 +1,2 @@
+1.00: New App!
+1.01: Use fractional numbers and scale the points to keep working consistently on whole screen

--- a/apps/calibration/README.md
+++ b/apps/calibration/README.md
@@ -6,6 +6,7 @@ A simple calibration app for the touchscreen
 Once lauched touch the cross that appear on the screen to make
 another spawn elsewhere.
 
-each new touch on the screen will help to calibrate the offset
-of your finger on the screen. After five or more input, press
-the button to save the calibration and close the application.
+Each new touch on the screen will help to calibrate the offset
+of your finger on the screen. After four or more inputs, press
+the button to save the calibration and close the application. Quality
+of the calibration gets better with every touch on a cross.

--- a/apps/calibration/app.js
+++ b/apps/calibration/app.js
@@ -49,7 +49,7 @@ class BanglejsApp {
     this.x = 16 + Math.floor(Math.random() * (g.getWidth() - 32));
     this.y = 40 + Math.floor(Math.random() * (g.getHeight() - 80));
 
-    g.clearRect(0, 24, g.getWidth(), g.getHeight() - 24);
+    g.clearRect(0, 0, g.getWidth(), g.getHeight());
     g.drawLine(this.x, this.y - 5, this.x, this.y + 5);
     g.drawLine(this.x - 5, this.y, this.x + 5, this.y);
     g.setFont('Vector', 10);
@@ -64,8 +64,6 @@ class BanglejsApp {
 
 
 E.srand(Date.now());
-Bangle.loadWidgets();
-Bangle.drawWidgets();
 
 calibration = new BanglejsApp();
 calibration.load_settings();

--- a/apps/calibration/app.js
+++ b/apps/calibration/app.js
@@ -1,26 +1,24 @@
 class BanglejsApp {
   constructor() {
+    this.updateFactor = 0.2;
     this.x = 0;
     this.y = 0;
+    this.step = 0;
     this.settings = {
       xoffset: 0,
       yoffset: 0,
+      xscale: 1,
+      yscale: 1,
       };
   }
 
   load_settings() {
     let settings = require('Storage').readJSON('calibration.json', true) || {active: false};
 
-    // do nothing if the calibration is deactivated
-    if (settings.active === true) {
-      // cancel the calibration offset 
-      Bangle.on('touch', function(button, xy) {
-        xy.x += settings.xoffset;
-        xy.y += settings.yoffset;
-      });
-    }
     if (!settings.xoffset) settings.xoffset = 0;
     if (!settings.yoffset) settings.yoffset = 0;
+    if (!settings.xscale) settings.xscale = 1;
+    if (!settings.yscale) settings.yscale = 1;
 
     console.log('loaded settings:');
     console.log(settings);
@@ -46,19 +44,63 @@ class BanglejsApp {
   }
 
   drawTarget() {
-    this.x = 16 + Math.floor(Math.random() * (g.getWidth() - 32));
-    this.y = 40 + Math.floor(Math.random() * (g.getHeight() - 80));
+    switch (this.step){
+      case 0:
+        this.x = Math.floor(0.2 * g.getWidth());
+        this.y = Math.floor(0.2 * g.getHeight());
+        break;
+      case 1:
+        this.x = Math.floor(0.8 * g.getWidth());
+        this.y = Math.floor(0.2 * g.getHeight());
+        break;
+      case 2:
+        this.x = Math.floor(0.5 * g.getWidth());
+        this.y = Math.floor(0.5 * g.getHeight());
+        break;
+      case 3:
+        this.x = Math.floor(0.2 * g.getWidth());
+        this.y = Math.floor(0.8 * g.getHeight());
+        break;
+      case 4:
+        this.x = Math.floor(0.8 * g.getWidth());
+        this.y = Math.floor(0.8 * g.getHeight());
+        break;
+    }
 
-    g.clearRect(0, 0, g.getWidth(), g.getHeight());
+    g.setColor(g.theme.fg);
     g.drawLine(this.x, this.y - 5, this.x, this.y + 5);
     g.drawLine(this.x - 5, this.y, this.x + 5, this.y);
     g.setFont('Vector', 10);
-    g.drawString('current offset: ' + this.settings.xoffset + ', ' + this.settings.yoffset, 0, 24);
+    g.drawString('current offset: ' + this.settings.xoffset.toFixed(3) + ', ' + this.settings.yoffset.toFixed(3), 2, 2);
+    g.drawString('current scale: ' + this.settings.xscale.toFixed(3) + ', ' + this.settings.yscale.toFixed(3), 2, 12);
   }
-
+  
   setOffset(xy) {
-    this.settings.xoffset = Math.round((this.settings.xoffset + (this.x - Math.floor((this.x + xy.x)/2)))/2);
-    this.settings.yoffset = Math.round((this.settings.yoffset + (this.y - Math.floor((this.y + xy.y)/2)))/2);
+    this.last=xy;
+    switch (this.step){
+      case 0:
+        this.settings.xoffset = this.settings.xoffset * (1-this.updateFactor) + (this.x - xy.x) * this.updateFactor;
+        this.settings.yoffset = this.settings.yoffset * (1-this.updateFactor) + (this.y - xy.y) * this.updateFactor;
+        break;
+      case 1:
+        this.settings.xscale = this.settings.xscale * (1-this.updateFactor) + ((xy.x + this.settings.xoffset) / this.x) * this.updateFactor;
+        this.settings.yoffset = this.settings.yoffset * (1-this.updateFactor) + (this.y - xy.y) * this.updateFactor;
+        break;
+      case 3:
+        this.settings.xoffset = this.settings.xoffset * (1-this.updateFactor) + (this.x - xy.x) * this.updateFactor;
+        this.settings.yscale = this.settings.yscale * (1-this.updateFactor) + ((xy.y + this.settings.yoffset) / this.y) * this.updateFactor;
+        break;
+      case 2:
+      case 4:
+        this.settings.xscale = this.settings.xscale * (1-this.updateFactor) + ((xy.x + this.settings.xoffset) / this.x) * this.updateFactor;
+        this.settings.yscale = this.settings.yscale * (1-this.updateFactor) + ((xy.y + this.settings.yoffset) / this.y) * this.updateFactor;
+        break;
+    }
+  }
+  
+  nextStep() {
+    this.step++;
+    if ( this.step == 5 ) this.step = 0;
   }
 }
 
@@ -67,6 +109,14 @@ E.srand(Date.now());
 
 calibration = new BanglejsApp();
 calibration.load_settings();
+Bangle.disableCalibration = true;
+
+function touchHandler (btn, xy){
+  g.clearRect(0, 0, g.getWidth(), g.getHeight());
+  if (xy) calibration.setOffset(xy);
+  calibration.drawTarget();
+  calibration.nextStep();
+}
 
 let modes = {
   mode  : 'custom',
@@ -74,10 +124,7 @@ let modes = {
     calibration.save_settings(this.settings);
     load();
   },
-  touch : function(btn, xy) {
-    calibration.setOffset(xy);
-    calibration.drawTarget();
-  },
+  touch : touchHandler,
 };
 Bangle.setUI(modes);
-calibration.drawTarget();
+touchHandler();

--- a/apps/calibration/boot.js
+++ b/apps/calibration/boot.js
@@ -1,7 +1,7 @@
 let cal_settings = require('Storage').readJSON("calibration.json", true) || {active: false};
 Bangle.on('touch', function(button, xy) {
   // do nothing if the calibration is deactivated
-  if (cal_settings.active === false) return;
+  if (cal_settings.active === false || Bangle.disableCalibration) return;
 
   // reload the calibration offset at each touch event /!\ bad for the flash memory
   if (cal_settings.reload === true) {
@@ -9,6 +9,6 @@ Bangle.on('touch', function(button, xy) {
   }
 
   // apply the calibration offset
-  xy.x += cal_settings.xoffset;
-  xy.y += cal_settings.yoffset;
+  xy.x = Math.round((xy.x + cal_settings.xoffset) * cal_settings.xscale);
+  xy.y = Math.round((xy.y + cal_settings.yoffset) * cal_settings.yscale);
 });

--- a/apps/calibration/boot.js
+++ b/apps/calibration/boot.js
@@ -9,6 +9,6 @@ Bangle.on('touch', function(button, xy) {
   }
 
   // apply the calibration offset
-  xy.x = Math.round((xy.x + cal_settings.xoffset) * cal_settings.xscale);
-  xy.y = Math.round((xy.y + cal_settings.yoffset) * cal_settings.yscale);
+  xy.x = E.clip(Math.round((xy.x + (cal_settings.xoffset || 0)) * (cal_settings.xscale || 1)),0,g.getWidth());
+  xy.y = E.clip(Math.round((xy.y + (cal_settings.yoffset || 0)) * (cal_settings.yscale || 1)),0,g.getHeight());
 });

--- a/apps/calibration/metadata.json
+++ b/apps/calibration/metadata.json
@@ -2,7 +2,7 @@
   "name": "Touchscreen Calibration",
   "shortName":"Calibration",
   "icon": "calibration.png",
-  "version":"1.00",
+  "version":"1.01",
   "description": "A simple calibration app for the touchscreen",
   "supports": ["BANGLEJS","BANGLEJS2"],
   "readme": "README.md",


### PR DESCRIPTION
I have tested this with two bangles and was slightly surprised by the different results:
```
{
  "xoffset": 0,
  "yoffset": -19.5,
  "xscale": 0.90285714285,
  "yscale": 1.04290429042,
  "active": true,
  "reload": false
}
```
```
{
  "xoffset": -8,
  "yoffset": -7.5,
  "xscale": 0.94894894894,
  "yscale": 0.95468277945,
  "active": true,
  "reload": false
}
```
Despite this it seems work well so far. Will test a bit longer before removing the draft marker.