### PR TITLE
messages: reduce widget memory usage

### DIFF
--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -108,7 +108,7 @@ exports.getMessageImage = function(msg) {
   * http://www.espruino.com/Image+Converter
   */
   if (msg.img) return atob(msg.img);
-  var s = (msg.src||"").toLowerCase();
+  const s = (("string"=== typeof msg) ? msg : (msg.src || "")).toLowerCase();
   if (s=="airbnb") return atob("GBgBAAAAAAAAAAAAADwAAH4AAGYAAMMAAIEAAYGAAYGAAzzAA2bABmZgBmZgDGYwDDwwCDwQCBgQDDwwB+fgA8PAAAAAAAAAAAAA");
   if (s=="alarm" || s =="alarmclockreceiver") return atob("GBjBAP////8AAAAAAAACAEAHAOAefng5/5wTgcgHAOAOGHAMGDAYGBgYGBgYGBgYGBgYDhgYBxgMATAOAHAHAOADgcAB/4AAfgAAAAAAAAA=");
   if (s=="bibel") return atob("GBgBAAAAA//wD//4D//4H//4H/f4H/f4H+P4H4D4H4D4H/f4H/f4H/f4H/f4H/f4H//4H//4H//4GAAAEAAAEAAACAAAB//4AAAA");
@@ -154,6 +154,7 @@ exports.getMessageImage = function(msg) {
 };
 
 exports.getMessageImageCol = function(msg,def) {
+  const s = (("string"=== typeof msg) ? msg : (msg.src || "")).toLowerCase();
   return {
     // generic colors, using B2-safe colors
     "airbnb": "#f00",
@@ -202,5 +203,5 @@ exports.getMessageImageCol = function(msg,def) {
     "whatsapp": "#4fce5d",
     "wordfeud": "#e7d3c7",
     "youtube": "#f00",
-  }[(msg.src||"").toLowerCase()]||(def !== undefined?def:g.theme.fg);
+  }[s]||(def !== undefined?def:g.theme.fg);
 };

--- a/apps/messages/widget.js
+++ b/apps/messages/widget.js
@@ -7,6 +7,7 @@ function getMessages() {
 
 function filterMessages(msgs) {
   return msgs.filter(msg => msg.new && msg.id != "music")
+    .map(m => m.src) // we only need this for icon/color
     .filter((msg, i, arr) => arr.findIndex(nmsg => msg.src == nmsg.src) == i);
 }
 
@@ -35,7 +36,7 @@ draw:function(recall) {
         }
       }
       g.setColor(colors[1]).setBgColor(colors[0]);
-      g.drawImage(i == (settings.maxMessages - 1) && msgs.length > settings.maxMessages ? atob("GBgBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH4H4H4H4H4H4H4H4H4H4H4H4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") : require("messages").getMessageImage(msg), this.x + i * this.iconwidth, this.y - 1);
+      g.drawImage(i == (settings.maxMessages - 1) && this.msgs.length > settings.maxMessages ? atob("GBgBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH4H4H4H4H4H4H4H4H4H4H4H4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") : require("messages").getMessageImage(msg), this.x + i * this.iconwidth, this.y - 1);
     }
   }
   if (c<settings.vibrateTimeout && // not going on too long...


### PR DESCRIPTION
Don't keep entire messages in memory: we only need `src` for icon+color

I figured this doesn't warrant a version bump, as there aren't any functional changes