### PR TITLE
[Alarms & Timers] Fix "Enable All"

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -29,3 +29,4 @@
 0.27: New UI!
 0.28: Fix bug with alarms not firing when configured to fire only once
 0.29: Fix wrong 'dow' handling in new timer if first day of week is Monday
+0.30: Fix "Enable All"

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -86,7 +86,8 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex) {
   const menu = {
     "": { "title": isNew ? /*LANG*/"New Alarm" : /*LANG*/"Edit Alarm" },
     "< Back": () => {
-      saveAlarm(alarm, alarmIndex, time);
+      prepareAlarmForSave(alarm, alarmIndex, time);
+      saveAndReload();
       showMainMenu();
     },
     /*LANG*/"Hour": {
@@ -144,7 +145,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex) {
   E.showMenu(menu);
 }
 
-function saveAlarm(alarm, alarmIndex, time) {
+function prepareAlarmForSave(alarm, alarmIndex, time) {
   alarm.t = require("time_utils").encodeTime(time);
   alarm.last = alarm.t < require("time_utils").getCurrentTimeMillis() ? new Date().getDate() : 0;
 
@@ -153,8 +154,6 @@ function saveAlarm(alarm, alarmIndex, time) {
   } else {
     alarms[alarmIndex] = alarm;
   }
-
-  saveAndReload();
 }
 
 function saveAndReload() {
@@ -251,7 +250,8 @@ function showEditTimerMenu(selectedTimer, timerIndex) {
   const menu = {
     "": { "title": isNew ? /*LANG*/"New Timer" : /*LANG*/"Edit Timer" },
     "< Back": () => {
-      saveTimer(timer, timerIndex, time);
+      prepareTimerForSave(timer, timerIndex, time);
+      saveAndReload();
       showMainMenu();
     },
     /*LANG*/"Hours": {
@@ -293,7 +293,7 @@ function showEditTimerMenu(selectedTimer, timerIndex) {
   E.showMenu(menu);
 }
 
-function saveTimer(timer, timerIndex, time) {
+function prepareTimerForSave(timer, timerIndex, time) {
   timer.timer = require("time_utils").encodeTime(time);
   timer.t = require("time_utils").getCurrentTimeMillis() + timer.timer;
   timer.last = 0;
@@ -303,8 +303,6 @@ function saveTimer(timer, timerIndex, time) {
   } else {
     alarms[timerIndex] = timer;
   }
-
-  saveAndReload();
 }
 
 function showAdvancedMenu() {
@@ -327,7 +325,16 @@ function enableAll(on) {
   } else {
     E.showPrompt(/*LANG*/"Are you sure?", { title: on ? /*LANG*/"Enable All" : /*LANG*/"Disable All" }).then((confirm) => {
       if (confirm) {
-        alarms.forEach(alarm => alarm.on = on);
+        alarms.forEach((alarm, i) => {
+          alarm.on = on;
+          if (on) {
+            if (alarm.timer) {
+              prepareTimerForSave(alarm, i, require("time_utils").decodeTime(alarm.timer))
+            } else {
+              prepareAlarmForSave(alarm, i, require("time_utils").decodeTime(alarm.t))
+            }
+          }
+        });
         saveAndReload();
         showMainMenu();
       } else {

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.29",
+  "version": "0.30",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm,widget",


### PR DESCRIPTION
I found a bug with a disabled timer + _enable all_ action: the _enable all_ does not update the `timer` field. This PR fixes the bug :-)