### PR TITLE
[Remote for Spotify] remove unnecessary removeListener

### DIFF
--- a/apps/spotrem/app.js
+++ b/apps/spotrem/app.js
@@ -125,8 +125,6 @@ let backToGfx = function() {
   E.showMenu();
   g.clear();
   g.reset();
-  Bangle.removeListener("touch", touchHandler);
-  Bangle.removeListener("swipe", swipeHandler);
   setUI();
   gfx();
   backToMenu = false;


### PR DESCRIPTION
Spotted this while updating Podcast Addict Remote where I already did this.

I don't think this warrants a version bump, the change is functionally insignificant and the last pr was just merged.