### PR TITLE
Fix messagesmusic

### DIFF
--- a/apps/messagesmusic/ChangeLog
+++ b/apps/messagesmusic/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Remove one line of code that didn't do anything other than in some instances hinder the function of the app.
 0.03: Use the new messages library
 0.04: Fix dependency on messages library
+      Fix loading message UI

--- a/apps/messagesmusic/ChangeLog
+++ b/apps/messagesmusic/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Remove one line of code that didn't do anything other than in some instances hinder the function of the app.
 0.03: Use the new messages library
+0.04: Fix dependency on messages library

--- a/apps/messagesmusic/app.js
+++ b/apps/messagesmusic/app.js
@@ -1,1 +1,1 @@
-require('messages').openGUI({"t":"add","artist":" ","album":" ","track":" ","dur":0,"c":-1,"n":-1,"id":"music","title":"Music","state":"play","new":true});
+setTimeout(()=>require('messages').openGUI({"t":"add","artist":" ","album":" ","track":" ","dur":0,"c":-1,"n":-1,"id":"music","title":"Music","state":"play","new":true}));

--- a/apps/messagesmusic/metadata.json
+++ b/apps/messagesmusic/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagesmusic",
   "name":"Messages Music",
-  "version":"0.03",
+  "version":"0.04",
   "description": "Uses Messages library to push a music message which in turn displays Messages app music controls",
   "icon":"app.png",
   "type": "app",
@@ -13,6 +13,5 @@
     {"name":"messagesmusic.app.js","url":"app.js"},
     {"name":"messagesmusic.img","url":"app-icon.js","evaluate":true}
   ],
-  "dependencies" : { "messagelib":"module" }
-
+  "dependencies":{"messages":"module"}
 }


### PR DESCRIPTION
Fix #2321
- Fix the dependency for `messagesmusic` (whoops)
- Wrap the app code in a timeout, as otherwise it didn't work for me (no idea why).