### PR TITLE
[Settings] Improve "Turn Off" user experience

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -50,3 +50,4 @@
       UI improvements to Locale and Date & Time menu
 0.45: Add calibrate battery option
 0.46: Fix regression after making 'calibrate battery' only for Bangle.js 2
+0.47: Improve "Turn Off" user experience

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.46",
+  "version": "0.47",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -569,7 +569,25 @@ function showUtilMenu() {
         } else showUtilMenu();
       });
     };
-  menu[/*LANG*/'Turn Off'] = ()=>{ if (Bangle.softOff) Bangle.softOff(); else Bangle.off() };
+  menu[/*LANG*/"Turn Off"] = () => {
+    E.showPrompt(/*LANG*/"Are you sure? Alarms and timers won't fire", {
+      title:/*LANG*/"Turn Off"
+    }).then((confirmed) => {
+      if (confirmed) {
+        E.showMessage(/*LANG*/"See you\nlater!", /*LANG*/"Goodbye");
+        setTimeout(() => {
+          // clear the screen so when the user will turn on the watch they'll see
+          // an empty screen instead of the latest displayed screen
+          E.showMessage();
+          g.clear(true);
+
+          Bangle.softOff ? Bangle.softOff() : Bangle.off();
+        }, 2500);
+      } else {
+        showUtilMenu();
+      }
+    });
+  };
 
   if (Bangle.factoryReset) {
     menu[/*LANG*/'Factory Reset'] = ()=>{


### PR DESCRIPTION
The _Turn Off_ feels strange: it shutdowns the watch immediatly without asking the user (sometimes I turned off the watch by mistake while exploring the menus) and the last displayed screen (before the shutdown) is shown when the watch is turned on again. This feels really strange and "broken" imho.

This PR improves the "turn off" user experience:

- The user must confirm 
- A goodbye message will be shown ("_See you later!_" &rarr; other ideas?)
- The screen will be cleared

Maybe this is a trivial change but I think this is a step towards better overall usability :-)


