### PR TITLE
Disable use of emulator in Pomodoro Plus because it does not work in the emulator.

### DIFF
--- a/apps/pomoplus/metadata.json
+++ b/apps/pomoplus/metadata.json
@@ -10,7 +10,6 @@
     "BANGLEJS",
     "BANGLEJS2"
   ],
-  "allow_emulator": true,
   "storage": [
     {
       "name": "pomoplus.app.js",


### PR DESCRIPTION
When ran in the emulator it gives me these errors:
```
>Uncaught Error: Module pomoplus-com.js not found
 at line 1 col 41
const common = require("pomoplus-com.js");
                                        ^
>Uncaught Error: Cannot read property 'settings' of undefined
 at line 2 col 9
  common.settings.pausedTimerExpireTime != 0 &&
        ^
>Uncaught Error: Cannot read property 'state' of undefined
 at line 1 col 184
...).setColor(1,1,1);if(!common.state.wasRunning){g.drawImage(co...
                               ^
in function "drawButtons" called from line 1 col 13
drawButtons();
            ^
>Uncaught Error: Cannot read property 'getTimeLeft' of undefined
 at line 1 col 17
let timeLeft=common.getTimeLeft();let hours=timeLeft/3600000;let minu...
                         ^
in function called from line 1 col 367
...utes)}:${pad(seconds)}`;})(),g.getWidth()/2,g.getHeight()/2)...
                              ^
in function "drawTimerAndMessage" called from line 1 col 21
drawTimerAndMessage();
                    ^
>Uncaught Error: Cannot read property 'state' of undefined
 at line 1 col 11
if (common.state.running) {
```
I am disabling the emulator functionality until someone can fix this problem.