### PR TITLE
[podcast Addict Remote] shorten prepended info re intents in comment

### DIFF
--- a/apps/podadrem/app.js
+++ b/apps/podadrem/app.js
@@ -1,69 +1,10 @@
 {
 /*
-Bluetooth.println(JSON.stringify({t:"intent", action:"", flags:["flag1", "flag2",...], categories:["category1","category2",...], mimetype:"", data:"",  package:"", class:"", target:"", extra:{someKey:"someValueOrString"}}));
+  Bluetooth.println(JSON.stringify({t:"intent", action:"", flags:["flag1", "flag2",...], categories:["category1","category2",...], mimetype:"", data:"",  package:"", class:"", target:"", extra:{someKey:"someValueOrString"}}));
 
-Podcast Addict is developed by Xavier Guillemane and can be downloaded on Google Play Store: https://play.google.com/store/apps/details?id=com.bambuna.podcastaddict&hl=en_US&gl=US
-
-Podcast Addict can be controlled through the sending of remote commands called 'Intents'.
-Some 3rd parties apps specialized in task automation will then allow you to control Podcast Addict. For example, you will be able to wake up to the sound of your playlist or to start automatically playing when some NFC tag has been detected.
-In Tasker, you just need to copy/paste one of the following intent in the task Action field ("Misc" action type then select "Send Itent") .
-If you prefer Automate It, you can use the Podcast Addict plugin that will save you some configuration time (https://play.google.com/store/apps/details?id=com.smarterapps.podcastaddictplugin )
-Before using an intent make sure to set the following:
-Package: com.bambuna.podcastaddict
-Class (UPDATE intent only): com.bambuna.podcastaddict.receiver.PodcastAddictBroadcastReceiver
-Class (every other intent): com.bambuna.podcastaddict.receiver.PodcastAddictPlayerReceiver
-Here are the supported commands (Intents) :
-com.bambuna.podcastaddict.service.player.toggle – Toggle the playlist
-com.bambuna.podcastaddict.service.player.stop – Stop the player and release its resources
-com.bambuna.podcastaddict.service.player.play – Start playing the playlist
-com.bambuna.podcastaddict.service.player.pause – Pause the playlist
-com.bambuna.podcastaddict.service.player.nexttrack – Start playing next track
-com.bambuna.podcastaddict.service.player.previoustrack – Start playing previous track
-com.bambuna.podcastaddict.service.player.jumpforward – Jump 30s forward
-com.bambuna.podcastaddict.service.player.jumpbackward – Jump 15s backward
-com.bambuna.podcastaddict.service.player.1xspeed - Disable the variable playback speed
-com.bambuna.podcastaddict.service.player.1.5xspeed – Force the playback speed at 1.5x
-com.bambuna.podcastaddict.service.player.2xspeed – Force the playback speed at 2.0x
-com.bambuna.podcastaddict.service.player.stoptimer – Disable the timer
-com.bambuna.podcastaddict.service.player.15mntimer – Set the timer at 15 minutes
-com.bambuna.podcastaddict.service.player.30mntimer – Set the timer at 30 minutes
-com.bambuna.podcastaddict.service.player.60mntimer – Set the timer at 1 hour
-com.bambuna.podcastaddict.service.update – Trigger podcasts update
-com.bambuna.podcastaddict.openmainscreen – Open the app on the Main screen
-com.bambuna.podcastaddict.openplaylist – Open the app on the Playlist screen
-com.bambuna.podcastaddict.openplayer – Open the app on the Player screen
-com.bambuna.podcastaddict.opennewepisodes – Open the app on the New episodes screen
-com.bambuna.podcastaddict.opendownloadedepisodes – Open the app on the Downloaded episodes screen
-com.bambuna.podcastaddict.service.player.playfirstepisode – Start playing the first episode in the playlist
-com.bambuna.podcastaddict.service.player.customspeed – Select playback speed
-In order to use this intent you need to pass a float argument called "arg1". Valid values are within [0.1, 5.0]
-com.bambuna.podcastaddict.service.player.customtimer – Start a custom timer
-In order to use this intent you need to pass an int argument called "arg1" containing the number of minutes. Valid values are within [1, 1440]
-com.bambuna.podcastaddict.service.player.deletecurrentskipnexttrack – Delete the current episode and skip to the next one. It behaves the same way as long pressing on the player >| button, but doesn't display any confirmation popup.
-com.bambuna.podcastaddict.service.player.deletecurrentskipprevioustrack – Delete the current episode and skip to the previous one. It behaves the same way as long pressing on the player |< button, but doesn't display any confirmation popup.
-com.bambuna.podcastaddict.service.player.boostVolume – Toggle the Volume Boost audio effect
-You can pass a, optional boolean argument called "arg1" in order to create a ON or OFF button for the volume boost. Without this parameter the app will just toggle the current value
-com.bambuna.podcastaddict.service.player.quickBookmark – Creates a bookmark at the current playback position so you can easily retrieve it later.
-com.bambuna.podcastaddict.service.download.pause – Pause downloads
-com.bambuna.podcastaddict.service.download.resume – Resume downloads
-com.bambuna.podcastaddict.service. download.toggle – Toggle downloads
-com.bambuna.podcastaddict.service.player.favorite – Mark the current episode playing as favorite.
-com.bambuna.podcastaddict.openplaylist – Open the app on the Playlist screen
-You can pass an optional string argument called "arg1" in order to select the playlist to open. Without this parameter the app will open the current playlist
-Here's how it works:
-##AUDIO## will open the Audio playlist screen
-##VIDEO## will open the Video playlist screen
-##RADIO## will open the Radio screen
-Any other argument will be used as a CATEGORY name. The app will then open this category under the playlist CUSTOM tab
-You can pass an optional boolean argument called "arg2" in order to select if the app UI should be opened. Without this parameter the playlist will be displayed
-You can pass an optional boolean argument called "arg3" in order to select if the app should start playing the selected playlist. Without this parameter the playback won't start
-Since v2020.3
-com.bambuna.podcastaddict.service.full_backup – Trigger a full backup of the app data (relies on the app automatic backup settings for the folder and the # of backup to keep)
-This task takes a lot of resources and might take up to a minute to complete, so please avoid using the app at the same time
-Since v2020.15
-com.bambuna.podcastaddict.service.player.toggletimer – This will toggle the Sleep Timer using the last duration and parameter used in the app.
-Since v2020.16
-com.bambuna.podcastaddict.service.player.togglespeed – This will toggle the Playback speed for the episode currently playing (alternate between selected speed and 1.0x).
+  Podcast Addict is developed by Xavier Guillemane and can be downloaded on Google Play Store: https://play.google.com/store/apps/details?id=com.bambuna.podcastaddict&hl=en_US&gl=US
+  
+  How to use intents to control Podcast Addict: https://podcastaddict.com/faq/130
 */
 
 let R;


### PR DESCRIPTION
No functional change - I don't think it warrants a version bump.