### PR TITLE
[Clock Info] Revert "Update clock_info to avoid a redraw/general tidyups"

### DIFF
--- a/apps/agenda/ChangeLog
+++ b/apps/agenda/ChangeLog
@@ -8,4 +8,3 @@
 0.08: Fix error in clkinfo (didn't require Storage & locale)
       Fix clkinfo icon
 0.09: Ensure Agenda supplies an image for clkinfo items
-0.10: Update clock_info to avoid a redraw

--- a/apps/agenda/agenda.clkinfo.js
+++ b/apps/agenda/agenda.clkinfo.js
@@ -20,7 +20,7 @@
     agendaItems.items.push({
       name: "Agenda "+i,
       get: () => ({ text: title + "\n" + dateStr, img: agendaItems.img }),
-      show: function() {},
+      show: function() { agendaItems.items[i].emit("redraw"); },
       hide: function () {}
     });
   });

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "agenda",
   "name": "Agenda",
-  "version": "0.10",
+  "version": "0.09",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],

--- a/apps/bwclk/ChangeLog
+++ b/apps/bwclk/ChangeLog
@@ -21,4 +21,3 @@
 0.21: On the default menu the week of year can be shown.
 0.22: Use the new clkinfo module for the menu.
 0.23: Feedback of apps after run is now optional and decided by the corresponding clkinfo.
-0.24: Update clock_info to avoid a redraw

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -93,7 +93,7 @@ var bwItems = {
   items: [
   { name: "WeekOfYear",
     get: () => ({ text: "Week " + weekOfYear(), img: null}),
-    show: function() {},
+    show: function() { bwItems.items[0].emit("redraw"); },
     hide: function () {}
   },
   ]

--- a/apps/bwclk/metadata.json
+++ b/apps/bwclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bwclk",
   "name": "BW Clock",
-  "version": "0.24",
+  "version": "0.23",
   "description": "A very minimalistic clock to mainly show date and time.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/clkinfofw/ChangeLog
+++ b/apps/clkinfofw/ChangeLog
@@ -1,2 +1,1 @@
 0.01: First release
-0.02: Update clock_info to avoid a redraw and image allocation

--- a/apps/clkinfofw/clkinfo.js
+++ b/apps/clkinfofw/clkinfo.js
@@ -4,13 +4,26 @@
     items: [
       { name : "FW",
         get : () => {
+          let d = new Date();
+          let g = Graphics.createArrayBuffer(24,24,1,{msb:true});
+          g.drawImage(atob("GBjC////AADve773VWmmmmlVVW22nnlVVbLL445VVwAAAADVWAAAAAAlrAAAAAA6sAAAAAAOWAAAAAAlrAD//wA6sANVVcAOWANVVcAlrANVVcA6rANVVcA6WANVVcAlsANVVcAOrAD//wA6WAAAAAAlsAAAAAAOrAAAAAA6WAAAAAAlVwAAAADVVbLL445VVW22nnlVVWmmmmlV"),1,0);
           return {
             text : process.env.VERSION,
-            img : atob("GBjC////AADve773VWmmmmlVVW22nnlVVbLL445VVwAAAADVWAAAAAAlrAAAAAA6sAAAAAAOWAAAAAAlrAD//wA6sANVVcAOWANVVcAlrANVVcA6rANVVcA6WANVVcAlsANVVcAOrAD//wA6WAAAAAAlsAAAAAAOrAAAAAA6WAAAAAAlVwAAAADVVbLL445VVW22nnlVVWmmmmlV")
+            img : g.asImage("string")
           };
         },
-        show : function() {},
-        hide : function() {}
+        show : function() {
+          this.interval = setTimeout(()=>{
+            this.emit("redraw");
+            this.interval = setInterval(()=>{
+              this.emit("redraw");
+            }, 86400000);
+          }, 86400000 - (Date.now() % 86400000));
+        },
+       hide : function() {
+          clearInterval(this.interval);
+          this.interval = undefined;
+        }
       }
     ]
   };

