### PR TITLE
Clockface fixes

### DIFF
--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -108,7 +108,7 @@ ClockFace.prototype.resume = function() {
   delete this._last;
   this.paused = false;
   if (this._resume) this._resume.apply(this);
-  this.tick(true);
+  this.tick();
 };
 
 /**

--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -19,7 +19,7 @@ function ClockFace(options) {
     options.update.apply(this, [t, {d: true, h: true, m: true, s: true}]);
   });
   this.update = options.update || (t => {
-    g.clear();
+    g.clearRect(Bangle.appRect);
     options.draw.apply(this, [t, {d: true, h: true, m: true, s: true}]);
   });
   if (options.precision===1000||options.precision===60000) throw "ClockFace precision is in seconds, not ms";


### PR DESCRIPTION
* Don't erase widgets when using `draw`, see discussion for [this PR](https://github.com/espruino/BangleApps/pull/1979)
* minor cleanup: remove unused argument from `tick` call