### PR TITLE
[ptlaunch] Add setUI custom clock recognition

### DIFF
--- a/apps/ptlaunch/ChangeLog
+++ b/apps/ptlaunch/ChangeLog
@@ -6,3 +6,4 @@
 0.12: Improve pattern detection code readability by PaddeK http://forum.espruino.com/profiles/117930/
 0.13: Improve pattern rendering by HughB http://forum.espruino.com/profiles/167235/
 0.14: Update setUI to work with new Bangle.js 2v13 menu style
+0.15: Update to support clocks in custom setUI mode

--- a/apps/ptlaunch/boot.js
+++ b/apps/ptlaunch/boot.js
@@ -76,13 +76,8 @@
   var sui = Bangle.setUI;
   Bangle.setUI = function (mode, cb) {
     sui(mode, cb);
-    if ("object"==typeof mode) mode = mode.mode;
-    if (!mode) {
-      Bangle.removeListener("drag", dragHandler);
-      storedPatterns = {};
-      return;
-    }
-    if (!mode.startsWith("clock")) {
+    if (typeof mode === "object") mode = { mode: mode };
+    if (!mode || !(mode.clock || mode.startsWith("clock"))) {
       storedPatterns = {};
       Bangle.removeListener("drag", dragHandler);
       return;

--- a/apps/ptlaunch/boot.js
+++ b/apps/ptlaunch/boot.js
@@ -76,10 +76,10 @@
   var sui = Bangle.setUI;
   Bangle.setUI = function (mode, cb) {
     sui(mode, cb);
-    if (typeof mode === "object") mode = { mode: mode };
-    if (!mode || !(mode.clock || mode.startsWith("clock"))) {
+    if (typeof mode === "object") mode = (mode.clock ? "clock" : "") + mode.mode;
+    if (!mode || !mode.startsWith("clock")) {
       storedPatterns = {};
-      Bangle.removeListener("drag", dragHandler);
+      Bangle.removeListener("drag", dragHandler);s
       return;
     }
 

--- a/apps/ptlaunch/boot.js
+++ b/apps/ptlaunch/boot.js
@@ -79,7 +79,7 @@
     if (typeof mode === "object") mode = (mode.clock ? "clock" : "") + mode.mode;
     if (!mode || !mode.startsWith("clock")) {
       storedPatterns = {};
-      Bangle.removeListener("drag", dragHandler);s
+      Bangle.removeListener("drag", dragHandler);
       return;
     }
 

--- a/apps/ptlaunch/metadata.json
+++ b/apps/ptlaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "ptlaunch",
   "name": "Pattern Launcher",
   "shortName": "Pattern Launcher",
-  "version": "0.14",
+  "version": "0.15",
   "description": "Directly launch apps from the clock screen with custom patterns.",
   "icon": "app.png",
   "screenshots": [{"url":"manage_patterns_light.png"}],


### PR DESCRIPTION
Update boot.js to support clocks in custom setUI mode, started with: `Bangle.setUI({ mode: "custom", clock: 1, ... });`