### PR TITLE
boot - Add polyfills for Bangle.load and Bangle.showClock

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -59,3 +59,4 @@
       Add patch to ensure that compass heading is corrected on pre-2v15.68 firmware
       Ensure clock is only fast-loaded if it doesn't contain widgets
 0.52: Ensure heading patch for pre-2v15.68 firmware applies to getCompass
+0.53: Add polyfills for pre-2v15.135 firmware for Bangle.load and Bangle.showClock

--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -82,6 +82,14 @@ if (process.version.replace("v","")<215.68)
   boot += `Bangle.on('mag',e=>{if(!isNaN(e.heading))e.heading=360-e.heading;});
 Bangle.getCompass=(c=>(()=>{e=c();if(!isNaN(e.heading))e.heading=360-e.heading;return e;}))(Bangle.getCompass);`;
 
+ // deleting stops us getting confused by our own decl. builtins can't be deleted
+if (process.version.replace("v","")<215.135) { // this is a polyfill without fastloading capability
+  delete Bangle.showClock;
+  if (!Bangle.showClock) boot += `Bangle.showClock = ()=>{load(".bootcde")};\n`;
+  delete Bangle.load;
+  if (!Bangle.load) boot += `Bangle.load = load;\n`;
+}
+
 // ================================================== BOOT.JS
 // Append *.boot.js files
 // These could change bleServices/bleServiceOptions if needed

--- a/apps/boot/metadata.json
+++ b/apps/boot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boot",
   "name": "Bootloader",
-  "version": "0.52",
+  "version": "0.53",
   "description": "This is needed by Bangle.js to automatically load the clock, menu, widgets and settings",
   "icon": "bootloader.png",
   "type": "bootloader",


### PR DESCRIPTION
These are minimal polyfills, just delegating the new calls to load(). Is this enough or should they mimic more of the new calls?