### PR TITLE
Allow Noteify on Bangle.js 1

### DIFF
--- a/apps/noteify/README.md
+++ b/apps/noteify/README.md
@@ -1,6 +1,6 @@
 # WARNING
 
-This app uses the [Scheduler library](https://banglejs.com/apps/?id=sched) and requires a keyboard such as [Swipe keyboard](https://banglejs.com/apps/?id=kbswipe).
+This app uses the [Scheduler library](https://banglejs.com/apps/?id=sched) and requires a [keyboard library](https://banglejs.com/apps/?c=textinput#).
 
 ## Usage
 

--- a/apps/noteify/metadata.json
+++ b/apps/noteify/metadata.json
@@ -5,7 +5,7 @@
   "description": "Write notes using an onscreen keyboard and use them as custom messages for alarms or timers.",
   "icon": "app.png",
   "tags": "tool,alarm",
-  "supports": ["BANGLEJS2"],
+  "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",
   "storage": [
     {"name":"noteify.app.js","url":"app.js"},


### PR DESCRIPTION
The Noteify app said it only supported Bangle.js 2, but it actually works fine on Bangle.js 1, as long as a different textinput library is used. (Although because kbmorse is the only such library for Bangle.js 1 and it's currently [broken](https://github.com/espruino/Espruino/issues/2240), it doesn't change much just yet).