### PR TITLE
circlesclock: fixed crash if item has no image and cutting long text

### DIFF
--- a/apps/circlesclock/ChangeLog
+++ b/apps/circlesclock/ChangeLog
@@ -38,3 +38,4 @@
       Add fast load capability
 0.21: Remade all icons without a palette for dark theme
       Now re-adds widgets if they were hidden when fast-loading
+0.22: Fixed crash if item has no image and cutting long overflowing text

--- a/apps/circlesclock/app.js
+++ b/apps/circlesclock/app.js
@@ -183,9 +183,12 @@ let drawCircle = function(index, item, data) {
   if (txt.endsWith(" bpm")) txt=txt.slice(0,-4); // hack for heart rate - remove the 'bpm' text
   if(item.hasRange) percent = (data.v-data.min) / (data.max-data.min);
   if(data.short) txt = data.short;
+  //long text can overflow and we do not draw there anymore..
+  if(txt.length>6) txt = txt.slice(0,5)+"\n"+txt.slice(5,10)
   drawGauge(w, h3, percent, color);
   drawInnerCircleAndTriangle(w);
   writeCircleText(w, txt);
+  if(!img) return; //or get it from the clkinfo?
   g.setColor(getCircleIconColor(index, color, percent))
     .drawImage(img, w - iconOffset, h3 + radiusOuter - iconOffset, {scale: 16/24});
 }

--- a/apps/circlesclock/metadata.json
+++ b/apps/circlesclock/metadata.json
@@ -1,7 +1,7 @@
 { "id": "circlesclock",
   "name": "Circles clock",
   "shortName":"Circles clock",
-  "version":"0.21",
+  "version":"0.22",
   "description": "A clock with three or four circles for different data at the bottom in a probably familiar style",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot-dark.png"}, {"url":"screenshot-light.png"}, {"url":"screenshot-dark-4.png"}, {"url":"screenshot-light-4.png"}],


### PR DESCRIPTION
Quick and dirty as my watch was crashing every time I was getting to the calendar clkinfo. In this case I guess the `addInteractive` could also populate the img field with the one from the menu item (still i think we ought to check it).
The text slicing is also preventing to draw outside the circle so that the text doesn't stay there while rotating, again this could be handled better splitting words, but I'd rather have clkinfos using the short field in this case (I'm planning to do it myself for the agenda, when I have some time).