### PR TITLE
clkinfo: repeating selection if menu is empty

### DIFF
--- a/modules/clock_info.js
+++ b/modules/clock_info.js
@@ -239,10 +239,15 @@ exports.addInteractive = function(menu, options) {
     } else if (lr) {
       if (menu.length==1) return; // 1 item - can't move
       oldMenuItem = menu[options.menuA].items[options.menuB];
-      options.menuA += lr;
-      if (options.menuA<0) options.menuA = menu.length-1;
-      if (options.menuA>=menu.length) options.menuA = 0;
-      options.menuB = 0;
+      do {
+        options.menuA += lr;
+        if (options.menuA<0) options.menuA = menu.length-1;
+        if (options.menuA>=menu.length) options.menuA = 0;
+        options.menuB = 0;
+        //get the next one if the menu is empty
+        //can happen for dynamic ones (alarms, events)
+        //in the worst case we come back to 0
+      } while(menu[options.menuA].items.length==0);
     }
     if (oldMenuItem) {
       menuHideItem(oldMenuItem);


### PR DESCRIPTION
Not sure if this has been discussed somewhere.
I can happen that some clock infos don't have elements (e.g. those with `dynamic` like alarms and calendar events, if the user simply doesn't have any). Swiping around in the `addInteractive` opens also those pointing to the first element (`undefined`) and crashes.
With this PR we are simply going on in the same swipe direction until we find a menu with at least an item (which is surely there as the module itself provides some items).
It looks to me more tidy than handling the case displaying an empty menu element.