### PR TITLE
[LCARS] Add ability to disable alarms 

### DIFF
--- a/apps/lcars/ChangeLog
+++ b/apps/lcars/ChangeLog
@@ -21,3 +21,4 @@
 0.21: Add custom theming.
 0.22: Fix alarm and add build in function for step counting.
 0.23: Add warning for low flash memory
+0.24: Add ability to disable alarm functionality

--- a/apps/lcars/lcars.app.js
+++ b/apps/lcars/lcars.app.js
@@ -12,6 +12,7 @@ let settings = {
   themeColor1BG: "#FF9900",
   themeColor2BG: "#FF00DC",
   themeColor3BG: "#0094FF",
+  disableAlarms: false,
 };
 let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || settings;
 for (const key in saved_settings) {
@@ -722,12 +723,12 @@ Bangle.on('touch', function(btn, e){
   }
 
   if(lcarsViewPos == 0){
-    if(is_upper){
+    if(is_upper && !settings.disableAlarms){
       feedback();
       increaseAlarm();
       drawState();
       return;
-    } if(is_lower){
+    } if(is_lower && !settings.disableAlarms){
       feedback();
       decreaseAlarm();
       drawState();

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -13,6 +13,7 @@
     themeColor1BG: "#FF9900",
     themeColor2BG: "#FF00DC",
     themeColor3BG: "#0094FF",
+    disableAlarms: false,
   };
   let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || settings;
   for (const key in saved_settings) {
@@ -102,6 +103,14 @@
         settings.themeColor3BG = bg_code[v];
         save();
       },
-    }
+    },
+    'Disable alarm functionality': {
+      value: settings.disableAlarms,
+      format: () => (settings.disableAlarms ? 'Yes' : 'No'),
+      onchange: () => {
+        settings.disableAlarms = !settings.disableAlarms;
+        save();
+      },
+    },
   });
 })

--- a/apps/lcars/metadata.json
+++ b/apps/lcars/metadata.json
@@ -3,7 +3,7 @@
   "name": "LCARS Clock",
   "shortName":"LCARS",
   "icon": "lcars.png",
-  "version":"0.23",
+  "version":"0.24",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "Library Computer Access Retrieval System (LCARS) clock.",


### PR DESCRIPTION
Really like this watch face, but I would find myself accidentally starting alarms when trying to touch right to go to the activity view, and occasionally also have "ghost" alarms where I didn't feel like I pressed something but must have accidentally started an alarm. This adds a simple setting for disabling the functionality without having to uninstall the Scheduler library.