### PR TITLE
messages: pass all messages through "message" event

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -76,3 +76,4 @@
 0.53: Messages now uses Bangle.load() to load messages app faster (if possible)
 0.54: Move icons out to messageicons module
 0.55: Always use "message" events, even for the default app/widget
+      Hide widget while app is open

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -75,3 +75,4 @@
       Fix background color in messages list after one unread message is shown
 0.53: Messages now uses Bangle.load() to load messages app faster (if possible)
 0.54: Move icons out to messageicons module
+0.55: Always use "message" events, even for the default app/widget

--- a/apps/messages/app-newmessage.js
+++ b/apps/messages/app-newmessage.js
@@ -2,4 +2,5 @@
 BUZZ_ON_NEW_MESSAGE is set so when messages.app.js loads it knows
 that it should buzz */
 global.BUZZ_ON_NEW_MESSAGE = true;
+__FILE__="messages.app.js"; // used by widget to check if app is active
 eval(require("Storage").read("messages.app.js"));

--- a/apps/messages/app.js
+++ b/apps/messages/app.js
@@ -62,6 +62,11 @@ var onMessagesModified = function(msg) {
   }
   showMessage(msg&&msg.id);
 };
+Bangle.on("message", (type, msg) => {
+  msg.handled = true;
+  onMessagesModified(msg);
+});
+
 function saveMessages() {
   require("Storage").writeJSON("messages.json",MESSAGES)
 }

