### PR TITLE
weather: don't mark app as CLOCK.

### DIFF
--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -12,3 +12,4 @@
 0.13: Tweak Bangle.js 2 light theme colors
 0.14: Use weather condition code for icon selection
 0.15: Fix widget icon
+0.16: Don't mark app as clock

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -101,7 +101,11 @@ weather.on("update", update);
 
 update();
 
-// Show launcher when middle button pressed
+// We want this app to behave like a clock:
+// i.e. show launcher when middle button pressed
 Bangle.setUI("clock");
+// But the app is not actually a clock
+// This matters for widgets that hide themselves for clocks, like widclk or widclose
+delete Bangle.CLOCK;
 
 Bangle.drawWidgets();

--- a/apps/weather/metadata.json
+++ b/apps/weather/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "weather",
   "name": "Weather",
-  "version": "0.15",
+  "version": "0.16",
   "description": "Show Gadgetbridge weather report",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
Use setWatch() instead of setUI to make middle button open the launcher, checking HWVERSION to watch the correct button.

Otherwise widgets get confused and you don't get e.g. a close button.