### PR TITLE
Barclock powersaving

### DIFF
--- a/apps/barclock/ChangeLog
+++ b/apps/barclock/ChangeLog
@@ -12,3 +12,4 @@
 0.12: Add settings to hide date,widgets
 0.13: Add font setting
 0.14: Use ClockFace_menu.addItems
+0.15: Add Power saving option

--- a/apps/barclock/README.md
+++ b/apps/barclock/README.md
@@ -8,3 +8,4 @@ A simple digital clock showing seconds as a horizontal bar.
 ## Settings
 * `Show date`: display date at the bottom of screen
 * `Font`: choose between bitmap or vector fonts
+* `Power saving`: (Bangle.js 2 only) don't draw the seconds bar while the watch is locked

--- a/apps/barclock/clock-bar.js
+++ b/apps/barclock/clock-bar.js
@@ -13,7 +13,7 @@ let locale = require("locale");
   locale.hasMeridian = (locale.meridian(date)!=="");
 }
 
-let barW = 0,prevX = 0;
+let barW = 0, prevX = 0;
 function renderBar(l) {
   "ram";
   if (l) prevX = 0; // called from Layout: drawing area was cleared
@@ -23,10 +23,9 @@ function renderBar(l) {
   if (x2===prevX) return; // nothing to do
   if (x2===0) x2--; // don't leave 1px line
   if (x2<Math.max(0, prevX)) g.setBgColor(l.bgCol || g.theme.bg).clearRect(x2+1, l.y, prevX, l.y2);
-  else g.setColor(l.col||g.theme.fg).fillRect(prevX+1, l.y, x2, l.y2);
+  else g.setColor(l.col || g.theme.fg).fillRect(prevX+1, l.y, x2, l.y2);
   prevX = x2;
 }
-
 
 function timeText(date) {
   if (!clock.is12Hour) {
@@ -54,16 +53,16 @@ function dateText(date) {
 
 const ClockFace = require("ClockFace"),
   clock = new ClockFace({
-    precision:1,
-    settingsFile:'barclock.settings.json',
+    precision: 1,
+    settingsFile: "barclock.settings.json",
     init: function() {
       const Layout = require("Layout");
       this.layout = new Layout({
         type: "v", c: [
           {
             type: "h", c: [
-              {id: "time", label: "88:88", type: "txt", font: "6x8:5", col:g.theme.fg, bgCol: g.theme.bg}, // updated below
-              {id: "ampm", label: "  ", type: "txt", font: "6x8:2", col:g.theme.fg, bgCol: g.theme.bg},
+              {id: "time", label: "88:88", type: "txt", font: "6x8:5", col: g.theme.fg, bgCol: g.theme.bg}, // updated below
+              {id: "ampm", label: "  ", type: "txt", font: "6x8:2", col: g.theme.fg, bgCol: g.theme.bg},
             ],
           },
           {id: "bar", type: "custom", fillx: 1, height: 6, col: g.theme.fg2, render: renderBar},

--- a/apps/barclock/clock-bar.js
+++ b/apps/barclock/clock-bar.js
@@ -14,12 +14,10 @@ let locale = require("locale");
 }
 
 function renderBar(l) {
-  if (!this.fraction) {
-    // zero-size fillRect stills draws one line of pixels, we don't want that
-    return;
-  }
-  const width = this.fraction*l.w;
-  g.fillRect(l.x, l.y, l.x+width-1, l.y+l.height-1);
+  "ram";
+  if (!this.fraction) return; // zero-size fillRect stills draws one line of pixels, we don't want that
+  if (this.powerSave && Bangle.isLocked()) return;
+  g.fillRect(l.x, l.y, l.x+this.fraction*l.w-1, l.y+l.height-1);
 }
 
 
@@ -91,6 +89,7 @@ const ClockFace = require("ClockFace"),
       this.layout.update();
     },
     update: function(date, c) {
+      "ram";
       if (c.m) this.layout.time.label = timeText(date);
       if (c.h) this.layout.ampm.label = ampmText(date);
       if (c.d && this.showDate) this.layout.date.label = dateText(date);
@@ -102,4 +101,18 @@ const ClockFace = require("ClockFace"),
       this.layout.forgetLazyState();
     },
   });
+if (clock.powerSave) {
+  Bangle.on("lock", l => {
+    if (l) {
+      clock.precision = 60;
+      clock.tick();
+      const l = clock.layout.bar;
+      setTimeout(() => g.clearRect(l.x, l.y, l.x+l.w-1, l.y+l.height-1), 100);
+    } else {
+      clock.precision = 1;
+      clock.tick();
+    }
+  });
+}
+
 clock.start();

--- a/apps/barclock/metadata.json
+++ b/apps/barclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "barclock",
   "name": "Bar Clock",
-  "version": "0.14",
+  "version": "0.15",
   "description": "A simple digital clock showing seconds as a bar",
   "icon": "clock-bar.png",
   "screenshots": [{"url":"screenshot.png"},{"url":"screenshot_pm.png"}],

--- a/apps/barclock/settings.js
+++ b/apps/barclock/settings.js
@@ -17,10 +17,14 @@
       onchange: v => save("font", v),
     },
   };
-  require("ClockFace_menu").addItems(menu, save, {
+  let items = {
     showDate: s.showDate,
     loadWidgets: s.loadWidgets,
-  });
-
+  };
+  // Power saving for Bangle.js 1 doesn't make sense (no updates while screen is off anyway)
+  if (process.env.HWVERSION>1) {
+    items.powerSave = s.powerSave;
+  }
+  require("ClockFace_menu").addItems(menu, save, items);
   E.showMenu(menu);
 });

--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -49,6 +49,7 @@ function ClockFace(options) {
 }
 
 ClockFace.prototype.tick = function() {
+  "ram"
   const time = new Date();
   const now = {
     d: `${time.getFullYear()}-${time.getMonth()}-${time.getDate()}`,

--- a/modules/ClockFace.md
+++ b/modules/ClockFace.md
@@ -208,7 +208,7 @@ let menu = {
   /*LANG*/"< Back": back,  
 };
 require("ClockFace_menu").addSettingsFile(menu, "<appid>.settings.json", [ 
-  "showDate", "loadWidgets"
+  "showDate", "loadWidgets", "powerSave",
 ]);
 E.showMenu(menu);
 

--- a/modules/ClockFace_menu.js
+++ b/modules/ClockFace_menu.js
@@ -11,12 +11,16 @@ exports.addItems = function(menu, callback, items) {
     const label = {
       showDate:/*LANG*/"Show date",
       loadWidgets:/*LANG*/"Load widgets",
+      powerSave:/*LANG*/"Power saving",
     }[key];
     switch(key) {
+      // boolean options which default to true
       case "showDate":
       case "loadWidgets":
-        // boolean options, which default to true
         if (value===undefined) value = true;
+        // fall through
+      case "powerSave":
+        // same for all boolean options:
         menu[label] = {
           value: !!value,
           onchange: v => callback(key, v),


### PR DESCRIPTION
(Needs the [Clockface: powersaving](https://github.com/espruino/BangleApps/pull/2046) PR)

* Optimize drawing: second updates (the bar) happen in `"ram"`, and only redraw the changed part of the screen. (Instead of calling `layout.render()` every second)
* (Bangle.js 2 only): adds a "Power saving" option: only draws the bar while unlocked, otherwise only update once a minute.