### PR TITLE
Move tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "typeRoots": ["./types"]
+    "typeRoots": ["./typescript/types"]
   },
-  "include": ["../apps/**/*", "./**/*"]
+  "include": ["./**/*"]
 }


### PR DESCRIPTION
In the editor I use the TypeScript language server doesn't detect the `tsconfig.json` file when it's in the `typescript` folder, meaning I have to manually open the `main.d.ts` file. Moving it to the root folder fixes that.