### PR TITLE
[Remote for Spotify] remove only specific listeners

### DIFF
--- a/apps/spotrem/ChangeLog
+++ b/apps/spotrem/ChangeLog
@@ -4,3 +4,5 @@
 0.04: New layout.
 0.05: Add widgets field. Tweak layout.
 0.06: Make compatible with Fastload Utils app.
+0.07: Remove just the specific listeners to not interfere with Quick Launch
+when fastloading.

--- a/apps/spotrem/app.js
+++ b/apps/spotrem/app.js
@@ -57,8 +57,8 @@ let touchHandler = function(_, xy) {
   // doing a<b+1 seemed faster than a<=b, also using a>b-1 instead of a>b.
   if ((R.x-1<x && x<R.x+len) && (R.y-1<y && y<R.y+len)) {
     //Menu
-    Bangle.removeAllListeners("touch");
-    Bangle.removeAllListeners("swipe");
+    Bangle.removeListener("touch", touchHandler);
+    Bangle.removeListener("swipe", swipeHandler);
     backToMenu = true;
     E.showMenu(spotifyMenu);
   } else if ((R.x-1<x && x<R.x+len) && (R.y2-len<y && y<R.y2+1)) {
@@ -67,13 +67,13 @@ let touchHandler = function(_, xy) {
     gadgetbridgeWake();
   } else if ((R.x2-len<x && x<R.x2+1) && (R.y-1<y && y<R.y+len)) {
     //Srch
-    Bangle.removeAllListeners("touch");
-    Bangle.removeAllListeners("swipe");
+    Bangle.removeListener("touch", touchHandler);
+    Bangle.removeListener("swipe", swipeHandler);
     E.showMenu(searchMenu);
   } else if ((R.x2-len<x && x<R.x2+1) && (R.y2-len<y && y<R.y2+1)) {
     //Saved
-    Bangle.removeAllListeners("touch");
-    Bangle.removeAllListeners("swipe");
+    Bangle.removeListener("touch", touchHandler);
+    Bangle.removeListener("swipe", swipeHandler);
     E.showMenu(savedMenu);
   } else if ((R.x-1<x && x<R.x+len) && (R.y+R.h/2-len/2<y && y<R.y+R.h/2+len/2)) {
     //Previous 
@@ -89,7 +89,7 @@ let touchHandler = function(_, xy) {
   }
 };
 
-// Swipe handler for main layout, used to jump backward and forward within a podcast episode.
+// Swipe handler for main layout, used for next previous track.
 let swipeHandler = function(LR, _) {
   if (LR==-1) {
     spotifyWidget("NEXT");
@@ -125,8 +125,8 @@ let backToGfx = function() {
   E.showMenu();
   g.clear();
   g.reset();
-  Bangle.removeAllListeners("touch");
-  Bangle.removeAllListeners("swipe");
+  Bangle.removeListener("touch", touchHandler);
+  Bangle.removeListener("swipe", swipeHandler);
   setUI();
   gfx();
   backToMenu = false;
@@ -286,6 +286,5 @@ let savedMenu = {
 
 Bangle.loadWidgets();
 setUI();
-widgetUtils.hide();
 gfx();
 }

--- a/apps/spotrem/metadata.json
+++ b/apps/spotrem/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "spotrem",
   "name": "Remote for Spotify",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Control spotify on your android device.",
   "readme": "README.md",
   "type": "app",


### PR DESCRIPTION
When fastloading Quick Launch listeners would be removed as well - this fixes that.