--- a/apps/clkinfofw/metadata.json
+++ b/apps/clkinfofw/metadata.json
@@ -1,6 +1,6 @@
 { "id": "clkinfofw",
   "name": "Firmware Clockinfo",
-  "version":"0.02",
+  "version":"0.01",
   "description": "For clocks that display 'clockinfo', this displays the firmware version string",
   "icon": "app.png",
   "type": "clkinfo",

--- a/apps/ha/ChangeLog
+++ b/apps/ha/ChangeLog
@@ -4,4 +4,3 @@
 0.04: Feedback if clkinfo run is called.
 0.05: Clkinfo improvements.
 0.06: Updated clkinfo icon.
-0.07: Update clock_info to avoid a redraw

--- a/apps/ha/ha.clkinfo.js
+++ b/apps/ha/ha.clkinfo.js
@@ -12,7 +12,7 @@
       haItems.items.push({
         name: null,
         get: () => ({ text: trigger.display, img: trigger.getIcon()}),
-        show: function() {},
+        show: function() { haItems.items[i].emit("redraw"); },
         hide: function () {},
         run: function() {
           ha.sendTrigger("TRIGGER_BW");

--- a/apps/ha/metadata.json
+++ b/apps/ha/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "ha",
   "name": "HomeAssistant",
-  "version": "0.07",
+  "version": "0.06",
   "description": "Integrates your BangleJS into HomeAssistant.",
   "icon": "ha.png",
   "type": "app",

--- a/apps/linuxclock/ChangeLog
+++ b/apps/linuxclock/ChangeLog
@@ -1,3 +1,2 @@
 0.01: New App.
 0.02: Performance improvements.
-0.03: Update clock_info to avoid a redraw

--- a/apps/linuxclock/app.js
+++ b/apps/linuxclock/app.js
@@ -52,22 +52,22 @@ var H = g.getHeight();
    items: [
      { name: "time",
      get: () => ({ text: getTime(), img: null}),
-     show: function() {},
+     show: function() { dateMenu.items[0].emit("redraw"); },
      hide: function () {}
    },
    { name: "day",
     get: () => ({ text: getDay(), img: null}),
-    show: function() {},
+    show: function() { dateMenu.items[2].emit("redraw"); },
     hide: function () {}
    },
    { name: "date",
      get: () => ({ text: getDate(), img: null}),
-     show: function() {},
+     show: function() { dateMenu.items[1].emit("redraw"); },
      hide: function () {}
    },
    { name: "week",
      get: () => ({ text: weekOfYear(), img: null}),
-     show: function() {},
+     show: function() { dateMenu.items[3].emit("redraw"); },
      hide: function () {}
    },
    ]

--- a/apps/linuxclock/metadata.json
+++ b/apps/linuxclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "linuxclock",
   "name": "Linux Clock",
-  "version": "0.03",
+  "version": "0.02",
   "description": "A Linux inspired clock.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -1,6 +1,6 @@
 0.01: New App!
 0.02: Fix scheduling of other alarms if there is a pending alarm from the past (fix #1667)
-0.03: Fix `getTimeToAlarm` for a timer already used at same day, don't set `last` for timers.
+0.03: Fix `getTimeToAlarm` for a timer already used at same day, don't set `last` for timers. 
 0.04: Fix `getTimeToAlarm` to check for next dow if alarm.t lower currentTime.
 0.05: Export new functions (`newDefaultAlarm/Timer`), add Settings page
 0.06: Refactor some methods to library
@@ -18,4 +18,3 @@
 0.15: Automatic translation of some string in clkinfo
 0.16: Improve support for date timezone
 0.17: Fix midnight in local timezone (alarms wouldn't always fire as expected in timezone != 0)
-0.18: Update clock_info to avoid a redraw

--- a/apps/sched/clkinfo.js
+++ b/apps/sched/clkinfo.js
@@ -63,7 +63,7 @@
         hasRange: true,
         get: () => ({ text: getAlarmText(a), img: getAlarmIcon(a),
           v: getAlarmValue(a), min:0, max:getAlarmMax(a)}),
-        show: function() {},
+        show: function() { alarmItems.items[i].emit("redraw"); },
         hide: function () {},
         run: function() { }
       })),

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.18",
+  "version": "0.17",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/smpltmr/ChangeLog
+++ b/apps/smpltmr/ChangeLog
@@ -4,4 +4,3 @@
 0.04: Improvements of clock infos.
 0.05: Updated clkinfo icon.
 0.06: Ensure Timer supplies an image for clkinfo items
-0.07: Update clock_info to avoid a redraw

--- a/apps/smpltmr/clkinfo.js
+++ b/apps/smpltmr/clkinfo.js
@@ -70,7 +70,7 @@
       {
         name: null,
         get: () => ({ text: getAlarmMinutesText() + (isAlarmEnabled() ? " min" : ""), img: smpltmrItems.img }),
-        show: function() {},
+        show: function() { smpltmrItems.items[0].emit("redraw"); },
         hide: function () {},
         run: function() { }
       },
@@ -82,7 +82,7 @@
     smpltmrItems.items = smpltmrItems.items.concat({
       name: null,
       get: () => ({ text: (o > 0 ? "+" : "") + o + " min.", img: smpltmrItems.img }),
-      show: function() {},
+      show: function() { smpltmrItems.items[i+1].emit("redraw"); },
       hide: function () {},
       run: function() {
         if(o > 0) increaseAlarm(o);

--- a/apps/smpltmr/metadata.json
+++ b/apps/smpltmr/metadata.json
@@ -2,7 +2,7 @@
   "id": "smpltmr",
   "name": "Simple Timer",
   "shortName": "Simple Timer",
-  "version": "0.07",
+  "version": "0.06",
   "description": "A very simple app to start a timer.",
   "icon": "app.png",
   "tags": "tool,alarm,timer,clkinfo",

--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -19,4 +19,3 @@
 0.20: Added weather condition with temperature to clkinfo.
 0.21: Updated clkinfo icon.
 0.22: Automatic translation of strings, some left untranslated.
-0.23: Update clock_info to avoid a redraw

--- a/apps/weather/clkinfo.js
+++ b/apps/weather/clkinfo.js
@@ -34,14 +34,14 @@
                 name: "conditionWithTemperature",
                 get: () => ({ text: weather.temp, img: weatherIcon(weather.code),
                   v: parseInt(weather.temp), min: -30, max: 55}),
-                show: function() {},
+                show: function() { this.emit("redraw"); },
                 hide: function () {}
             },
             {
                 name: "condition",
                 get: () => ({ text: weather.txt, img: weatherIcon(weather.code),
                   v: weather.code}),
-                show: function() {},
+                show: function() { this.emit("redraw"); },
                 hide: function () {}
             },
             {
@@ -49,7 +49,7 @@
                 hasRange : true,
                 get: () => ({ text: weather.temp, img: atob("GBiBAAA8AAB+AADnAADDAADDAADDAADDAADDAADbAADbAADbAADbAADbAADbAAHbgAGZgAM8wAN+wAN+wAM8wAGZgAHDgAD/AAA8AA=="),
                   v: parseInt(weather.temp), min: -30, max: 55}),
-                show: function() {},
+                show: function() { this.emit("redraw"); },
                 hide: function () {}
             },
             {
@@ -57,7 +57,7 @@
                 hasRange : true,
                 get: () => ({ text: weather.hum, img: atob("GBiBAAAEAAAMAAAOAAAfAAAfAAA/gAA/gAI/gAY/AAcfAA+AQA+A4B/A4D/B8D/h+D/j+H/n/D/n/D/n/B/H/A+H/AAH/AAD+AAA8A=="),
                   v: parseInt(weather.hum), min: 0, max: 100}),
-                show: function() {},
+                show: function() { this.emit("redraw"); },
                 hide: function () {}
             },
             {
@@ -65,7 +65,7 @@
                 hasRange : true,
                 get: () => ({ text: weather.wind, img: atob("GBiBAAHgAAPwAAYYAAwYAAwMfAAY/gAZh3/xg//hgwAAAwAABg///g//+AAAAAAAAP//wH//4AAAMAAAMAAYMAAYMAAMcAAP4AADwA=="),
                   v: parseInt(weather.wind), min: 0, max: 118}),
-                show: function() {},
+                show: function() { this.emit("redraw"); },
                 hide: function () {}
             },
         ]

--- a/apps/weather/metadata.json
+++ b/apps/weather/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "weather",
   "name": "Weather",
-  "version": "0.23",
+  "version": "0.22",
   "description": "Show Gadgetbridge weather report",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
This reverts commit 8425f0b50aea39a9083b95ccc9f4211d9c5d556a, fixing bugs that appeared in BW Clock.

As per https://github.com/espruino/BangleApps/issues/2361#issuecomment-1366693191.

Maybe this should be fixed in some other way, then just disregard this PR.