### PR TITLE
widcw: fix memory leak

### DIFF
--- a/apps/widcw/ChangeLog
+++ b/apps/widcw/ChangeLog
@@ -1,1 +1,2 @@
 0.01: First version
+0.02: Fix memory leak

--- a/apps/widcw/metadata.json
+++ b/apps/widcw/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widcw",
   "name": "Calendar Week Widget",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Widget which shows the current calendar week",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widcw/widget.js
+++ b/apps/widcw/widget.js
@@ -34,8 +34,8 @@
     }
     
     // redraw when date changes
-    setTimeout(()=>WIDGETS["widcw"].draw(), (86401 - Math.floor(date/1000) % 86400)*1000);
-    
+    if (WIDGETS["widcw"].to) clearTimeout(WIDGETS["widcw"].to);
+    WIDGETS["widcw"].to = setTimeout(()=>WIDGETS["widcw"].draw(), (86401 - Math.floor(date/1000) % 86400)*1000);
   }
 
   // add your widget


### PR DESCRIPTION
Repeated redrawing would create multiple redraw-timeouts

(Same as https://github.com/espruino/BangleApps/pull/1713 for `widcal`)