### PR TITLE
iconlaunch - Remove no longer needed fastload option

### DIFF
--- a/apps/iconlaunch/ChangeLog
+++ b/apps/iconlaunch/ChangeLog
@@ -7,3 +7,4 @@
 0.07: Read app icons on demand
       Add swipe-to-exit
 0.08: Only use fast loading for switching to clock to prevent problems in full screen apps
+0.09: Remove fast load option since clocks containing Bangle.loadWidgets are now always normally loaded

--- a/apps/iconlaunch/README.md
+++ b/apps/iconlaunch/README.md
@@ -10,7 +10,3 @@ This launcher shows 9 apps per screen, making it much faster to navigate versus 
 ## Technical note
 
 The app uses `E.showScroller`'s code in the app but not the function itself because `E.showScroller` doesn't report the position of a press to the select function.
-
-### Fastload option
-
-Fastload clears up the memory used by the launcher and directly evals the code of the clock to load.

--- a/apps/iconlaunch/app.js
+++ b/apps/iconlaunch/app.js
@@ -1,6 +1,6 @@
 {
   const s = require("Storage");
-  const settings = s.readJSON("launch.json", true) || { showClocks: true, fullscreen: false,direct:false,swipeExit:false,oneClickExit:false,fastload:false };
+  const settings = s.readJSON("launch.json", true) || { showClocks: true, fullscreen: false,direct:false,swipeExit:false,oneClickExit:false};
   if (!settings.fullscreen) {
     Bangle.loadWidgets();
     Bangle.drawWidgets();
@@ -180,24 +180,20 @@
   };
 
   const returnToClock = function() {
-    if (settings.fastload == true){
-      Bangle.setUI();
-      delete launchCache;
-      delete launchHash;
-      delete drawItemAuto;
-      delete drawText;
-      delete selectItem;
-      delete onDrag;
-      delete drawItems;
-      delete drawItem;
-      delete returnToClock;
-      delete idxToY;
-      delete YtoIdx;
-      delete settings;
-      setTimeout(eval, 0, s.read(".bootcde"));
-    } else {
-      load();
-    }
+    Bangle.setUI();
+    delete launchCache;
+    delete launchHash;
+    delete drawItemAuto;
+    delete drawText;
+    delete selectItem;
+    delete onDrag;
+    delete drawItems;
+    delete drawItem;
+    delete returnToClock;
+    delete idxToY;
+    delete YtoIdx;
+    delete settings;
+    setTimeout(eval, 0, s.read(".bootcde"));
   };
 
   

--- a/apps/iconlaunch/metadata.json
+++ b/apps/iconlaunch/metadata.json
@@ -2,7 +2,7 @@
 	"id": "iconlaunch",
 	"name": "Icon Launcher",
 	"shortName" : "Icon launcher",
-	"version": "0.08",
+	"version": "0.09",
 	"icon": "app.png",
 	"description": "A launcher inspired by smartphones, with an icon-only scrollable menu.",
 	"tags": "tool,system,launcher",

--- a/apps/iconlaunch/settings.js
+++ b/apps/iconlaunch/settings.js
@@ -5,8 +5,7 @@
     fullscreen: false,
     direct: false,
     oneClickExit: false,
-    swipeExit: false,
-    fastload: false
+    swipeExit: false
   }, require("Storage").readJSON("launch.json", true) || {});
 
   let fonts = g.getFonts();
@@ -36,10 +35,6 @@
     /*LANG*/"Swipe exit": {
       value: settings.swipeExit == true,
       onchange: m => { save("swipeExit", m) }
-    },
-    /*LANG*/"Fastload": {
-      value: settings.fastload == true,
-      onchange: (m) => { save("fastload", m) }
     }
   };
   E.showMenu(appMenu);


### PR DESCRIPTION
Always try to fastload the clock as .bootcde now checks if it has widgets.