### PR TITLE
Add option to hide GPS widget when GPS is off

### DIFF
--- a/apps/widgps/ChangeLog
+++ b/apps/widgps/ChangeLog
@@ -5,4 +5,4 @@
 0.05: Don't poll for GPS status, override setGPSPower handler (fix #1456)
 0.06: Periodically update so the always on display does show current GPS fix
 0.07: Alternative marker icon (configurable via settings)
-0.08: Add ability to hide the icon when GPS is off, for a cleaner appearance
+0.08: Add ability to hide the icon when GPS is off, for a cleaner appearance.

--- a/apps/widgps/ChangeLog
+++ b/apps/widgps/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Don't poll for GPS status, override setGPSPower handler (fix #1456)
 0.06: Periodically update so the always on display does show current GPS fix
 0.07: Alternative marker icon (configurable via settings)
+0.08: Add ability to hide the icon when GPS is off, for a cleaner appearance

--- a/apps/widgps/README.md
+++ b/apps/widgps/README.md
@@ -14,11 +14,14 @@ There are two icons which can be used to visualize the GPS/GNSS status:
     - Shows in green when the GPS is on and has a fix
 2. Different place markers depending on GPS/GNSS status
 
+You can also choose to hide the icon when the GPS is off in the settings.
     
 Written by: [Hugh Barney](https://github.com/hughbarney) For support
 and discussion please post in the [Bangle JS
 Forum](http://forum.espruino.com/microcosms/1424/)
 
 Extended by Marco ([myxor](https://github.com/myxor))
+
+Extended by khromov ([myxor](https://github.com/khromov))
 
 Place marker icons from [icons8.com](https://icons8.com/icon/set/maps/material-outlined).

--- a/apps/widgps/README.md
+++ b/apps/widgps/README.md
@@ -22,6 +22,6 @@ Forum](http://forum.espruino.com/microcosms/1424/)
 
 Extended by Marco ([myxor](https://github.com/myxor))
 
-Extended by khromov ([myxor](https://github.com/khromov))
+Extended by khromov ([khromov](https://github.com/khromov))
 
 Place marker icons from [icons8.com](https://icons8.com/icon/set/maps/material-outlined).

--- a/apps/widgps/default.json
+++ b/apps/widgps/default.json
@@ -1,1 +1,1 @@
-{"crossIcon": "true"}
+{"crossIcon": true, "hideWhenGpsOff": false}

--- a/apps/widgps/metadata.json
+++ b/apps/widgps/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widgps",
   "name": "GPS Widget",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Tiny widget to show the power and fix status of the GPS/GNSS",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widgps/settings.js
+++ b/apps/widgps/settings.js
@@ -23,6 +23,10 @@ var mainmenu = {
     value : !!settings.crossIcon ,
       onchange : v => { writeSettings("crossIcon", v); }
     },
+  "Hide icon when GPS off" : {
+      value : !!settings.hideWhenGpsOff ,
+        onchange : v => { writeSettings("hideWhenGpsOff", v); }
+      },
 };
 E.showMenu(mainmenu);
 });

--- a/apps/widgps/settings.js
+++ b/apps/widgps/settings.js
@@ -20,11 +20,11 @@ var mainmenu = {
   '' : {'title' : 'GPS widget'},
   '< Back' : back,
   "Cross icon" : {
-    value : !!settings.crossIcon ,
+    value : settings.crossIcon ,
       onchange : v => { writeSettings("crossIcon", v); }
     },
   "Hide icon when GPS off" : {
-      value : !!settings.hideWhenGpsOff ,
+      value : settings.hideWhenGpsOff ,
         onchange : v => { writeSettings("hideWhenGpsOff", v); }
       },
 };

--- a/apps/widgps/widget.js
+++ b/apps/widgps/widget.js
@@ -1,6 +1,9 @@
 (function() {
-let settings =
-    require("Storage").readJSON("widgps.json", 1) || {crossIcon: true, hideWhenGpsOff: false};
+
+let settings = Object.assign(
+      require('Storage').readJSON("widgps.default.json", true) || {},
+      require('Storage').readJSON("widgps.json", true) || {}
+);
 
 var interval;
 

--- a/apps/widgps/widget.js
+++ b/apps/widgps/widget.js
@@ -35,13 +35,23 @@ WIDGETS.gps = {
         } else {
           g.setColor("#FD0"); // on but no fix = amber
         }
-      } else {
-        g.setColor("#888"); // off = grey
-      }
-      g.drawImage(
+
+        g.drawImage(
           atob(
               "GBiBAAAAAAAAAAAAAA//8B//+BgYGBgYGBgYGBgYGBgYGBgYGB//+B//+BgYGBgYGBgYGBgYGBgYGBgYGB//+A//8AAAAAAAAAAAAA=="),
           this.x, 2 + this.y);
+
+      } else {
+        if(!settings.hideWhenGpsOff) {
+          g.setColor("#888"); // off = grey
+
+          g.drawImage(
+            atob(
+                "GBiBAAAAAAAAAAAAAA//8B//+BgYGBgYGBgYGBgYGBgYGBgYGB//+B//+BgYGBgYGBgYGBgYGBgYGBgYGB//+A//8AAAAAAAAAAAAA=="),
+            this.x, 2 + this.y);
+        }
+      }
+
     } else { // marker icons
       if (Bangle.isGPSOn()) {  
         const gpsObject = Bangle.getGPSFix();

--- a/apps/widgps/widget.js
+++ b/apps/widgps/widget.js
@@ -1,6 +1,6 @@
 (function() {
 let settings =
-    require("Storage").readJSON("widgps.json", 1) || {crossIcon : true};
+    require("Storage").readJSON("widgps.json", 1) || {crossIcon: true, hideWhenGpsOff: false};
 
 var interval;
 
@@ -59,9 +59,11 @@ WIDGETS.gps = {
         }
       } else {
         // GNSS off
-        g.drawImage(
-              atob("GBiBAAAAAAAAAAB+ABj/ABxDgA4AwAcAwAeMYAfEYAbgYAZwYAM4wAMcQAOOAAGHAAHDgADDwABm4AB+cAA8OAAYGAAAAAAAAAAAAA=="),
-              this.x, 2 + this.y);
+        if(!settings.hideWhenGpsOff) {
+          g.drawImage(
+                atob("GBiBAAAAAAAAAAB+ABj/ABxDgA4AwAcAwAeMYAfEYAbgYAZwYAM4wAMcQAOOAAGHAAHDgADDwABm4AB+cAA8OAAYGAAAAAAAAAAAAA=="),
+                this.x, 2 + this.y);
+        }
       }
     }
   }


### PR DESCRIPTION
Small refactor that allows the user to switch off the icons when GPS is off.

![Screenshot 2022-08-11 at 00 10 24](https://user-images.githubusercontent.com/1207507/184038281-581ff279-f88c-47f6-afa8-299c84772efc.png)

