### PR TITLE
messages: improve memory usage

### DIFF
--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -286,6 +286,7 @@ function showMessage(msgid) {
     }
   }
   function goBack() {
+    layout = undefined;
     msg.new = false; saveMessages(); // read mail
     cancelReloadTimeout(); // don't auto-reload to clock now
     checkMessages({clockIfNoMsg:1,clockIfAllRead:0,showMsgIfUnread:0,openMusic:openMusic});


### PR DESCRIPTION
Clear `layout` when going back from message to list

Map and music already do this, just the single message view missed it.

I also considered converting `layout` from a global to local variables, but figured that leaving it global makes debugging easier.