### PR TITLE
[Quick Launch] Revert "Use Bangle.load(), remove the special 'Show launcher' entry"

### DIFF
--- a/apps/quicklaunch/ChangeLog
+++ b/apps/quicklaunch/ChangeLog
@@ -3,4 +3,3 @@
 0.03: Better performance by not scanning on every boot
 0.04: Better performace by not scanning on boot at all
 0.05: Update to work with new 'fast switch' clock->launcher functionality
-0.06: Use Bangle.load() to allow 'fast switch' for apps where it's available.

--- a/apps/quicklaunch/ChangeLog
+++ b/apps/quicklaunch/ChangeLog
@@ -3,3 +3,5 @@
 0.03: Better performance by not scanning on every boot
 0.04: Better performace by not scanning on boot at all
 0.05: Update to work with new 'fast switch' clock->launcher functionality
+0.06: Use Bangle.load() to allow 'fast switch' for apps where it's available.
+0.07: Revert version 0.06. This version is the same as 0.05.

--- a/apps/quicklaunch/boot.js
+++ b/apps/quicklaunch/boot.js
@@ -10,15 +10,15 @@
 
   Bangle.on("touch", () => {
     if (!Bangle.CLOCK) return;
-    if (settings.tapapp.src){ if (!storage.read(settings.tapapp.src)) reset("tapapp"); else Bangle.load(settings.tapapp.src); }
+    if (settings.tapapp.src){ if (!storage.read(settings.tapapp.src)) reset("tapapp"); else load(settings.tapapp.src); }
   });
 
   Bangle.on("swipe", (lr,ud) => {
     if (!Bangle.CLOCK) return;
 
-    if (lr == -1 && settings.leftapp && settings.leftapp.src){ if (!storage.read(settings.leftapp.src)) reset("leftapp"); else Bangle.load(settings.leftapp.src); }
-    if (lr == 1 && settings.rightapp && settings.rightapp.src){ if (!storage.read(settings.rightapp.src)) reset("rightapp"); else Bangle.load(settings.rightapp.src); }
-    if (ud == -1 && settings.upapp && settings.upapp.src){ if (!storage.read(settings.upapp.src)) reset("upapp"); else Bangle.load(settings.upapp.src); }
-    if (ud == 1 && settings.downapp && settings.downapp.src){ if (!storage.read(settings.downapp.src)) reset("downapp"); else Bangle.load(settings.downapp.src); }
+    if (lr == -1 && settings.leftapp && settings.leftapp.src){ if (settings.leftapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.leftapp.src)) reset("leftapp"); else load(settings.leftapp.src); }
+    if (lr == 1 && settings.rightapp && settings.rightapp.src){ if (settings.rightapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.rightapp.src)) reset("rightapp"); else load(settings.rightapp.src); }
+    if (ud == -1 && settings.upapp && settings.upapp.src){ if (settings.upapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.upapp.src)) reset("upapp"); else load(settings.upapp.src); }
+    if (ud == 1 && settings.downapp && settings.downapp.src){ if (settings.downapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.downapp.src)) reset("downapp"); else load(settings.downapp.src); }
   });
 }

--- a/apps/quicklaunch/metadata.json
+++ b/apps/quicklaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "quicklaunch",
   "name": "Quick Launch",
   "icon": "app.png",
-  "version":"0.06",
+  "version":"0.05",
   "description": "Tap or swipe left/right/up/down on your clock face to launch up to five apps of your choice. Configurations can be accessed through Settings->Apps.",
   "type": "bootloader",
   "tags": "tools, system",

--- a/apps/quicklaunch/metadata.json
+++ b/apps/quicklaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "quicklaunch",
   "name": "Quick Launch",
   "icon": "app.png",
-  "version":"0.05",
+  "version":"0.07",
   "description": "Tap or swipe left/right/up/down on your clock face to launch up to five apps of your choice. Configurations can be accessed through Settings->Apps.",
   "type": "bootloader",
   "tags": "tools, system",

--- a/apps/quicklaunch/settings.js
+++ b/apps/quicklaunch/settings.js
@@ -7,6 +7,13 @@ for (let c of ["leftapp","rightapp","upapp","downapp","tapapp"]){
 
 var apps = require("Storage").list(/\.info$/).map(app=>{var a=require("Storage").readJSON(app,1);return a&&{name:a.name,type:a.type,sortorder:a.sortorder,src:a.src};}).filter(app=>app && (app.type=="app" || app.type=="launch" || app.type=="clock" || !app.type));
 
+// Add psuedo app to trigger Bangle.showLauncher later
+apps.push({
+    "name": "Show Launcher",
+    "type": undefined, "sortorder": -10,
+    "src": "no sorce"
+   });
+
 apps.sort((a,b)=>{
   var n=(0|a.sortorder)-(0|b.sortorder);
   if (n) return n; // do sortorder first
@@ -124,4 +131,3 @@ apps.forEach((a)=>{
 
 showMainMenu();
 })
-


### PR DESCRIPTION
This reverts commit e115cac82a7cbc055b2473997c026554c1b1e9a7.

Back to how version 0.05 worked.

This solves #2295, but does not implement any of the suggestions regarding still using Bangle.load where applicable.