--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -12,11 +12,15 @@ function openMusic() {
   {t:"modify",id:int, title:string} // modified
 */
 exports.pushMessage = function(event) {
-  var messages = exports.getMessages();
+  const inApp = ("undefined"!=typeof MESSAGES);
+  // Always set MESSAGES, even when not in the app, so calls to getMessages from
+  // listeners to "message" event don't all cause Storage.read()s
+  // If not in the app: We delete MESSAGES after the handleMessage timeout
+  MESSAGES = exports.getMessages();
   // now modify/delete as appropriate
-  var mIdx = messages.findIndex(m=>m.id==event.id);
+  var mIdx = MESSAGES.findIndex(m=>m.id==event.id);
   if (event.t=="remove") {
-    if (mIdx>=0) messages.splice(mIdx, 1); // remove item
+    if (mIdx>=0) MESSAGES.splice(mIdx, 1); // remove item
     mIdx=-1;
   } else { // add/modify
     if (event.t=="add"){
@@ -26,16 +30,15 @@ exports.pushMessage = function(event) {
     }
     if (mIdx<0) {
       mIdx=0;
-      messages.unshift(event); // add new messages to the beginning
+      MESSAGES.unshift(event); // add new messages to the beginning
     }
-    else Object.assign(messages[mIdx], event);
-    if (event.id=="music" && messages[mIdx].state=="play") {
-      messages[mIdx].new = true; // new track, or playback (re)started
-      type = 'music';
+    else Object.assign(MESSAGES[mIdx], event);
+    if (event.id=="music" && MESSAGES[mIdx].state=="play") {
+      MESSAGES[mIdx].new = true; // new track, or playback (re)started
     }
   }
-  require("Storage").writeJSON("messages.json",messages);
-  var message = mIdx<0 ? {id:event.id, t:'remove'} : messages[mIdx];
+  require("Storage").writeJSON("messages.json",MESSAGES);
+  var message = mIdx<0 ? {id:event.id, t:'remove'} : MESSAGES[mIdx];
   // emit message event
   var type = 'text';
   if (["call", "music", "map"].includes(message.id)) type = message.id;
@@ -43,12 +46,12 @@ exports.pushMessage = function(event) {
   Bangle.emit("message", type, message);
   var handleMessage = () => {
     // if no new messages now, make sure we don't load the messages app
-    if (event.t=="remove" && exports.messageTimeout && !messages.some(m => m.new)) {
+    if (event.t=="remove" && exports.messageTimeout && !MESSAGES.some(m => m.new)) {
       clearTimeout(exports.messageTimeout);
       delete exports.messageTimeout;
     }
     // ok, saved now
-    if (event.id=="music" && Bangle.CLOCK && messages[mIdx].new && openMusic()) {
+    if (event.id=="music" && Bangle.CLOCK && MESSAGES[mIdx].new && openMusic()) {
       // just load the app to display music: no buzzing
       Bangle.load("messages.app.js");
     } else if (event.t!="add") {
@@ -84,25 +87,26 @@ exports.pushMessage = function(event) {
   };
   setTimeout(()=>{
     if (!message.handled) handleMessage();
+    if (!inApp) delete MESSAGES; // don't keep this around
   },0);
 }
 /// Remove all messages
 exports.clearAll = function() {
-  if ("undefined"!= typeof MESSAGES) { // we're in a messages app, clear that as well
-    MESSAGES = [];
-  }
+  const inApp = ("undefined"!=typeof MESSAGES);
   // Clear all messages
+  MESSAGES = [];
   require("Storage").writeJSON("messages.json", []);
   // let message listeners know
   Bangle.emit("message", "clearAll", {}); // guarantee listeners an object as `message`
   // clearAll cannot be marked as "handled"
+  if (!inApp) delete MESSAGES;
 }
 
 /**
  * @returns {array} All messages
  */
 exports.getMessages = function() {
-  if ("undefined"!=typeof MESSAGES) return MESSAGES; // loaded/managed by app
+  if ("undefined"!=typeof MESSAGES) return MESSAGES; // already loaded
   return require("Storage").readJSON("messages.json",1)||[];
 }
 

--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -36,15 +36,11 @@ exports.pushMessage = function(event) {
   }
   require("Storage").writeJSON("messages.json",messages);
   var message = mIdx<0 ? {id:event.id, t:'remove'} : messages[mIdx];
-  // if in app, process immediately
-  if ("undefined"!=typeof MESSAGES) return onMessagesModified(message);
   // emit message event
   var type = 'text';
   if (["call", "music", "map"].includes(message.id)) type = message.id;
   if (message.src && message.src.toLowerCase().startsWith("alarm")) type = "alarm";
   Bangle.emit("message", type, message);
-  // update the widget icons shown
-  if (global.WIDGETS && WIDGETS.messages) WIDGETS.messages.update(messages,true);
   var handleMessage = () => {
     // if no new messages now, make sure we don't load the messages app
     if (event.t=="remove" && exports.messageTimeout && !messages.some(m => m.new)) {
@@ -83,7 +79,6 @@ exports.pushMessage = function(event) {
         // we will buzz when we enter the messages app
         return Bangle.load("messages.new.js");
       }
-      if (global.WIDGETS && WIDGETS.messages) WIDGETS.messages.update(messages);
       exports.buzz(message.src);
     }, 500);
   };
@@ -98,14 +93,9 @@ exports.clearAll = function() {
   }
   // Clear all messages
   require("Storage").writeJSON("messages.json", []);
-  // if we have a widget, update it
-  if (global.WIDGETS && WIDGETS.messages)
-    WIDGETS.messages.update([]);
   // let message listeners know
   Bangle.emit("message", "clearAll", {}); // guarantee listeners an object as `message`
   // clearAll cannot be marked as "handled"
-  // update app if in app
-  if ("function"== typeof onMessagesModified) onMessagesModified();
 }
 
 /**

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.54",
+  "version": "0.55",
   "description": "App to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messages/widget.js
+++ b/apps/messages/widget.js
@@ -38,9 +38,11 @@ WIDGETS["messages"]={area:"tl", width:0, draw:function(recall) {
   }
   WIDGETS["messages"].i=setTimeout(()=>WIDGETS["messages"].draw(true), 1000);
   if (process.env.HWVERSION>1) Bangle.on('touch', this.touch);
-},update:function(rawMsgs) {
+},onMsg:function(type, msg) {
+  if (type==="music") return;
+  if (msg.t!=="remove" && this.msgs.includes(msg.src)) return; // icon for this src already shown
   const settings =  Object.assign({maxMessages:3},require('Storage').readJSON("messages.settings.json", true) || {});
-  this.msgs = filterMessages(rawMsgs);
+  this.msgs = filterMessages(require("messages").getMessages());
   this.width = 24 * E.clip(this.msgs.length, 0, settings.maxMessages);
   Bangle.drawWidgets();
 },touch:function(b,c) {
@@ -52,5 +54,6 @@ WIDGETS["messages"]={area:"tl", width:0, draw:function(recall) {
 /* We might have returned here if we were in the Messages app for a
 message but then the watch was never viewed. */
 if (global.MESSAGES===undefined)
-  WIDGETS["messages"].update(require("messages").getMessages());
+  WIDGETS["messages"].onMsg('',{});
+  Bangle.on("message", WIDGETS["messages"].onMsg);
 })();


### PR DESCRIPTION
Instead of directly calling from the lib into the app/widget, always use "message" events.      
Also adds some optimization so we only read messages from storage once per event.

This also gets rid of the `update` method, see https://forum.espruino.com/comments/16740860/

Marking this as draft because it's friday night, and I don't have time to properly test it, but other than that it is finished ;-)