### PR TITLE
messages,messagegui: fix handling of music

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -77,3 +77,4 @@
 0.54: Move icons out to messageicons module
 0.55: Rename to messagegui, move global message handling library to message module
       Move widget to widmessage
+0.56: Fix handling of music messages

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -112,9 +112,11 @@ function showMapMessage(msg) {
   Bangle.setUI({mode:"updown", back: back}, back); // any input takes us back
 }
 
-var updateLabelsInterval;
+let updateLabelsInterval,
+  music = {artist: "", album: "", title: ""}; // defaults, so e.g. msg.title.length doesn't error
 function showMusicMessage(msg) {
   active = "music";
+  msg = Object.assign(music, msg); // combine+remember "musicinfo" and "musicstate" messages
   openMusic = msg.state=="play";
   var trackScrollOffset = 0;
   var artistScrollOffset = 0;

--- a/apps/messagegui/lib.js
+++ b/apps/messagegui/lib.js
@@ -15,12 +15,12 @@ exports.listener = function(type, msg) {
   const appSettings = require("Storage").readJSON("messages.settings.json", 1) || {};
   let loadMessages = (Bangle.CLOCK || event.important);
   if (type==="music") {
-    if (Bangle.CLOCK && msg.new && appSettings.openMusic) loadMessages = true;
+    if (Bangle.CLOCK && msg.state && msg.title && appSettings.openMusic) loadMessages = true;
     else return;
   }
   require("messages").save(msg);
   msg.handled = true;
-  if (msg.t!=="add" || !msg.new) {
+  if ((msg.t!=="add" || !msg.new) && (type!=="music")) { // music always has t:"modify"
     return;
   }
 

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagegui",
   "name": "Message UI",
-  "version": "0.55",
+  "version": "0.56",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -1,1 +1,2 @@
 0.55: Moved messages library into standalone library
+0.56: Fix handling of music messages

--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -6,7 +6,6 @@ exports.music = {};
 function emit(msg) {
   let type = "text";
   if (["call", "music", "map"].includes(msg.id)) type = msg.id;
-  if (type==="music" && msg.t!=="remove" && (!("state" in msg) || (!("track" in msg)))) return; // wait for complete music info
   if (msg.src && msg.src.toLowerCase().startsWith("alarm")) type = "alarm";
   Bangle.emit("message", type, msg);
 }

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.55",
+  "version": "0.56",
   "description": "Library to handle, load and store message events received from Android/iOS",
   "icon": "app.png",
   "type": "module",


### PR DESCRIPTION
The library combines musicinfo+musicstate messages, and waited for a "complete" message before emitting the event.
But once you are playing music you don't get new music state events. The problem was that when the first "complete" message arrives, the UI is `load()`ed, so the library forgets its state, and doesn't emit anymore music events until the play state changes.

This
- changes the library to keep combining music messages, but always emit an event
- makes the UI only launch itself if it sees a "complete" music event
- makes the UI also combine musicinfo+musicstate messages