### PR TITLE
ClockFace: fix fast loading

### DIFF
--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -58,6 +58,7 @@ function ClockFace(options) {
 
 ClockFace.prototype.tick = function() {
   "ram"
+  if (this._removed) return;
   const time = new Date();
   const now = {
     d: `${time.getFullYear()}-${time.getMonth()}-${time.getDate()}`,
@@ -131,6 +132,7 @@ ClockFace.prototype.resume = function() {
   this.tick();
 };
 ClockFace.prototype.remove = function() {
+  this._removed = true;
   if (this._timeout) clearTimeout(this._timeout);
   Bangle.removeListener("lcdPower", this._onLcd);
   if (this._remove) this._remove.apply(this);


### PR DESCRIPTION
I don't know why this is needed, but it was definitely broken for at least `barclock`: after fast loading a messages app, it would still draw over it once.

I tried adding a bunch of logging: it *does* call `clearTimeout` with the correct ID, but somehow the timeout fires anyway.   
No idea if it's a bug in `barclock`/`ClockFace` I missed, or some subtle problem with `clearTimeout` 🙁, but at least this fixes it.