### PR TITLE
Update README.md to hint about how to require Bangle modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,10 @@ It should also add `myappid.json` to `data`, to make sure it is cleaned up when 
 ## Modules
 
 You can include any of [Espruino's modules](https://www.espruino.com/Modules) as
-normal with `require("modulename")`. If you want to develop your own module for your
+normal with `require("modulename")`. To include [Bangle's modules](modules) for use in the Web
+IDE, [upload the modules to internal storage](modules#upload-the-module-to-the-bangles-internal-storage)
+or [change the IDE's search path](modules#change-the-web-ide-search-path-to-include-banglejs-modules).
+If you want to develop your own module for your
 app(s) then you can do that too. Just add the module into the `modules` folder
 then you can use it from your app as normal.
 


### PR DESCRIPTION
It's frustrating for newcomers to try to tweak an existing app in the Web IDE and get "Module ... not found" and not know why, when this section just seem to state that any "require" should work.  The extra note clarifies this.