### PR TITLE
calendar - fix off-by-one-error on next year

### DIFF
--- a/apps/calendar/ChangeLog
+++ b/apps/calendar/ChangeLog
@@ -9,3 +9,4 @@
       read start of week from system settings
 0.09: Fix scope of let variables
 0.10: Use default Bangle formatter for booleans
+0.11: Fix off-by-one-error on next year

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -226,15 +226,14 @@ drawCalendar(date);
 clearWatch();
 Bangle.on("touch", area => {
   const month = date.getMonth();
-  let prevMonth;
   if (area == 1) {
     let prevMonth = month > 0 ? month - 1 : 11;
     if (prevMonth === 11) date.setFullYear(date.getFullYear() - 1);
     date.setMonth(prevMonth);
   } else {
-    let prevMonth = month < 11 ? month + 1 : 0;
-    if (prevMonth === 0) date.setFullYear(date.getFullYear() + 1);
-    date.setMonth(month + 1);
+    let nextMonth = month < 11 ? month + 1 : 0;
+    if (nextMonth === 0) date.setFullYear(date.getFullYear() + 1);
+    date.setMonth(nextMonth);
   }
   drawCalendar(date);
 });

--- a/apps/calendar/metadata.json
+++ b/apps/calendar/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "calendar",
   "name": "Calendar",
-  "version": "0.10",
+  "version": "0.11",
   "description": "Simple calendar",
   "icon": "calendar.png",
   "screenshots": [{"url":"screenshot_calendar.png"}],


### PR DESCRIPTION
The calendar jumps from 2022 to 2024 between December and January, and this seems to fix it

Signed-off-by: James Taylor <jt-git@nti.me.uk>