### PR TITLE
Update changelog link to https

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -49,7 +49,7 @@ function onFoundDeviceInfo(deviceId, deviceVersion) {
   if (deviceId != "BANGLEJS" && deviceId != "BANGLEJS2") {
     showToast(`You're using ${deviceId}, not a Bangle.js. Did you want <a href="https://espruino.com/apps">espruino.com/apps</a> instead?` ,"warning", 20000);
   } else if (versionLess(deviceVersion, RECOMMENDED_VERSION)) {
-    showToast(`You're using an old Bangle.js firmware (${deviceVersion}) and ${RECOMMENDED_VERSION} is available (<a href="http://www.espruino.com/ChangeLog" target="_blank">see changes</a>). You can update ${fwExtraText}<a href="${fwURL}" target="_blank">with the instructions here</a>` ,"warning", 20000);
+    showToast(`You're using an old Bangle.js firmware (${deviceVersion}) and ${RECOMMENDED_VERSION} is available (<a href="https://www.espruino.com/ChangeLog" target="_blank">see changes</a>). You can update ${fwExtraText}<a href="${fwURL}" target="_blank">with the instructions here</a>` ,"warning", 20000);
   }
   // check against features shown?
   filterAppsForDevice(deviceId);


### PR DESCRIPTION
This fixes Bangle.JS Gadgetbridge from failing to load the ChangeLog with net::ERR_CLEARTEXT_NOT_PERMITTED

![image](https://user-images.githubusercontent.com/1885159/208298345-15ade621-34ec-4491-a5f6-403916a048c1.png)
![image](https://user-images.githubusercontent.com/1885159/208298349-e6fc8cd9-4c0c-4bfa-9bcc-ba915f79a2b8.png)
