### PR TITLE
apploader - Ignore empty folder instead of creating invalid json

### DIFF
--- a/bin/create_apps_json.sh
+++ b/bin/create_apps_json.sh
@@ -23,7 +23,7 @@ echo "[" > "$outfile"
 first=1
 for app in apps/*/; do 
   echo "Processing $app..."; 
-  if [[ "$app" =~ ^apps/_example.* ]]; then
+  if [[ "$app" =~ ^apps/_example.* ]] || [ ! -e "$app/"metadata.json ]; then
     echo "Ignoring $app"
   else
     if [ $first -eq 1 ]; then


### PR DESCRIPTION
Git is not good at cleaning up empty folders on changing branches. The script created corrupt json on empty app folders.