### PR TITLE
widget_utils - Prevent initial draw clearing on global g

### DIFF
--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -42,6 +42,10 @@ exports.cleanup = function() {
     clearTimeout(exports.hideTimeout);
     delete exports.hideTimeout;
   }
+  if (exports.origDraw) {
+    Bangle.drawWidgets = exports.origDraw;
+    delete exports.origDraw;
+  }
 }
 
 /** Put widgets offscreen, and allow them to be swiped
@@ -85,7 +89,13 @@ exports.swipeOn = function() {
     if (w.area.startsWith("b"))
       w.area = "t"+w.area.substr(1);
   }
-  Bangle.drawWidgets();
+  
+  exports.origDraw = Bangle.drawWidgets;
+  Bangle.drawWidgets = ()=>{
+    g=og;
+    exports.origDraw();
+    g=_g;
+  };
   
   function anim(dir, callback) {
     if (exports.animInterval) clearInterval(exports.interval);


### PR DESCRIPTION
This fixes `Bangle.drawWidgets` clearing the top widget bar on the global graphics object instead of the newly allocated buffer for the widgets.