### PR TITLE
Fix "Vibrate: off" being ignored by messages app

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -54,3 +54,4 @@
 0.39: Set default color for message icons according to theme
 0.40: Use default Bangle formatter for booleans
 0.41: Add notification icons in the widget
+0.42: Fix messages ignoring "Vibrate: Off" setting

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.41",
+  "version": "0.42",
   "description": "App to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messages/widget.js
+++ b/apps/messages/widget.js
@@ -62,7 +62,9 @@ draw:function(recall) {
   Bangle.drawWidgets();
 },buzz:function() {
   if ((require('Storage').readJSON('setting.json',1)||{}).quiet) return; // never buzz during Quiet Mode
-  require("buzz").pattern((require('Storage').readJSON("messages.settings.json", true) || {}).vibrate || ":");
+  var pattern = (require('Storage').readJSON("messages.settings.json", true) || {}).vibrate;
+  if (pattern === undefined) { pattern = ":"; } // pattern may be "", so we can't use || ":" here
+  require("buzz").pattern(pattern);
 },touch:function(b,c) {
   var w=WIDGETS["messages"];
   if (!w||!w.width||c.x<w.x||c.x>w.x+w.width||c.y<w.y||c.y>w.y+w.iconwidth) return;


### PR DESCRIPTION
The messages app used this code:
``` js
(require('Storage').readJSON("messages.settings.json", true) || {}).vibrate || ":"
```
to determine the buzz pattern.

If I set the buzz pattern to "Off" in the settings app, it will return an empty string (`""`), which is falsey in JS, therefore the `|| ":"` will still return ":" in this case, causing a buzz, even though I explicitely disabled it in the settings.