### PR TITLE
[Torch] use Bangle.showClock

### DIFF
--- a/apps/torch/ChangeLog
+++ b/apps/torch/ChangeLog
@@ -7,3 +7,4 @@
 0.07: Code tweaks
 0.08: Force background of widget field to the torch colour
 0.09: Change code taking FW tweaks into account
+0.10: Introduce fast switching.

--- a/apps/torch/app.js
+++ b/apps/torch/app.js
@@ -1,21 +1,31 @@
-const SETTINGS_FILE = "torch.json";
-let settings;
+{
+  const SETTINGS_FILE = "torch.json";
+  let settings;
 
-function loadSettings() {
-  settings = require("Storage").readJSON(SETTINGS_FILE,1)|| {'bg': '#FFFFFF', 'color': 'White'};
+  let loadSettings = function() {
+    settings = require("Storage").readJSON(SETTINGS_FILE,1)|| {'bg': '#FFFFFF', 'color': 'White'};
+  };
+
+  loadSettings();
+
+  let brightnessBackup = require("Storage").readJSON('setting.json').brightness;
+  let optionsBackup = Bangle.getOptions();
+  Bangle.setLCDBrightness(1);
+  Bangle.setLCDPower(1);
+  Bangle.setLCDTimeout(0);
+  g.reset();
+  let themeBackup = g.theme;
+  g.setTheme({bg:settings.bg,fg:"#000"});
+  g.setColor(settings.bg);
+  g.fillRect(0,0,g.getWidth(),g.getHeight());
+  Bangle.setUI({
+    mode : 'custom',
+    back : Bangle.showClock, // B2: SW back button to exit
+    btn :  _=>Bangle.showClock(), // B1&2: HW button to exit. 
+    remove : ()=>{
+      Bangle.setLCDBrightness(brightnessBackup);
+      Bangle.setOptions(optionsBackup);
+      g.setTheme(themeBackup);
+    }
+  });
 }
-
-loadSettings();
-
-Bangle.setLCDBrightness(1);
-Bangle.setLCDPower(1);
-Bangle.setLCDTimeout(0);
-g.reset();
-g.setTheme({bg:settings.bg,fg:"#000"});
-g.setColor(settings.bg);
-g.fillRect(0,0,g.getWidth(),g.getHeight());
-Bangle.setUI({
-  mode : 'custom',
-  back : load, // B2: SW back button to exit
-  btn : ()=>{load();}, // B1&2: HW button to exit. // A simple 'load' as on the line above did not work for btn???
-});

--- a/apps/torch/metadata.json
+++ b/apps/torch/metadata.json
@@ -2,7 +2,7 @@
   "id": "torch",
   "name": "Torch",
   "shortName": "Torch",
-  "version": "0.09",
+  "version": "0.10",
   "description": "Turns screen white to help you see in the dark. Select from the launcher or press BTN1,BTN3,BTN1,BTN3 quickly to start when in any app that shows widgets on Bangle.js 1. You can also set the color through the app's setting menu.",
   "icon": "app.png",
   "tags": "tool,torch",


### PR DESCRIPTION
Weirdly exiting with HW button behaves a little differently from using the red back button.
 
- Red back button: the clock and widgets are displayed at the same time when everything is ready.
- HW button: the widgets are displayed immediately, followed shortly thereafter by the clock.

Open question: should we just leave widgets shown i.e. we could do without `widget_utils` here?