### PR TITLE
add message input and dated Events

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -37,3 +37,4 @@
 0.34: Add "Confirm" option to alarm/timer edit menus
 0.35: Add automatic translation of more strings
 0.36: alarm widget moved out of app
+0.37: add message input and dated Events

--- a/apps/alarm/README.md
+++ b/apps/alarm/README.md
@@ -1,15 +1,18 @@
 # Alarms & Timers
 
-This app allows you to add/modify any alarms and timers.
+This app allows you to add/modify any alarms, timers and events.
+
+Optional: When a keyboard app is detected, you can add a message to display when any of these is triggered.
 
 It uses the [`sched` library](https://github.com/espruino/BangleApps/blob/master/apps/sched) to handle the alarm scheduling in an efficient way that can work alongside other apps.
 
 ## Menu overview
 
 - `New...`
-  - `New Alarm` &rarr; Configure a new alarm
+  - `New Alarm` &rarr; Configure a new alarm (triggered based on time and day of week)
     - `Repeat` &rarr; Select when the alarm will fire. You can select a predefined option (_Once_, _Every Day_, _Workdays_ or _Weekends_ or you can configure the days freely)
-  - `New Timer` &rarr; Configure a new timer
+  - `New Timer` &rarr; Configure a new timer (triggered based on amount of time elapsed in hours/minutes/seconds)
+  - `New Event` &rarr; Configure a new event (triggered based on time and date)
 - `Advanced`
   - `Scheduler settings` &rarr; Open the [Scheduler](https://github.com/espruino/BangleApps/tree/master/apps/sched) settings page, see its [README](https://github.com/espruino/BangleApps/blob/master/apps/sched/README.md) for details
   - `Enable All` &rarr; Enable _all_ disabled alarms & timers

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.36",
+  "version": "0.37",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
1. Users can now create Events (triggered based on time and date, vs alarms, which are triggered based on time and day of week).  In this first version, there is no "Repeat" option for Events (e.g. "20th of each month"), but I hope to add that in a future version.
2. Users can now input a message to be shown for alarms, timers and dated events.  The message input is optional: I don't add a dependency to textinput, but juste remove the Message entry if it isn't detected.

Eventually, if we want to allow people to download just the functionalities they want from this "default" alarm app (e.g. if they don't need dated Events and want to spare resources), I could use the "custom" and "content" options of metadata.json to read and customize app.js based on user's choice.
e.g. tag the source code with comments such as the following, and remove everything in between if the user does not want a feature:
```
/*Option1->*/
...
/*<-Option1*/
```
