### PR TITLE
Fix mapping of Gadegtbridge GPS data and adjust event name

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -18,3 +18,4 @@
 0.18: Use new message library
       If connected to Gadgetbridge, allow GPS forwarding from phone (Gadgetbridge code still not merged)
 0.19: Add automatic translation for a couple of strings.
+0.20: Fix wrong event used for forwarded GPS data from Gadgetbridge and add mapper to map longitude value correctly.

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -134,6 +134,9 @@
         event.satellites = NaN;
         event.course = NaN;
         event.fix = 1;
+        event.lon = event.long;
+        delete event.long;
+
         Bangle.emit('gps', event);
       },
       "is_gps_active": function() {
@@ -208,7 +211,7 @@
     // Replace set GPS power logic to suppress activation of gps (and instead request it from the phone)
     Bangle.setGPSPower = (isOn, appID) => {
       // if not connected, use old logic
-      if (!NRF.getSecurityStatus().connected) return originalSetGpsPower(isOn, appID); 
+      if (!NRF.getSecurityStatus().connected) return originalSetGpsPower(isOn, appID);
       // Emulate old GPS power logic
       if (!Bangle._PWR) Bangle._PWR={};
       if (!Bangle._PWR.GPS) Bangle._PWR.GPS=[];

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -137,7 +137,7 @@
         event.lon = event.long;
         delete event.long;
 
-        Bangle.emit('gps', event);
+        Bangle.emit('GPS', event);
       },
       "is_gps_active": function() {
         gbSend({ t: "gps_power", status: Bangle._PWR && Bangle._PWR.GPS && Bangle._PWR.GPS.length>0 });

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.19",
+  "version": "0.20",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",


### PR DESCRIPTION
Hi everyone i found some bugs in the handling of the gadgetbridge gps data.

**The current state**

If we retrieve the gps data from the Gadegtbridge app, we receive a JSON object with the different values. The object has a key "long" which contains the longitude gps value. The received object will then be published under the "gps" event on the global Bangle object.

**Changes in this PR**

To prevent breaking of code if you start using the gps data provided by Gadgetbridge, i adjusted the event name from "gps" to "GPS" and added a mapper to map the longitude value from "long" to "lon" so that it is similar to a gps object, which you wouuld receive if you use the normal gps chip of the banglejs device.
