### PR TITLE
Clockface: powersaving 

### DIFF
--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -49,6 +49,7 @@ function ClockFace(options) {
 }
 
 ClockFace.prototype.tick = function() {
+  "ram"
   const time = new Date();
   const now = {
     d: `${time.getFullYear()}-${time.getMonth()}-${time.getDate()}`,

--- a/modules/ClockFace.md
+++ b/modules/ClockFace.md
@@ -208,7 +208,7 @@ let menu = {
   /*LANG*/"< Back": back,  
 };
 require("ClockFace_menu").addSettingsFile(menu, "<appid>.settings.json", [ 
-  "showDate", "loadWidgets"
+  "showDate", "loadWidgets", "powerSave",
 ]);
 E.showMenu(menu);
 

--- a/modules/ClockFace_menu.js
+++ b/modules/ClockFace_menu.js
@@ -11,12 +11,16 @@ exports.addItems = function(menu, callback, items) {
     const label = {
       showDate:/*LANG*/"Show date",
       loadWidgets:/*LANG*/"Load widgets",
+      powerSave:/*LANG*/"Power saving",
     }[key];
     switch(key) {
+      // boolean options which default to true
       case "showDate":
       case "loadWidgets":
-        // boolean options, which default to true
         if (value===undefined) value = true;
+        // fall through
+      case "powerSave":
+        // same for all boolean options:
         menu[label] = {
           value: !!value,
           onchange: v => callback(key, v),


### PR DESCRIPTION
* Makes `tick` a "ram" function, so if clocks implement their `update()` in "ram" as well, (in theory) updating the clock doesn't need to wake flash. (Based on [this forum thread](http://forum.espruino.com/conversations/375995/))
* Adds a `powerSave` menu option. (It's a boolean for now, in the future maybe also allow integer options (`["Always","During Quiet Mode", "Never"]`), but that would mean clocks need to watch for quiet mode changes.)
