### PR TITLE
Use /usr/bin/env as shebang everywhere

### DIFF
--- a/bin/apploader.js
+++ b/bin/apploader.js
@@ -1,4 +1,4 @@
-#!/usr/bin/nodejs
+#!/usr/bin/env nodejs
 /* Simple Command-line app loader for Node.js
 ===============================================
 

--- a/bin/create_app_supports_field.js
+++ b/bin/create_app_supports_field.js
@@ -1,4 +1,4 @@
-#!/usr/bin/nodejs
+#!/usr/bin/env nodejs
 /* Quick hack to add proper 'supports' field to apps.json
 */
 

--- a/bin/create_apps_json.sh
+++ b/bin/create_apps_json.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ================================================================
 # apps.json used to contain the metadata for every app. Now the
 # metadata is stored in each apps's directory - app/yourapp/metadata.js

--- a/bin/firmwaremaker.js
+++ b/bin/firmwaremaker.js
@@ -1,4 +1,4 @@
-#!/usr/bin/nodejs
+#!/usr/bin/env nodejs
 /*
 Mashes together a bunch of different apps to make
 a single firmware JS file which can be uploaded.

--- a/bin/firmwaremaker_c.js
+++ b/bin/firmwaremaker_c.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 /*
 Mashes together a bunch of different apps into a big binary blob.
 We then store this *inside* the Bangle.js firmware and can use it

--- a/bin/pre-publish.sh
+++ b/bin/pre-publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`/..
 nodejs bin/sanitycheck.js || exit 1

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 /* Checks for any obvious problems in apps.json
 */
 

--- a/bin/thumbnailer.js
+++ b/bin/thumbnailer.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 /*
 var EMULATOR = "banglejs2";

--- a/tests/Layout/bin/runalltests.sh
+++ b/tests/Layout/bin/runalltests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`/..
 ls tests/*.js | xargs -I{} bin/runtest.sh {}

--- a/tests/Layout/bin/runtest.sh
+++ b/tests/Layout/bin/runtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Requires Linux x64 (for ./espruino)
 # Also imagemagick for display
 


### PR DESCRIPTION
It's not guaranteed that bash will be available at /bin/bash; it's even less likely that node will always be installed at /usr/bin/node{,js}. Always indirecting through /usr/bin/env means that there is only one such path that needs to be available on every system everywhere forever.

In particular, /bin/bash _is_ frequently available, but is not included in NixOS, which means I can't use the scripts unmodified for local development.

Note: `npm run update-local-apps` works for me after this, but I have not tested whether this breaks e.g. the github actions stuff.