### PR TITLE
[Alarms & Timers] Allow hiding timers/alarms

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -33,4 +33,5 @@
 0.31: Add seconds to timers
 0.32: Fix wrong hidden filter
       Add option for auto-delete a timer after it expires
+0.33: Allow hiding timers&alarms
 

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -124,6 +124,10 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex) {
       value: alarm.as,
       onchange: v => alarm.as = v
     },
+    /*LANG*/"Hidden": {
+      value: alarm.hidden || false,
+      onchange: v => alarm.hidden = v
+    },
     /*LANG*/"Cancel": () => showMainMenu()
   };
 
@@ -283,6 +287,10 @@ function showEditTimerMenu(selectedTimer, timerIndex) {
     /*LANG*/"Delete After Expiration": {
       value: timer.del,
       onchange: v => timer.del = v
+    },
+    /*LANG*/"Hidden": {
+      value: timer.hidden || false,
+      onchange: v => timer.hidden = v
     },
     /*LANG*/"Vibrate": require("buzz_menu").pattern(timer.vibrate, v => timer.vibrate = v),
     /*LANG*/"Cancel": () => showMainMenu()

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.32",
+  "version": "0.33",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm,widget",


### PR DESCRIPTION
In my quest to hide as many widgets as I can; here is the ability to hide alarms or timers from the Alarms & Timers widget.

This feature was already available in the "sched" library & the widget, it just wasn't exposed in the menu.
So allow to change this from the menu now.
It mostly serves to hide the daily morning alarm that you might have set up.