### PR TITLE
Improve Calendar Clock current time contrast

### DIFF
--- a/apps/calclock/ChangeLog
+++ b/apps/calclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial version
 0.02: More compact rendering & app icon
 0.03: Tell clock widgets to hide.
+0.04: Improve current time readability in light theme.

--- a/apps/calclock/calclock.js
+++ b/apps/calclock/calclock.js
@@ -68,7 +68,7 @@ function drawEvent(event, y) {
 var curEventHeight = 0;
 
 function drawCurrentEvents(y) {
-  g.setColor("#0ff");
+  g.setColor(g.theme.dark ? "#0ff" : "#006060");
   g.clearRect(5, y, g.getWidth() - 5, y + curEventHeight);
   curEventHeight = y;
 

--- a/apps/calclock/metadata.json
+++ b/apps/calclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "calclock",
   "name": "Calendar Clock",
   "shortName": "CalClock",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Show the current and upcoming events synchronized from Gadgetbridge",
   "icon": "calclock.png",
   "type": "clock",


### PR DESCRIPTION
Fixes #2154, see that issue for the reasoning of how I came to this colour.

It's raining outside today quite badly and it doesn't look like the weather will improve much, so I haven't tested this under more glare yet. But I can notice a big difference just leaving my watch lying on the table with the screen dimmed from not actively using it.

I'm marking this as draft for now and will un-draft it sometime during next week when I have tested it during a regular work day.

P.S.: I'm impressed by how easy the BangleJS tooling is to use. The Web IDE works great and setting up my own App Loader based on the README instructions were easy and helped me feel certain everything would work well before making this PR. Thanks for BangleJS, this project really shows how great Open Source smartwatches can be :)