### PR TITLE
messages: Fix/improve README

### DIFF
--- a/apps/messages/README.md
+++ b/apps/messages/README.md
@@ -9,13 +9,14 @@ Assuming you are using GadgetBridge and "overlay notifications":
 
 1. Gadgetbridge sends an event to your watch for an incoming message
 2. The `android` app parses the message, and calls `require("messages").pushMessage({/** the message */})`
-3. `require("messages")` (provided by `messagelib`) calls `Bangle.emit("message", "text", {/** the message */})`
+3. `require("messages")` calls `Bangle.emit("message", "text", {/** the message */})`
 4. Overlay Notifications shows the message in an overlay, and marks it as `handled`
-5. The default GUI app (`messages`) sees the event is marked as `handled`, so does nothing.
+5. The default UI app (Message UI, `messagegui`) sees the event is marked as `handled`, so does nothing.
 6. The default widget (`widmessages`) does nothing with `handled`, and shows a notification icon.
-7. You tap the notification, in order to open the full GUI Overlay Notifications
+7. You tap the notification, in order to open the full GUI: Overlay Notifications
    calls `require("messages").openGUI({/** the message */})`
-8. The default GUI app (`messages`) sees the "messageGUI" event, and launches itself
+8. `openGUI` calls `require("messagegui").open(/** copy of the message */)`.
+9. The `messagegui` library loads the Message UI app.
 
 
 
@@ -28,7 +29,7 @@ it like this:
 myMessageListener = Bangle.on("message", (type, message)=>{
   if (message.handled) return; // another app already handled this message
   // <type> is one of "text", "call", "alarm", "map", or "music"
-  // see `messagelib/lib.js` for possible <message> formats
+  // see `messages/lib.js` for possible <message> formats
   // message.t could be "add", "modify" or "remove"
   E.showMessage(`${message.title}\n${message.body}`, `${message.t} ${type} message`);
   // You can prevent the default `message` app from loading by setting `message.handled = true`:
@@ -52,7 +53,7 @@ Bangle.on("messageGUI", message=>{
 
 ## Requests
 
-Please file any issues on https://github.com/espruino/BangleApps/issues/new?title=messagelib%library
+Please file any issues on https://github.com/espruino/BangleApps/issues/new?title=[messages]%20library
 
 ## Creator
 


### PR DESCRIPTION
It wasn't up-to-date anymore with how the library/gui now work, and still mentioned `messagelib`.
I didn't think this warrants a version bump though.