### PR TITLE
miclock2: Fix typo in redraw check

### DIFF
--- a/apps/miclock2/ChangeLog
+++ b/apps/miclock2/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Redraw only when seconds change
+0.03: Fix typo in redraw check

--- a/apps/miclock2/clock-mixed.js
+++ b/apps/miclock2/clock-mixed.js
@@ -48,7 +48,7 @@ function setLineWidth(x1, y1, x2, y2, lw) {
 
 function drawMixedClock(force) {
   var date = new Date();
-  if ((force || Bangle.isLCDOn()) && buf.buffer && date.getSeconds() === lastDate.getSeconds()) {
+  if ((force || Bangle.isLCDOn()) && buf.buffer && date.getSeconds() !== lastDate.getSeconds()) {
     lastDate = date;
     var dateArray = date.toString().split(" ");
     var isEn = locale.name.startsWith("en");

--- a/apps/miclock2/metadata.json
+++ b/apps/miclock2/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "miclock2",
   "name": "Mixed Clock 2",
-  "version": "0.02",
+  "version": "0.03",
   "description": "White color variant of the Mixed Clock with thicker clock hands for better readability in the bright sunlight, extra space under the clock for widgets and seconds in the digital clock.",
   "icon": "clock-mixed.png",
   "type": "clock",


### PR DESCRIPTION
For some reason a test with reversed equal comparison got committed and pushed.