### PR TITLE
Informational Clock delete emulator functionality because it does not work

### DIFF
--- a/apps/infoclk/metadata.json
+++ b/apps/infoclk/metadata.json
@@ -2,6 +2,7 @@
   "id": "infoclk",
   "name": "Informational clock",
   "version": "0.08",
+  "dependencies": {"weather":"app"},
   "description": "A configurable clock with extra info and shortcuts when unlocked, but large time when locked",
   "readme": "README.md",
   "icon": "icon.png",

--- a/apps/infoclk/metadata.json
+++ b/apps/infoclk/metadata.json
@@ -10,7 +10,6 @@
   "supports": [
     "BANGLEJS2"
   ],
-  "allow_emulator": true,
   "storage": [
     {
       "name": "infoclk.app.js",


### PR DESCRIPTION
when opened in the emulator the app gives several errors so I deleted the ability to open the app in the emulator. I also added a dependency to the weather app because without it the app does not work.