### PR TITLE
agenda: disable past events display from settings

### DIFF
--- a/apps/agenda/ChangeLog
+++ b/apps/agenda/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Basic agenda with events from GB
 0.02: Added settings page to force calendar sync
+0.03: Disable past events display from settings

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "agenda",
   "name": "Agenda",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],
@@ -13,5 +13,6 @@
     {"name":"agenda.app.js","url":"agenda.js"},
     {"name":"agenda.settings.js","url":"settings.js"},
     {"name":"agenda.img","url":"agenda-icon.js","evaluate":true}
-  ]
+  ],
+  "data": [{"name":"agenda.settings.json"}]
 }

--- a/apps/agenda/settings.js
+++ b/apps/agenda/settings.js
@@ -3,6 +3,10 @@
     Bluetooth.println("");
     Bluetooth.println(JSON.stringify(message));
   }
+  var settings = require("Storage").readJSON("agenda.settings.json",1)||{};
+  function updateSettings() {
+    require("Storage").writeJSON("agenda.settings.json", settings);
+  }
   var CALENDAR = require("Storage").readJSON("android.calendar.json",true)||[];
   var mainmenu = {
     "" : { "title" : "Agenda" },
@@ -30,6 +34,13 @@
         });
       } else {
         E.showAlert(/*LANG*/"You are not connected").then(()=>E.showMenu(mainmenu));
+      }
+    },
+    /*LANG*/"Show past events" : {
+      value : !!settings.pastEvents,
+      onchange: v => {
+        settings.pastEvents = v;
+        updateSettings();
       }
     },
   };


### PR DESCRIPTION
(Small feature hoping someone is actually able to use the agenda with GB)
Gadgetbridge doesn't synchronize events very frequently, unless there's a change in the calendar (new events), the update may take a day or more, depending on the connection status.
This means that before GB realizes there are old events and deletes them, we may see them in the calendar for a while.

With this update, by default the agenda won't show them. If enabled they can still be shown (grayed out). An event is considered old immediately after its finishing time, in a future update we could add a threshold for that (e.g. show events finished 1 hour ago).