### PR TITLE
LCARS Clock 0.25-New Colors and ability to disable data charts.

### DIFF
--- a/apps/lcars/ChangeLog
+++ b/apps/lcars/ChangeLog
@@ -20,5 +20,6 @@
 0.20: Use alarm for alarm functionality instead of own implementation.
 0.21: Add custom theming.
 0.22: Fix alarm and add build in function for step counting.
-0.23: Add warning for low flash memory
-0.24: Add ability to disable alarm functionality
+0.23: Add warning for low flash memory.
+0.24: Add ability to disable alarm functionality.
+0.25: Add more colors to the settings and add the ability to disable the data charts+Markup.

--- a/apps/lcars/README.md
+++ b/apps/lcars/README.md
@@ -19,6 +19,8 @@ the "sched" app must be installed on your device.
  * The lower orange line indicates the battery level.
  * Display graphs (day or month) for steps + hrm on the second screen.
  * Customizable theming colors in the settings menu of the app.
+ * Enable or disable the alarm feature.
+ * Enable or disbale the graphs for steps + hrm.
 
 ## Data that can be configured
  * Steps - Steps loaded via the wpedom app.

--- a/apps/lcars/lcars.app.js
+++ b/apps/lcars/lcars.app.js
@@ -13,6 +13,7 @@ let settings = {
   themeColor2BG: "#FF00DC",
   themeColor3BG: "#0094FF",
   disableAlarms: false,
+  disableData: false,
 };
 let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || settings;
 for (const key in saved_settings) {
@@ -55,7 +56,7 @@ function convert24to16(input)
   return "0x"+RGB565.toString(16);
 }
 
-var color1C = convert24to16(color1);
+var color1C = convert24to16(color1);//Converting colors to the correct format.
 var color2C = convert24to16(color2);
 var color3C = convert24to16(color3);
 
@@ -63,7 +64,7 @@ var color3C = convert24to16(color3);
 * Requirements and globals
 */
 
