### PR TITLE
sched: update clock_info to refresh periodically on active alarms/timers

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -19,3 +19,4 @@
 0.16: Improve support for date timezone
 0.17: Fix midnight in local timezone (alarms wouldn't always fire as expected in timezone != 0)
 0.18: Update clock_info to avoid a redraw
+0.19: Update clock_info to refresh periodically on active alarms/timers

--- a/apps/sched/clkinfo.js
+++ b/apps/sched/clkinfo.js
@@ -49,6 +49,52 @@
     return val;
   }
 
+  /*
+   * Returns the array [interval, switchTimeout]
+   * `interval` is the refresh rate (hourly or per minute)
+   * `switchTimeout` is the time before the refresh rate should change (or expiration)
+   */
+  function getRefreshIntervals(a) {
+    const minute = 60 * 1000;
+    const halfhour = 30 * minute;
+    const hour = 2 * halfhour;
+    let msecs = alarm.getTimeToAlarm(a);
+    if(typeof msecs == "undefined" || msecs == 0)
+      return [];
+    if(msecs > hour) { //refresh every half an hour
+      let remain = (msecs+minute) % halfhour;
+      if(remain < 27 * minute && remain != 0) //first align period (some tolerance)
+        return [ halfhour, remain ];
+      return [ halfhour, msecs - hour ];
+    } else { //refresh every minute
+      //alarms just need the progress bar refreshed, no need every minute
+      if(!a.timer) return [];
+      return [ minute, msecs ];
+    }
+  }
+
+  function _doInterval(interval) {
+    return setTimeout(()=>{
+      this.emit("redraw");
+      this.interval = setInterval(()=>{
+        this.emit("redraw");
+      }, interval);
+    }, interval);
+  }
+  function _doSwitchTimeout(a, switchTimeout) {
+    return setTimeout(()=>{
+      this.emit("redraw");
+      clearInterval(this.interval);
+      this.interval = undefined;
+      var tmp = getRefreshIntervals(a);
+      var interval = tmp[0];
+      var switchTimeout = tmp[1];
+      if(!interval) return;
+      this.interval = _doInterval.call(this, interval);
+      this.switchTimeout = _doSwitchTimeout.call(this, a, switchTimeout);
+    }, switchTimeout);
+  }
+
   var img = iconAlarmOn;
   //get only alarms not created by other apps
   var alarmItems = {
@@ -63,8 +109,20 @@
         hasRange: true,
         get: () => ({ text: getAlarmText(a), img: getAlarmIcon(a),
           v: getAlarmValue(a), min:0, max:getAlarmMax(a)}),
-        show: function() {},
-        hide: function () {},
+        show: function() {
+          var tmp = getRefreshIntervals(a);
+          var interval = tmp[0];
+          var switchTimeout = tmp[1];
+          if(!interval) return;
+          this.interval = _doInterval.call(this, interval);
+          this.switchTimeout = _doSwitchTimeout.call(this, a, switchTimeout);
+        },
+        hide: function() {
+          clearInterval(this.interval);
+          clearTimeout(this.switchTimeout);
+          this.interval = undefined;
+          this.switchTimeout = undefined;
+        },
         run: function() { }
       })),
   };

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
After the last modification, the text and progress bars were not updated from the clkinfo. With this PR the items are updated with a frequency that depends on how far will the timer fire.
I hope I didn't leave any dangling timeout around :)