### PR TITLE
[thumbnailer.js] Output app name, reset lcd and intervals

### DIFF
--- a/bin/thumbnailer.js
+++ b/bin/thumbnailer.js
@@ -79,7 +79,7 @@ function getThumbnail(appId, imageFn) {
       settings : SETTINGS,
       device : { id : DEVICEID }
       }).then(files => {
-        console.log("AppInfo returned");//, files);
+        console.log(`AppInfo returned for ${appId}`);//, files);
         flashMemory.set(factoryFlashMemory);
         jsTransmitString("reset()\n");
         console.log("Uploading...");
@@ -89,6 +89,7 @@ function getThumbnail(appId, imageFn) {
         appLog = "";
         jsTransmitString(command);
         console.log("Done.");
+        jsTransmitString("Bangle.setLCDMode();clearInterval();clearTimeout();\n");
         jsStopIdle();
 
         var rgba = new Uint8Array(GFX_WIDTH*GFX_HEIGHT*4);


### PR DESCRIPTION
flow app sets LCDMode to 120x120 wich will break image export (`TypeError: FUNCTION_TABLE[(HEAPU8[(($0 + 52) | 0)] | (HEAPU8[(($0 + 53) | 0)] << 8) | ((HEAPU8[(($0 + 54) | 0)] << 16) | (HEAPU8[(($0 + 55) | 0)] << 24)))] is not a function`)

Some applications use a very short timeout, which also break the export.