### PR TITLE
Teatimer display bug

### DIFF
--- a/apps/teatimer/ChangeLog
+++ b/apps/teatimer/ChangeLog
@@ -1,0 +1,2 @@
+0.01: New App
+0.02: Fixed rendering problem of several text messages

--- a/apps/teatimer/app.js
+++ b/apps/teatimer/app.js
@@ -98,6 +98,7 @@ function countDown() {
 
 // 
 function outOfTime() {
+  E.showMessage("", "");
   E.showMessage("Time is up!",appTitle());
   setState(states.countUp);
   resetTimer();
@@ -146,6 +147,7 @@ function resetTimer() {
 // timer is stopped by user => state: stop
 function stopTimer() {
   resetTimer();
+  E.showMessage("", "");
   E.showMessage("Timer stopped!", appTitle());
   setState(states.stop);
 }
@@ -216,6 +218,7 @@ function initDragEvents() {
 function showHelp() {
   if (state == states.start) {
     state = states.help;
+    E.showMessage("", "");
     E.showMessage("Swipe up/down\n+/- one minute\n\nSwipe left/right\n+/- 15 seconds\n\nPress Btn1 to start","Tea timer help");
   }
   // return to start

--- a/apps/teatimer/metadata.json
+++ b/apps/teatimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "teatimer",
   "name": "Tea Timer",
-  "version": "0.01",
+  "version": "0.02",
   "description": "A simple timer. You can easyly set up the time.",
   "icon": "teatimer.png",
   "type": "app",


### PR DESCRIPTION
Most text messages drawn by using `E.showMessage` were not shown properly on Bangle.js 2. Only the title line was visible but the complete message space was drawn in white, no text was visible.
Added empty `E.showMessage` calls before the actual text rendering was added as a workaround. I'm not sure, however, why this is necessary, so probably there might be a better way to fix this.