### PR TITLE
Waypoint bugfix

### DIFF
--- a/apps/waypoints/lib.js
+++ b/apps/waypoints/lib.js
@@ -1,7 +1,7 @@
 exports.load = (num) => {
-  return require("Storage").readJSON(`waypoints${num?`.${num}`:""}.json`)||[{name:"NONE"}];
+  return require("Storage").readJSON(`waypoints${num?".${num}":""}.json`)||[{name:"NONE"}];
 };
 
 exports.save = (waypoints,num) => {
-  require("Storage").writeJSON(`waypoints${num?`.${num}`:""}.json`, waypoints);
+  require("Storage").writeJSON(`waypoints${num?".${num}":""}.json`, waypoints);
 };

--- a/apps/waypoints/lib.js
+++ b/apps/waypoints/lib.js
@@ -1,7 +1,7 @@
 exports.load = (num) => {
-  return require("Storage").readJSON(`waypoints${num?".${num}":""}.json`)||[{name:"NONE"}];
+  return require("Storage").readJSON(`waypoints${num?"."+num:""}.json`)||[{name:"NONE"}];
 };
 
 exports.save = (waypoints,num) => {
-  require("Storage").writeJSON(`waypoints${num?".${num}":""}.json`, waypoints);
+  require("Storage").writeJSON(`waypoints${num?"."+num:""}.json`, waypoints);
 };


### PR DESCRIPTION
The current library for waypoints includes nested backticks for format string evaluation. However, when attempting to import this library (e.g. with `require("waypoints").load()` such as in the Way Pointer app) I get the error  

`Uncaught SyntaxError: Got EOF expected ':'
 at line 1 col 5
num?
    ^
 at line 1 col 5
num?
    ^
in function "load" called from line 44 col 38 in waypointer.app.js
var waypoints=require("waypoints").load();`. 

This is fixed by removing the inner backticks and replacing them with string concatenation, which still appears to evaluate the format string correctly.