### PR TITLE
fix midnight recompute time in local timezone

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -17,3 +17,4 @@
 0.14: Added clkinfo for alarms and timers
 0.15: Automatic translation of some string in clkinfo
 0.16: Improve support for date timezone
+0.17: Fix midnight in local timezone (alarms wouldn't always fire as expected in timezone != 0)

--- a/apps/sched/boot.js
+++ b/apps/sched/boot.js
@@ -26,7 +26,7 @@
     If active[0].js is defined, just run that code as-is and not alarm.js */
     Bangle.SCHED = setTimeout(active[0].js||'load("sched.js")',t);
   } else { // check for new alarms at midnight (so day of week works)
-    Bangle.SCHED = setTimeout('eval(require("Storage").read("sched.boot.js"))', 86400000 - (Date.now()%86400000));
+    Bangle.SCHED = setTimeout('eval(require("Storage").read("sched.boot.js"))', 86400000 - currentTime);
   }
 })();
 /* DEBUGGING

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.16",
+  "version": "0.17",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
To reproduce the bug that this PR fixes:
```
E.setTimeZone(-5); // works if we pass timezone 0 here
setTime(new Date("2022-12-10T23:59").getTime()/1000);
console.log("seconds to midnight (expect <=60)", (86400000 - (Date.now()%86400000)) / 1000);
```