### PR TITLE
[kbmulti] switch directions for Caps lock switch and Move cursor mode

### DIFF
--- a/apps/kbmulti/ChangeLog
+++ b/apps/kbmulti/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Introduce setting "Show help button?". Make setting firstLaunch invisible by removing corresponding code from settings.js. Add marker that shows when character selection timeout has run out. Display opened text on launch when editing existing text string. Perfect horizontal alignment of buttons. Tweak help message letter casing.
 0.03: Use default Bangle formatter for booleans
 0.04: Allow moving the cursor
+0.05: Switch swipe directions for Caps Lock and moving cursor.

--- a/apps/kbmulti/README.md
+++ b/apps/kbmulti/README.md
@@ -2,7 +2,7 @@
 
 A library that provides the ability to input text in a style familiar to anyone who had a mobile phone before they went all touchscreen.
 
-Swipe right for Space, left for Backspace, down for cursor moving mode, and up for Caps lock. Swipe left and right to move the cursor in moving mode. Tap the '?' button in the app if you need a reminder!
+Swipe right for Space, left for Backspace, down for Caps lock switch, and up for cursor moving mode. Swipe left and right to move the cursor in moving mode. Tap the '?' button in the app if you need a reminder!
 
 At time of writing, only the [Noteify app](http://microco.sm/out/Ffe9i) uses a keyboard.
 

--- a/apps/kbmulti/lib.js
+++ b/apps/kbmulti/lib.js
@@ -17,7 +17,7 @@ exports.input = function(options) {
     "4":"GHI4","5":"JKL5","6":"MNO6",
     "7":"PQRS7","8":"TUV80","9":"WXYZ9",
   };
-  var helpMessage = 'Swipe:\nRight: Space\nLeft:Backspace\nUp: Caps lock\nDown:Move mode';
+  var helpMessage = 'Swipe:\nRight: Space\nLeft:Backspace\nUp: Move mode\nDown:Caps lock';
 
   var charTimeout; // timeout after a key is pressed
   var charCurrent; // current character (index in letters)
@@ -122,10 +122,10 @@ exports.input = function(options) {
 
   function onSwipe(dirLeftRight, dirUpDown) {
     if (dirUpDown == -1) {
-      setCaps();
-    } else if (dirUpDown == 1) {
       moveMode = !moveMode;
       displayText(false);
+    } else if (dirUpDown == 1) {
+      setCaps();
     } else if (dirLeftRight == 1) {
       if (!moveMode){
         text = text.slice(0, textIndex + 1) + " " + text.slice(++textIndex);

--- a/apps/kbmulti/metadata.json
+++ b/apps/kbmulti/metadata.json
@@ -1,6 +1,6 @@
 { "id": "kbmulti",
   "name": "Multitap keyboard",
-  "version":"0.04",
+  "version":"0.05",
   "description": "A library for text input via multitap/T9 style keypad",
   "icon": "app.png",
   "type":"textinput",


### PR DESCRIPTION
I switched the direction for Caps lock switching and Move cursor mode. I have two rationalizations for this. One, I feel the top-to-bottom swipe motion is more natural/pleasant to perform and should therefore be used for the more frequently used task - for me, and I suspect most users, this is to switch Caps lock. Two, since we start with upper case it makes sense to make a downward motion to get to lower case letters.

A counter argument is doing this switch might interfere with established habits. Should this be a setting in that case? If so I suggest the default to be as what I change it to with this PR.

What do you think? @sir-indy @halemmerich 