### PR TITLE
[Desktop Launcher] widget field follow correct theme immediately

### DIFF
--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -23,4 +23,6 @@ button to exit is no longer an option.
 facilitate 'fast switching' of apps where available.
 0.20: Bangle 2: Revert use of Bangle.load() to classic load() calls since
 widgets would still be loaded when they weren't supposed to.
+0.21: Bangle 2: Call Bangle.drawWidgets() early on so that the widget field
+immediately follows the correct theme.
 

--- a/apps/dtlaunch/app-b2.js
+++ b/apps/dtlaunch/app-b2.js
@@ -84,6 +84,7 @@
     g.flip();
   };
 
+  Bangle.drawWidgets(); // To immediately update widget field to follow current theme - remove leftovers if previous app set custom theme.
   Bangle.loadWidgets();
   drawPage(0);
 

--- a/apps/dtlaunch/metadata.json
+++ b/apps/dtlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "dtlaunch",
   "name": "Desktop Launcher",
-  "version": "0.20",
+  "version": "0.21",
   "description": "Desktop style App Launcher with six (four for Bangle 2) apps per page - fast access if you have lots of apps installed.",
   "screenshots": [{"url":"shot1.png"},{"url":"shot2.png"},{"url":"shot3.png"}],
   "icon": "icon.png",


### PR DESCRIPTION
When fast loading from BW Clock to Desktop Launcher the widget field would keep the inverted theme background then quickly resetting to follow non-inverted theme. 

With this PR this is no longer the case - I have inner peace.