### PR TITLE
[Apploader] Extend Issue Template, add Button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bangle-bug-report-custom-form.yaml
+++ b/.github/ISSUE_TEMPLATE/bangle-bug-report-custom-form.yaml
@@ -58,3 +58,7 @@ body:
 
     validations:
       required: true
+  - type: textarea
+    id: apps
+    attributes:
+      label: Installed apps

--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
            <button class="btn" id="reinstallall" data-tooltip="Remove and re-install every app, leaving all other data intact">Reinstall apps</button>
            <button class="btn" id="installdefault">Install default apps</button>
            <button class="btn" id="installfavourite" data-tooltip="Delete everything, install apps you've marked as favourites">Install favourite apps</button></p>
+           <button class="btn" id="newGithubIssue" data-tooltip="Create a new issue on github">New issue on github</button></p>
         <p><button class="btn tooltip tooltip-right" id="downloadallapps" data-tooltip="Download all Bangle.js files to a ZIP file">Backup</button>
            <button class="btn tooltip tooltip-right" id="uploadallapps" data-tooltip="Restore Bangle.js from a ZIP file">Restore</button></p>
         <h3>Settings</h3>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
            <button class="btn" id="removeall" data-tooltip="Delete everything from your Bangle, leaving it blank">Remove all Apps</button>
            <button class="btn" id="reinstallall" data-tooltip="Remove and re-install every app, leaving all other data intact">Reinstall apps</button>
            <button class="btn" id="installdefault">Install default apps</button>
-           <button class="btn" id="installfavourite" data-tooltip="Delete everything, install apps you've marked as favourites">Install favourite apps</button></p>
+           <button class="btn" id="installfavourite" data-tooltip="Delete everything, install apps you've marked as favourites">Install favourite apps</button>
            <button class="btn" id="newGithubIssue" data-tooltip="Create a new issue on github">New issue on github</button></p>
         <p><button class="btn tooltip tooltip-right" id="downloadallapps" data-tooltip="Download all Bangle.js files to a ZIP file">Backup</button>
            <button class="btn tooltip tooltip-right" id="uploadallapps" data-tooltip="Restore Bangle.js from a ZIP file">Restore</button></p>


### PR DESCRIPTION
### Extend issue template
Add a new Textarea to enter a list of installed apps 
![grafik](https://user-images.githubusercontent.com/10829389/209687933-aa7a04c9-f2db-402d-aff3-ee820a24b744.png)

### Add "New issue on github"
Adding a new button, which depends on https://github.com/espruino/EspruinoAppLoaderCore/pull/45 
If https://github.com/espruino/EspruinoAppLoaderCore/pull/45 is merged, a click on the button opens a prefilled issue on github (Bangle Version and installed apps with version).
