### PR TITLE
[Android] Add handling of phone gps data

### DIFF
--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -130,6 +130,13 @@
           request.j(event.err); //r = reJect function
         else
           request.r(event); //r = resolve function
+      },
+      "gps": function() {
+        delete event.t;
+        event.satellites = NaN;
+        event.course = NaN;
+        event.fix = 1;
+        Bangle.emit('gps', event);
       }
     };
     var h = HANDLERS[event.t];

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -139,6 +139,10 @@
         event.course = NaN;
         event.fix = 1;
         Bangle.emit('gps', event);
+      },
+      "is_gps_active": function() {
+        const gpsActive = originalIsGpsOn();
+        sendGPSPowerStatus(gpsActive);
       }
     };
     var h = HANDLERS[event.t];
@@ -205,12 +209,15 @@
   const originalSetGpsPower = Bangle.setGPSPower;
   const originalIsGpsOn = Bangle.isGPSOn;
 
+  function sendGPSPowerStatus(status) { gbSend({ t: "gps_power", status: status }); }
+
   // Replace set GPS power logic to suppress activation of gps, if the overwrite option is active
   Bangle.setGPSPower = (isOn, appID) => {
     const currentSettings = require("Storage").readJSON("android.settings.json",1)||{};
     if (!currentSettings.overwriteGps) {
       originalSetGpsPower(isOn, appID);
     } else {
+      sendGPSPowerStatus(Bangle.isGPSOn());
       const logMessage = 'Ignore gps power change due to the gps overwrite from android integration app';
       console.log(logMessage);
       Bluetooth.println(logMessage);

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -132,6 +132,8 @@
           request.r(event); //r = resolve function
       },
       "gps": function() {
+        const settings = require("Storage").readJSON("android.settings.json",1)||{};
+        if (!settings.overwriteGps) return;
         delete event.t;
         event.satellites = NaN;
         event.course = NaN;

--- a/apps/android/settings.js
+++ b/apps/android/settings.js
@@ -1,4 +1,13 @@
 (function(back) {
+
+  function onGpsOverwriteChange(newValue) {
+    if (newValue) {
+      Bangle.setGPSPower(false, 'android');
+    }
+    settings.overwriteGps = newValue;
+    updateSettings();
+  }
+
   function gb(j) {
     Bluetooth.println(JSON.stringify(j));
   }
@@ -22,6 +31,10 @@
         settings.keep = v;
         updateSettings();
       }
+    },
+    /*LANG*/"Overwrite GPS" : {
+      value : !!settings.overwriteGps,
+      onchange: onGpsOverwriteChange
     },
     /*LANG*/"Messages" : ()=>load("messages.app.js"),
   };


### PR DESCRIPTION
In the [Gadgedbridge PR](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/2976), i add the possibility to use the gps data of the phone.

With this PR, the android app gets extended, so that it can handle the communication with the gadegtbridge part.
To enable to do that i changed the following.
* I added a handler for a "gps" and a "is_gps_active" GB message.
   - The "gps" message retrieves the gps position of the phone and publishes it as a "gps" event onto the "Bangle" object.
   - The "is_gps_active" messages is a request of the phone to retrieve the current power status of the gps. This is used on the phone to stop sending GPS data if the gps is turned off on the bangle device to perserve the battery of the phone.
* I added a logic to overwrite the "setGPSPower" method and the "isGPSOn" method. This is needed so that, if the phone gps data is being used, the gps of the banglejs device is turned off.
* I added a setting to enable the overwrite. This must be set or other wise the messages from the phone will be ignored.


* The received gps data will be provided under the "gps" event, like if you would use the normal gps chip of the banglejs. However if the phone data is being used, the event "GPS-raw" will not be fired. (I don't know how to convert the gps data to raw data, if anyone can and want to do it, feel free to add this)
* The phone gps also dose not provide the amount of satelites and the course. Those two values will be set to the NaN value. Also the fix value will be set to 1 ( If someone knows how to set the correct "fix" value, feel free to add it)
* GPS data, which was provided through the phone will have an extra flag called "externalSource".
