### PR TITLE
apploader - Load puck.js locally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "EspruinoAppLoaderCore"]
 	path = core
 	url = https://github.com/espruino/EspruinoAppLoaderCore.git
+[submodule "webtools"]
+	path = webtools
+	url = https://github.com/espruino/EspruinoWebTools.git

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
       </div>
     </footer>
 
-    <script src="https://www.puck-js.com/puck.js"></script>
+    <script src="webtools/puck.js"></script>
     <script src="core/lib/marked.min.js"></script>
     <script src="core/lib/espruinotools.js"></script>
     <script src="core/lib/heatshrink.js"></script>


### PR DESCRIPTION
Is this a valid way to make the locally hosted apploader usable if puck-js.com is not reachable? It did work for me, but I do not know if there are other implications of this.