### PR TITLE
sched - improve support for date timezone, toLocalISOString

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -16,3 +16,4 @@
 0.13: Ask to delete a timer after stopping it
 0.14: Added clkinfo for alarms and timers
 0.15: Automatic translation of some string in clkinfo
+0.16: Improve support for date timezone

--- a/apps/sched/boot.js
+++ b/apps/sched/boot.js
@@ -13,7 +13,7 @@
     && (a.last != d) // not already fired today
     && (a.t + 60000 > currentTime) // is not in the past by >1 minute
     && (a.dow >> time.getDay() & 1) // is allowed on this day of the week
-    && (!a.date || a.date == time.toISOString().substr(0, 10)) // is allowed on this date
+    && (!a.date || a.date == time.toLocalISOString().substr(0, 10)) // is allowed on this date
   );
   if (active.length) {
     active = active.sort((a,b)=>a.t-b.t); // sort by time

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -21,7 +21,7 @@ exports.getActiveAlarms = function (alarms, time) {
       && (a.last != time.getDate()) // not already fired today
       && (a.t < currentTime)
       && (a.dow >> time.getDay() & 1) // is allowed on this day of the week
-      && (!a.date || a.date == time.toISOString().substr(0, 10)) // is allowed on this date
+      && (!a.date || a.date == time.toLocalISOString().substr(0, 10)) // is allowed on this date
     )
     .sort((a, b) => a.t - b.t);
 }
@@ -46,7 +46,7 @@ exports.getTimeToAlarm = function(alarm, time) {
   if (!alarm) return undefined;
   if (!time) time = new Date();
   var currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000);
-  var active = alarm.on && (alarm.dow>>((time.getDay()+(alarm.t<currentTime))%7))&1 && (!alarm.date || alarm.date==time.toISOString().substr(0,10));
+  var active = alarm.on && (alarm.dow>>((time.getDay()+(alarm.t<currentTime))%7))&1 && (!alarm.date || alarm.date==time.toLocalISOString().substr(0,10));
   if (!active) return undefined;
   var t = alarm.t-currentTime;
   if (alarm.last == time.getDate() || t < -60000) t += 86400000;

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.15",
+  "version": "0.16",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
Test scenario that this patch fixes:
```
E.setTimeZone(-8);
date = new Date("2022-12-05T23:00");
date.toLocalISOString(); // -> "2022-12-05T23:00:00.000-0800"
getActiveAlarms([{on: true, t: 0, dow: 0b1111111, date: "2022-12-05"}], date); //should be marked as active, but isn't
getActiveAlarms([{on: true, t: 0, dow: 0b1111111, date: "2022-12-06"}], date); //should not be marked as active, but it is because it's already "tomorrow" in UTC
```