### PR TITLE
Iconlaunch - Back to slow loading apps

### DIFF
--- a/apps/iconlaunch/ChangeLog
+++ b/apps/iconlaunch/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Cache apps for faster start
 0.07: Read app icons on demand
       Add swipe-to-exit
+0.08: Only use fast loading for switching to clock to prevent problems in full screen apps

--- a/apps/iconlaunch/README.md
+++ b/apps/iconlaunch/README.md
@@ -13,4 +13,4 @@ The app uses `E.showScroller`'s code in the app but not the function itself beca
 
 ### Fastload option
 
-Fastload clears up the memory used by the launcher and directly evals the code of the app to load. This means if widgets are loaded (fullscreen option) it is possible that widgets stay loaded in apps not expecting that and the widgets may draw over the app.
+Fastload clears up the memory used by the launcher and directly evals the code of the clock to load.

--- a/apps/iconlaunch/app.js
+++ b/apps/iconlaunch/app.js
@@ -11,10 +11,10 @@
   launchCache = {
     hash : launchHash,
     apps : s.list(/\.info$/)
-      .map(app=>{var a=s.readJSON(app,1);return a&&{name:a.name,type:a.type,icon:a.icon,sortorder:a.sortorder,src:a.src};})
+      .map(app=>{let a=s.readJSON(app,1);return a&&{name:a.name,type:a.type,icon:a.icon,sortorder:a.sortorder,src:a.src};})
       .filter(app=>app && (app.type=="app" || (app.type=="clock" && settings.showClocks) || !app.type))
       .sort((a,b)=>{
-        var n=(0|a.sortorder)-(0|b.sortorder);
+        let n=(0|a.sortorder)-(0|b.sortorder);
         if (n) return n; // do sortorder first
         if (a.name<b.name) return -1;
         if (a.name>b.name) return 1;
@@ -54,7 +54,7 @@
     drawText(itemI);
   };
   let drawItemAuto = function(i) {
-    var y = idxToY(i);
+    let y = idxToY(i);
     g.reset().setClipRect(R.x, y, R.x2, y + itemSize);
     drawItem(i, {
       x: R.x,
@@ -86,7 +86,7 @@
     const appId = id * appsN + iconN;
     if( settings.direct && launchCache.apps[appId])
     {
-      loadApp(launchCache.apps[appId].src);
+      load(launchCache.apps[appId].src);
       return;
     }
     if (appId == selectedItem && launchCache.apps[appId]) {
@@ -94,7 +94,7 @@
       if (!app.src || s.read(app.src) === undefined) {
         E.showMessage( /*LANG*/ "App Source\nNot found");
       } else {
-        loadApp(app.src);
+        load(app.src);
       }
     }
     selectedItem = appId;
@@ -109,9 +109,9 @@
   let drawItems = function() {
     g.reset().clearRect(R.x, R.y, R.x2, R.y2);
     g.setClipRect(R.x, R.y, R.x2, R.y2);
-    var a = YtoIdx(R.y);
-    var b = Math.min(YtoIdx(R.y2), 99);
-    for (var i = a; i <= b; i++)
+    let a = YtoIdx(R.y);
+    let b = Math.min(YtoIdx(R.y2), 99);
+    for (let i = a; i <= b; i++)
       drawItem(i, {
       x: R.x,
       y: idxToY(i),
@@ -168,25 +168,20 @@
     }
     g.setClipRect(0, 0, g.getWidth() - 1, g.getHeight() - 1);
   };
-  Bangle.setUI({
+  let mode = {
     mode: "custom",
     drag: onDrag,
     touch: (_, e) => {
       if (e.y < R.y - 4) return;
-      var i = YtoIdx(e.y);
+      let i = YtoIdx(e.y);
       selectItem(i, e);
     },
     swipe: (h,_) => { if(settings.swipeExit && h==1) { returnToClock(); } },
-  });
-  const returnToClock = function() {
-    loadApp(".bootcde");
   };
-  let watch;
-  let loadApp;
-  if (settings.fastload){
-    loadApp = function(name) {
+
+  const returnToClock = function() {
+    if (settings.fastload == true){
       Bangle.setUI();
-      if (watch) clearWatch(watch);
       delete launchCache;
       delete launchHash;
       delete drawItemAuto;
@@ -199,16 +194,14 @@
       delete idxToY;
       delete YtoIdx;
       delete settings;
-      setTimeout(eval, 0, s.read(name));
-      return;
-    };
-  } else {
-    loadApp = function(name) {
-      load(name);
+      setTimeout(eval, 0, s.read(".bootcde"));
+    } else {
+      load();
     }
-  }
+  };
+
   
-  if (settings.oneClickExit) {
-    watch = setWatch(returnToClock, BTN1);
-  }
+  if (settings.oneClickExit) mode.btn = returnToClock;
+
+  Bangle.setUI(mode);
 }

--- a/apps/iconlaunch/metadata.json
+++ b/apps/iconlaunch/metadata.json
@@ -2,7 +2,7 @@
 	"id": "iconlaunch",
 	"name": "Icon Launcher",
 	"shortName" : "Icon launcher",
-	"version": "0.07",
+	"version": "0.08",
 	"icon": "app.png",
 	"description": "A launcher inspired by smartphones, with an icon-only scrollable menu.",
 	"tags": "tool,system,launcher",


### PR DESCRIPTION
Since there are problems with all full screen apps it's probably better to only directly load the clock. When fastloading full screen apps widgets will draw over those without a way of recovering without restarting the app.
Discussion on ongoing development for correctly fast loading apps can be found here: [https://forum.espruino.com/conversations/379724/](https://forum.espruino.com/conversations/379724/)