### PR TITLE
[slash] If midnight clear the display to clean up artifacts

### DIFF
--- a/apps/slash/ChangeLog
+++ b/apps/slash/ChangeLog
@@ -1,1 +1,2 @@
 0.01: First version for upload
+0.02: Fix for leftover date artifacts on display.

--- a/apps/slash/app.js
+++ b/apps/slash/app.js
@@ -57,6 +57,10 @@ function draw() {
   var minutes = ("0"+m).substr(-2);
   g.reset();
   
+  // If midnight clear display to remove day / date artifacts
+  if (h == 0 && m == 0)
+    g.clear();
+  
   // Convert to 12hr time mode
   if (is12Hour && h > 12) {
     h = h - 12;

--- a/apps/slash/metadata.json
+++ b/apps/slash/metadata.json
@@ -4,7 +4,7 @@
   "shortName":"Slash",
   "icon": "slash.png",
   "screenshots": [{"url":"screenshot.png"}],
-  "version":"0.01",
+  "version":"0.02",
   "description": "Slash Watch based on Pebble watch face by Nikki.",
   "tags": "clock",
   "type": "clock",


### PR DESCRIPTION
Since slash is (wisely) very conservative about clearing / redrawing, artifacts from past dates that aren't overwritten tend to stack up. On my watch now where it says "Sun 9/18" there is some left over "T" from last Thursday sticking out to the left of the "S" in "Sun", and some leftover "6" sticking out to the right of the "8" in "18" from two days ago. This should clear everything once a day at midnight so these artifacts get cleared out.