### PR TITLE
ClockFace: add settings support

### DIFF
--- a/modules/ClockFace.md
+++ b/modules/ClockFace.md
@@ -85,6 +85,7 @@ var clock = new ClockFace({
       if (dir === -1) // Up
       else // (dir === 1): Down
     },
+    settingsFile: 'appid.settings.json', // optional, values from file will be applied to `this`
   });
 clock.start();
 
@@ -110,11 +111,51 @@ clock.start();
 
 ```
 
+
+SettingsFile
+------------
+If you use the `settingsFile` option, values from that file are loaded and set
+directly on the clock.
+
+For example:
+
+```json
+// example.settings.json:
+{
+  "showDate": false,
+  "foo": 123
+}
+```
+```js
+   var ClockFace = require("ClockFace");
+   var clock = new ClockFace({
+     draw: function(){/*...*/},
+     settingsFile: "example.settings.json",
+   });
+   // now
+   clock.showDate === false;
+   clock.foo === 123;
+   clock.loadWidgets === true; // default when not in settings file
+   clock.is12Hour === ??; // not in settings file: uses global setting
+   clock.start();
+
+```
+
 Properties
 ----------
 The following properties are automatically set on the clock:
 * `is12Hour`: `true` if the "Time Format" setting is set to "12h", `false` for "24h".
 * `paused`: `true` while the clock is paused.  (You don't need to check this inside your `draw()` code)
+* `showDate`: `true` (if not overridden through the settings file.)
+* `loadWidgets`: `true` (if not overridden through the settings file.)   
+   If set to `false` before calling `start()`, the clock won't call `Bangle.loadWidgets();` for you.
+   Best is to add a setting for this, but if you never want to load widgets, you could do this:
+   ```js
+   var ClockFace = require("ClockFace");
+   var clock = new ClockFace({draw: function(){/*...*/}});
+   clock.loadWidgets = false; // prevent loading of widgets
+   clock.start();
+   ```
 
 Inside the `draw()`/`update()` function you can access these using `this`:
 

--- a/modules/ClockFace_menu.js
+++ b/modules/ClockFace_menu.js
@@ -1,0 +1,10 @@
+// boolean options, which default to true
+exports.showDate =
+exports.loadWidgets =
+  function(value, callback) {
+    if (value === undefined) value = true;
+    return {
+      value: !!value,
+      onchange: v=>callback(v),
+    };
+  };


### PR DESCRIPTION
The idea is you can specify a `settingsFile` in options, and it will be loaded directly into the clock object. (i.e. not inside a separate `settings` property, as I figured that only makes accessing settings more verbose.)

`loadWidgets` is special: it defaults to true, when `false` it prevents the call to `Bangle.loadWidgets()` (and we check if `WIDGETS` is loaded before calling `drawWidgets()`

`showDate` doesn't do anything special, but it does default to `true`

Also adds `ClockFace_menu`, although at the moment it only has two boolean menu options... Still cuts down on the boilerplate though.