### PR TITLE
[BWClock, AIClock and LinuxClock] Fix instability by using .get() instead of .show()

### DIFF
--- a/apps/aiclock/ChangeLog
+++ b/apps/aiclock/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Indicate battery level through line occurrence.
 0.04: Use widget_utils module.
 0.05: Support for clkinfo.
+0.06: ClockInfo Fix: Use .get instead of .show as .show is not implemented for weather etc.

--- a/apps/aiclock/aiclock.app.js
+++ b/apps/aiclock/aiclock.app.js
@@ -29,7 +29,6 @@ var H = g.getHeight();
 var cx = W/2;
 var cy = H/2;
 var drawTimeout;
-var lock_input = false;
 
 
 /************************************************
@@ -92,28 +91,6 @@ menu = menu.concat(clockItems);
     settings.menuPosX = 0;
     settings.menuPosY = 0;
   }
-
-  // Set draw functions for each item
-  menu.forEach((menuItm, x) => {
-    menuItm.items.forEach((item, y) => {
-      function drawItem() {
-        // For the clock, we have a special case, as we don't wanna redraw
-        // immediately when something changes. Instead, we update data each minute
-        // to save some battery etc. Therefore, we hide (and disable the listener)
-        // immedeately after redraw...
-        item.hide();
-
-        // After drawing the item, we enable inputs again...
-        lock_input = false;
-
-        var info = item.get();
-        drawMenuItem(info.text, info.img);
-      }
-
-      item.on('redraw', drawItem);
-    })
-  });
-
 
   function canRunMenuItem(){
     if(settings.menuPosY == 0){
@@ -204,8 +181,6 @@ function drawMenuItem(text, image){
         drawTime();
         return
     }
-    // image = atob("GBiBAAD+AAH+AAH+AAH+AAH/AAOHAAYBgAwAwBgwYBgwYBgwIBAwOBAwOBgYIBgMYBgAYAwAwAYBgAOHAAH/AAH+AAH+AAH+AAD+AA==");
-
     text = String(text);
 
     g.reset().setBgColor("#fff").setColor("#000");
@@ -292,7 +267,7 @@ function drawDigits(){
 }
 
 
-function drawDate(){
+function drawMenu(){
     var menuEntry = menu[settings.menuPosX];
 
     // The first entry is the overview...
@@ -302,9 +277,8 @@ function drawDate(){
     }
 
     // Draw item if needed
-    lock_input = true;
-    var item = menuEntry.items[settings.menuPosY-1];
-    item.show();
+    var item = menuEntry.items[settings.menuPosY-1].get();
+    drawMenuItem(item.text, item.img);
 }
 
 
@@ -320,7 +294,7 @@ function draw(){
     g.setColor(1,1,1);
 
     drawBackground();
-    drawDate();
+    drawMenu();
     drawCircle(Bangle.isLocked());
 }
 
@@ -352,10 +326,6 @@ Bangle.on('touch', function(btn, e){
     var is_left = e.x < left && !is_upper && !is_lower;
     var is_right = e.x > right && !is_upper && !is_lower;
     var is_center = !is_upper && !is_lower && !is_left && !is_right;
-
-    if(lock_input){
-        return;
-    }
 
     if(is_lower){
         Bangle.buzz(40, 0.6);

--- a/apps/aiclock/metadata.json
+++ b/apps/aiclock/metadata.json
@@ -3,7 +3,7 @@
   "name": "AI Clock",
   "shortName":"AI Clock",
   "icon": "aiclock.png",
-  "version":"0.05",
+  "version":"0.06",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "A watch face that was designed by an AI (stable diffusion) and implemented by a human.",

--- a/apps/bwclk/ChangeLog
+++ b/apps/bwclk/ChangeLog
@@ -22,3 +22,4 @@
 0.22: Use the new clkinfo module for the menu.
 0.23: Feedback of apps after run is now optional and decided by the corresponding clkinfo.
 0.24: Update clock_info to avoid a redraw
+0.25: ClockInfo Fix: Use .get instead of .show as .show is not implemented for weather etc.

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -12,7 +12,6 @@ const clock_info = require("clock_info");
 const SETTINGS_FILE = "bwclk.setting.json";
 const W = g.getWidth();
 const H = g.getHeight();
-var lock_input = false;
 
 
 /************************************************
@@ -122,27 +121,6 @@ if(settings.menuPosX >= menu.length || settings.menuPosY > menu[settings.menuPos
   settings.menuPosX = 0;
   settings.menuPosY = 0;
 }
-
-// Set draw functions for each item
-menu.forEach((menuItm, x) => {
-  menuItm.items.forEach((item, y) => {
-    function drawItem() {
-      // For the clock, we have a special case, as we don't wanna redraw
-      // immediately when something changes. Instead, we update data each minute
-      // to save some battery etc. Therefore, we hide (and disable the listener)
-      // immedeately after redraw...
-      item.hide();
-
-      // After drawing the item, we enable inputs again...
-      lock_input = false;
-
-      var info = item.get();
-      drawMenuItem(info.text, info.img);
-    }
-
-    item.on('redraw', drawItem);
-  })
-});
 
 
 function canRunMenuItem(){
@@ -292,9 +270,8 @@ function drawMenuAndTime(){
   }
 
   // Draw item if needed
-  lock_input = true;
-  var item = menuEntry.items[settings.menuPosY-1];
-  item.show();
+  var item = menuEntry.items[settings.menuPosY-1].get();
+  drawMenuItem(item.text, item.img);
 }
 
 
@@ -387,10 +364,6 @@ Bangle.on('touch', function(btn, e){
   var is_left = e.x < left && !is_upper && !is_lower;
   var is_right = e.x > right && !is_upper && !is_lower;
   var is_center = !is_upper && !is_lower && !is_left && !is_right;
-
-  if(lock_input){
-    return;
-  }
 
   if(is_lower){
     Bangle.buzz(40, 0.6);

--- a/apps/bwclk/metadata.json
+++ b/apps/bwclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bwclk",
   "name": "BW Clock",
-  "version": "0.24",
+  "version": "0.25",
   "description": "A very minimalistic clock to mainly show date and time.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/linuxclock/ChangeLog
+++ b/apps/linuxclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App.
 0.02: Performance improvements.
 0.03: Update clock_info to avoid a redraw
+0.04: Fix clkinfo -- use .get instead of .show

--- a/apps/linuxclock/app.js
+++ b/apps/linuxclock/app.js
@@ -76,21 +76,6 @@ var H = g.getHeight();
  var menu = clock_info.load();
  menu = menu.concat(dateMenu);
 
- // Set draw functions for each item
- menu.forEach((menuItm, x) => {
-   menuItm.items.forEach((item, y) => {
-     function drawItem() {
-       item.hide();
-
-       var info = item.get();
-       drawText(item.name, info.text, (y%4)+1);
-     }
-
-     item.on('redraw', drawItem);
-   })
- });
-
-
  // Ensure that our settings are still in range (e.g. app uninstall). Otherwise reset the position it.
  if(settings.menuPosX >= menu.length || settings.menuPosY > menu[settings.menuPosX].items.length ){
    settings.menuPosX = 0;
@@ -184,8 +169,9 @@ function drawMenuItems(menuItem) {
     if (i >= menuItem.items.length) {
       continue;
     }
-    lock_input++;
-    menuItem.items[i].show();
+
+    var item = menuItem.items[i];
+    drawText(item.name, item.get().text, (i%4)+1);
   }
 }
 
@@ -217,7 +203,6 @@ function drawText(key, value, line){
   value = String(value).replace("\n", " ");
   g.drawString(key + value, x, y);
 
-  lock_input -= 1;
 }
 
 
@@ -289,14 +274,8 @@ Bangle.on('charging',function(charging) {
   draw();
 });
 
-var lock_input = 0;
 
 Bangle.on('touch', function(btn, e){
-  if(lock_input > 0){
-    return;
-  }
-  lock_input = 0;
-
   var left = parseInt(g.getWidth() * 0.22);
   var right = g.getWidth() - left;
   var upper = parseInt(g.getHeight() * 0.22) + 20;

--- a/apps/linuxclock/metadata.json
+++ b/apps/linuxclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "linuxclock",
   "name": "Linux Clock",
-  "version": "0.03",
+  "version": "0.04",
   "description": "A Linux inspired clock.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
It seems that .show is not always implemented. As quick-fix I use .get() instead which works fine currently. Later on I plan using `addInteractive` -- at least for BWClock as well as AI clock this should not be a problem :)

This should also fix your report @gfwilliams:
```I can also reproduce this exact error in BW Clock without the sunrise widget - just right after starting the clock, keep tapping really quickly, and then after a few taps it stops updating.```
