### PR TITLE
[dtlaunch] 'Swipe to exit' now uses load()...

### DIFF
--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -12,3 +12,4 @@
 0.12: On Bangle 2 change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.
 0.13: Added swipeExit setting so that left-right to exit is an option
 0.14: Don't move pages when doing exit swipe.
+0.15: 'Swipe to exit'-code is slightly altered to be more reliable.

--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -11,5 +11,5 @@
 0.11: Fix bangle.js 1 white icons not displaying
 0.12: On Bangle 2 change to swiping up/down to move between pages as to match page indicator. Swiping from left to right now loads the clock.
 0.13: Added swipeExit setting so that left-right to exit is an option
-0.14: Don't move pages when doing exit swipe.
-0.15: 'Swipe to exit'-code is slightly altered to be more reliable.
+0.14: Don't move pages when doing exit swipe - Bangle 2.
+0.15: 'Swipe to exit'-code is slightly altered to be more reliable - Bangle 2.

--- a/apps/dtlaunch/README.md
+++ b/apps/dtlaunch/README.md
@@ -27,7 +27,7 @@ Bangle 2:
 
 ## Controls- Bangle 2
 
-**Touch** - icon to select, scond touch launches app
+**Touch** - icon to select, second touch launches app
 
 **Swipe Left/Up** -  move to next page of app icons
 

--- a/apps/dtlaunch/app-b2.js
+++ b/apps/dtlaunch/app-b2.js
@@ -89,7 +89,7 @@ function drawPage(p){
 Bangle.on("swipe",(dirLeftRight, dirUpDown)=>{
     selected = 0;
     oldselected=-1;
-    if(settings.swipeExit && dirLeftRight==1) showClock();
+    if(settings.swipeExit && dirLeftRight==1) load();
     if (dirUpDown==-1||dirLeftRight==-1){
         ++page; if (page>maxPage) page=0;
         drawPage(page);
@@ -98,12 +98,6 @@ Bangle.on("swipe",(dirLeftRight, dirUpDown)=>{
         drawPage(page);
     }
 });
-
-function showClock(){
-  var app = require("Storage").readJSON('setting.json', 1).clock;
-  if (app) load(app);
-  else E.showMessage("clock\nnot found");
-}
 
 function isTouched(p,n){
     if (n<0 || n>3) return false;

--- a/apps/dtlaunch/metadata.json
+++ b/apps/dtlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "dtlaunch",
   "name": "Desktop Launcher",
-  "version": "0.14",
+  "version": "0.15",
   "description": "Desktop style App Launcher with six (four for Bangle 2) apps per page - fast access if you have lots of apps installed.",
   "screenshots": [{"url":"shot1.png"},{"url":"shot2.png"},{"url":"shot3.png"}],
   "icon": "icon.png",


### PR DESCRIPTION
 ...instead of showClock()-function which has been completely removed.

As hinted by @gfwilliams in a comment on issue #1953 (This pull request does probably not address the original bug in the issue).

>[...] which implies that load() was called (which is the right thing to do). [...]

This makes 'Swipe to exit' a little more reliable. Specifically when a preferred clock isn't marked in the settings.