### PR TITLE
messagegui: write "remove" messages to flash

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -82,3 +82,4 @@
 0.58: Fast load messages without writing to flash
       Don't write messages to flash until the app closes
 0.59: Ensure we do write messages if messages app can't be fast loaded (see #2373)
+0.60: Fix saving of removal messages if UI not open

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.59",
+  "version": "0.60",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
Whoops: we didn't handle these at all, but are actually responsible for
        saving them, even if the UI won't be launched.

Fixes #2380