### PR TITLE
[Hank's World Clock] Setting for single extra timezone small

### DIFF
--- a/apps/hworldclock/ChangeLog
+++ b/apps/hworldclock/ChangeLog
@@ -16,3 +16,4 @@
 0.30: BJS2: swipe seems to be working now
 0.31: Tweaking the swipe option; Added mylocation as a dependency.
       Remove calls to Bangle.loadWidgets as they are not needed and create warnings
+0.32: Added setting to show single timezone small, like where multiple ones are configured

--- a/apps/hworldclock/README.md
+++ b/apps/hworldclock/README.md
@@ -9,6 +9,7 @@ All this is configurable:
 
  - Show seconds only when unlocked (saves battery) / always / do not show seconds
  - Green color on dark mode (on/off)
+ - 1 Offset Small: single location shows as small (like more than 1)
  - Show sun info (on/off) (set your location in the mylocation app)
  - Rotation degree on swipe (off / 90 / 180 / 270)
 

--- a/apps/hworldclock/app.js
+++ b/apps/hworldclock/app.js
@@ -257,7 +257,7 @@ let draw = function() {
 	minutes = doublenum(dx.getMinutes());
 
 
-	if (offsets.length === 1) {
+	if (offsets.length === 1 && false) {
 		let date = [require("locale").dow(new Date(), 1), require("locale").date(new Date(), 1)];	
 		// For a single secondary timezone, draw it bigger and drop time zone to second line
 		const xOffset = 30;

--- a/apps/hworldclock/app.js
+++ b/apps/hworldclock/app.js
@@ -104,6 +104,7 @@ let def = function(value, def) {
 let settings = require('Storage').readJSON(SETTINGSFILE, true) || {};
 secondsMode = def(settings.secondsMode, "when unlocked");
 showSunInfo = def(settings.showSunInfo, true);
+singleOffsetSmall = def(settings.singleOffsetSmall, false);
 colorWhenDark = def(settings.colorWhenDark, "green");
 rotationTarget = def(settings.rotationTarget, "90");
 rotationTarget = parseInt(rotationTarget) || 0;
@@ -257,7 +258,7 @@ let draw = function() {
 	minutes = doublenum(dx.getMinutes());
 
 
-	if (offsets.length === 1 && false) {
+	if (offsets.length === 1 && !singleOffsetSmall) {
 		let date = [require("locale").dow(new Date(), 1), require("locale").date(new Date(), 1)];	
 		// For a single secondary timezone, draw it bigger and drop time zone to second line
 		const xOffset = 30;

--- a/apps/hworldclock/metadata.json
+++ b/apps/hworldclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "hworldclock",
   "name": "Hanks World Clock",
   "shortName": "Hanks World Clock",
-  "version": "0.31",
+  "version": "0.32",
   "description": "Current time zone plus up to three others",
   "allow_emulator":true,
   "icon": "app.png",

--- a/apps/hworldclock/settings.js
+++ b/apps/hworldclock/settings.js
@@ -37,7 +37,7 @@
 	"Seconds": stringInSettings("secondsMode", ["always", "when unlocked", "none"]),
 	"Color w. dark": stringInSettings("colorWhenDark", ["green", "default"]),
   "1 Offset Small": {
-    value: (settings.singleOffsetSmall !== undefined ? settings.singleOffsetSmall : true),
+    value: (settings.singleOffsetSmall !== undefined ? settings.singleOffsetSmall : false),
     onchange: v=> {
       settings.singleOffsetSmall = v;
       writeSettings();

--- a/apps/hworldclock/settings.js
+++ b/apps/hworldclock/settings.js
@@ -36,13 +36,20 @@
     "< Back": () => back(),
 	"Seconds": stringInSettings("secondsMode", ["always", "when unlocked", "none"]),
 	"Color w. dark": stringInSettings("colorWhenDark", ["green", "default"]),
-    "Show SunInfo": {
-      value: (settings.showSunInfo !== undefined ? settings.showSunInfo : true),
-      onchange: v => {
-        settings.showSunInfo = v;
-        writeSettings();
-      }
-    },
+  "1 Offset Small": {
+    value: (settings.singleOffsetSmall !== undefined ? settings.singleOffsetSmall : true),
+    onchange: v=> {
+      settings.singleOffsetSmall = v;
+      writeSettings();
+    }
+  },
+  "Show SunInfo": {
+    value: (settings.showSunInfo !== undefined ? settings.showSunInfo : true),
+    onchange: v => {
+      settings.showSunInfo = v;
+      writeSettings();
+    }
+  },
 	"Rotation": stringInSettings("rotationTarget", ["off", "90", "180", "270"]),
   };
 


### PR DESCRIPTION
First, offtopic: Awesome work Gordon with the bangle! My garmin fenix 6 is sitting on my desk unused since I got the banglejs2 ! Awesome! 
Have a nice vacation!

Great work with updating this @pebl-hank ! I think in the future this setting could go in the initial pre-upload setup page, but this is my first time getting my fingers wet with the bangle and it was clear how to add it to the watch settings.
![20221218_133126](https://user-images.githubusercontent.com/14359848/208296041-a415039c-1ce5-417c-97ea-c4bb6974661a.jpg)
 
I don't want to step any boundaries with modifying someone else's watch face unless that's fine for the original author, and I can create a rworldclock, but I'd rather not. @pebl-hank ? :D 

This adds an entry in the settings menu that allows the user to show an extra single timezone small. Just like there would be more than 1 timezone. I need an extra timezone, and only one, but I do not need it that big. 

Happy holidays everyone!