-var colorPalette = new Uint16Array([
+var colorPalette = new Uint16Array([/Used to change the color of the image if the user selects a color that is diffrent than the default.
   0x0000, // not used
   color2C,  // second
   color3C, // third
@@ -708,18 +709,20 @@ Bangle.on('touch', function(btn, e){
   var is_right = e.x > right;
   var is_upper = e.y < upper;
   var is_lower = e.y > lower;
+  
+  if(!settings.disableData){
+    if(is_left && lcarsViewPos == 1){
+      feedback();
+      lcarsViewPos = 0;
+      draw();
+      return;
 
-  if(is_left && lcarsViewPos == 1){
-    feedback();
-    lcarsViewPos = 0;
-    draw();
-    return;
-
-  } else if(is_right  && lcarsViewPos == 0){
-    feedback();
-    lcarsViewPos = 1;
-    draw();
-    return;
+    } else if(is_right  && lcarsViewPos == 0){
+      feedback();
+      lcarsViewPos = 1;
+      draw();
+      return;
+    }
   }
 
   if(lcarsViewPos == 0){

--- a/apps/lcars/lcars.app.js
+++ b/apps/lcars/lcars.app.js
@@ -64,7 +64,7 @@ var color3C = convert24to16(color3);
 * Requirements and globals
 */
 
-var colorPalette = new Uint16Array([/Used to change the color of the image if the user selects a color that is diffrent than the default.
+var colorPalette = new Uint16Array([//Used to change the color of the image if the user selects a color that is diffrent than the default.
   0x0000, // not used
   color2C,  // second
   color3C, // third

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -14,6 +14,7 @@
     themeColor2BG: "#FF00DC",
     themeColor3BG: "#0094FF",
     disableAlarms: false,
+    disableData: false,
   };
   let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || settings;
   for (const key in saved_settings) {
@@ -27,8 +28,8 @@
 
   var dataOptions = ["Steps", "Battery", "VREF", "HRM", "Temp", "Humidity", "Wind", "Altitude", "CoreT"];
   var speedOptions = ["kph", "mph"];
-  var color_options = ['Green','Orange','Cyan','Purple','Red','Blue','Yellow','White'];
-  var bg_code = ['#00ff00','#FF9900','#0094FF','#FF00DC','#ff0000','#0000ff','#ffef00','#FFFFFF'];
+  var color_options = ['Green','Orange','Cyan','Purple','Red','Blue','Yellow','White','Purple','Pink','Light Green','Dark Green'];
+  var bg_code = ['#00ff00','#FF9900','#0094FF','#FF00DC','#ff0000','#0000ff','#ffef00','#FFFFFF','#FF00FF','#6C00FF','#99FF00',"#556B2F'];
 
   E.showMenu({
     '': { 'title': 'LCARS Clock' },
@@ -109,6 +110,14 @@
       format: () => (settings.disableAlarms ? 'Yes' : 'No'),
       onchange: () => {
         settings.disableAlarms = !settings.disableAlarms;
+        save();
+      },
+    },
+    'Disable data pages functionality': {
+      value: settings.disableData,
+      format: () => (settings.disableData ? 'Yes' : 'No'),
+      onchange: () => {
+        settings.disableData = !settings.disableData;
         save();
       },
     },

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -80,7 +80,7 @@
     },
     'Theme Color 1': {
       value: 0 | bg_code.indexOf(settings.themeColor1BG),
-      min: 0, max: 7,
+      min: 0, max: color_options.length,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor1BG = bg_code[v];
@@ -89,7 +89,7 @@
     },
     'Theme Color 2': {
       value: 0 | bg_code.indexOf(settings.themeColor2BG),
-      min: 0, max: 7,
+      min: 0, max: color_options.length,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor2BG = bg_code[v];
@@ -98,7 +98,7 @@
     },
     'Theme Color 3': {
       value: 0 | bg_code.indexOf(settings.themeColor3BG),
-      min: 0, max: 7,
+      min: 0, max: color_options.length,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor3BG = bg_code[v];

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -80,7 +80,7 @@
     },
     'Theme Color 1': {
       value: 0 | bg_code.indexOf(settings.themeColor1BG),
-      min: 0, max: color_options.length,
+      min: 0, max: 11,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor1BG = bg_code[v];
@@ -89,7 +89,7 @@
     },
     'Theme Color 2': {
       value: 0 | bg_code.indexOf(settings.themeColor2BG),
-      min: 0, max: color_options.length,
+      min: 0, max: 11,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor2BG = bg_code[v];
@@ -98,7 +98,7 @@
     },
     'Theme Color 3': {
       value: 0 | bg_code.indexOf(settings.themeColor3BG),
-      min: 0, max: color_options.length,
+      min: 0, max: 11,
       format: v => color_options[v],
       onchange: v => {
         settings.themeColor3BG = bg_code[v];

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -29,7 +29,7 @@
   var dataOptions = ["Steps", "Battery", "VREF", "HRM", "Temp", "Humidity", "Wind", "Altitude", "CoreT"];
   var speedOptions = ["kph", "mph"];
   var color_options = ['Green','Orange','Cyan','Purple','Red','Blue','Yellow','White','Purple','Pink','Light Green','Dark Green'];
-  var bg_code = ['#00ff00','#FF9900','#0094FF','#FF00DC','#ff0000','#0000ff','#ffef00','#FFFFFF','#FF00FF','#6C00FF','#99FF00',"#556B2F'];
+  var bg_code = ['#00ff00','#FF9900','#0094FF','#FF00DC','#ff0000','#0000ff','#ffef00','#FFFFFF','#FF00FF','#6C00FF','#99FF00','#556B2F'];
 
   E.showMenu({
     '': { 'title': 'LCARS Clock' },

--- a/apps/lcars/metadata.json
+++ b/apps/lcars/metadata.json
@@ -3,7 +3,7 @@
   "name": "LCARS Clock",
   "shortName":"LCARS",
   "icon": "lcars.png",
-  "version":"0.24",
+  "version":"0.25",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "Library Computer Access Retrieval System (LCARS) clock.",


### PR DESCRIPTION
I updated the clock to include 4 new colors and have the ability to disable the charts section in the settings for the app. 
dark green-556B2F
purple-FF00FF
pink-let-6C00FF
light green-99FF00
This picture showcases some of the new colors:
![image](https://user-images.githubusercontent.com/89286474/210465855-345c3d7d-082b-4b9a-9909-10d8582234e6.png)
