### PR TITLE
ClockFace: use widget_utils instead of not loading widgets

### DIFF
--- a/apps/barclock/ChangeLog
+++ b/apps/barclock/ChangeLog
@@ -14,3 +14,4 @@
 0.14: Use ClockFace_menu.addItems
 0.15: Add Power saving option
 0.16: Support Fast Loading
+0.17: Hide widgets instead of not loading them at all

--- a/apps/barclock/metadata.json
+++ b/apps/barclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "barclock",
   "name": "Bar Clock",
-  "version": "0.16",
+  "version": "0.17",
   "description": "A simple digital clock showing seconds as a bar",
   "icon": "clock-bar.png",
   "screenshots": [{"url":"screenshot.png"},{"url":"screenshot_pm.png"}],

--- a/apps/barclock/settings.js
+++ b/apps/barclock/settings.js
@@ -1,5 +1,10 @@
 (function(back) {
   let s = require("Storage").readJSON("barclock.settings.json", true) || {};
+  // migrate "don't load widgets" to "hide widgets"
+  if (!("hideWidgets" in s) && ("loadWidgets" in s) && !s.loadWidgets) {
+    s.hideWidgets = 1;
+  }
+  delete s.loadWidgets;
 
   function save(key, value) {
     s[key] = value;
@@ -19,7 +24,7 @@
   };
   let items = {
     showDate: s.showDate,
-    loadWidgets: s.loadWidgets,
+    hideWidgets: s.hideWidgets,
   };
   // Power saving for Bangle.js 1 doesn't make sense (no updates while screen is off anyway)
   if (process.env.HWVERSION>1) {

--- a/apps/cogclock/ChangeLog
+++ b/apps/cogclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New clock
 0.02: Use ClockFace library, add settings
 0.03: Use ClockFace_menu.addSettingsFile
+0.04: Hide widgets instead of not loading them at all

--- a/apps/cogclock/metadata.json
+++ b/apps/cogclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "cogclock",
   "name": "Cog Clock",
-  "version": "0.03",
+  "version": "0.04",
   "description": "A cross-shaped clock inside a cog",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/cogclock/settings.js
+++ b/apps/cogclock/settings.js
@@ -4,7 +4,7 @@
     /*LANG*/"< Back": back,
   };
   require("ClockFace_menu").addSettingsFile(menu, "cogclock.settings.json", [
-    "showDate", "loadWidgets"
+    "showDate", "hideWidgets"
   ]);
   E.showMenu(menu);
 });

--- a/apps/saclock/ChangeLog
+++ b/apps/saclock/ChangeLog
@@ -1,0 +1,2 @@
+0.01: New App!
+0.02: Hide widgets instead of not loading them at all

--- a/apps/saclock/metadata.json
+++ b/apps/saclock/metadata.json
@@ -1,7 +1,7 @@
 { "id": "saclock",
   "name": "Simple analog clock",
   "shortName":"Analog clock",
-  "version":"0.01",
+  "version":"0.02",
   "description": "A very basic analog clock",
   "screenshots": [{"url":"screenshot.png"}],
   "icon": "icon.png",

--- a/apps/saclock/settings.js
+++ b/apps/saclock/settings.js
@@ -4,7 +4,7 @@
     /*LANG*/"< Back": back,
   };
   require("ClockFace_menu").addSettingsFile(menu, "saclock.settings.json", [
-    "loadWidgets"
+    "hideWidgets"
   ]);
   E.showMenu(menu);
 });

--- a/apps/terminalclock/ChangeLog
+++ b/apps/terminalclock/ChangeLog
@@ -5,3 +5,5 @@
 0.05: Add altitude display (only Bangle.js 2)
 0.06: Add power related settings to control the HR and pressure(altitude) sensor from the watchface
 0.07: Use ClockFace module and rework the settings to be able to personnalize the order of the lines
+0.08: Hide widgets instead of not loading them at all
+      Use Clockface_menu for widgets and power saving settings

--- a/apps/terminalclock/app.js
+++ b/apps/terminalclock/app.js
@@ -32,7 +32,8 @@ const clock = new ClockFace({
     this.unlock_precision = 1;
     if (this.HRMinConfidence === undefined) this.HRMinConfidence = 50;
     if (this.PowerOnInterval === undefined) this.PowerOnInterval = 15;
-    if (this.powerSaving===undefined) this.powerSaving = true;
+    if (this.powerSave===undefined) this.powerSave = this.powerSaving; // migrate old setting
+    if (this.powerSave===undefined) this.powerSave = true;
     ["L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9"].forEach(k => {
       if (this[k]===undefined){
         if(k == "L2") this[k] = "Date";
@@ -55,7 +56,7 @@ const clock = new ClockFace({
     });
 
     // set the services (HRM, pressure sensor, etc....)
-    if(!this.powerSaving){
+    if(!this.powerSave){
       turnOnServices();
     } else{
       setInterval(turnOnServices, this.PowerOnInterval*60000); // every PowerOnInterval min
@@ -156,7 +157,7 @@ function turnOnServices(){
   if(clock.showAltitude){
     Bangle.setBarometerPower(true, "terminalclock");
   }
-  if(clock.powerSaving){
+  if(clock.powerSave){
     setTimeout(function () {
       turnOffServices();
     }, 45000);
@@ -194,7 +195,7 @@ Clock related functions but not in the ClockFace module
 ---------------------------------------------------- */
 
 function unlock(){
-  if(clock.powerSaving){
+  if(clock.powerSave){
     turnOnServices();
   }
   clock.precision = clock.unlock_precision;

--- a/apps/terminalclock/metadata.json
+++ b/apps/terminalclock/metadata.json
@@ -3,7 +3,7 @@
   "name": "Terminal Clock",
   "shortName":"Terminal Clock",
   "description": "A terminal cli like clock displaying multiple sensor data",
-  "version":"0.07",
+  "version":"0.08",
   "icon": "app.png",
   "type": "clock",
   "tags": "clock",

--- a/apps/terminalclock/settings.js
+++ b/apps/terminalclock/settings.js
@@ -2,11 +2,8 @@
   var FILE = "terminalclock.json";
   // Load settings
   var settings = Object.assign({
-    // ClockFace lib
-    loadWidgets: true,
     // TerminalClock specific
     HRMinConfidence: 50,
-    powerSaving: true,
     PowerOnInterval: 15,
     L2: 'Date',
     L3: 'HR',
@@ -17,6 +14,18 @@
     L8: 'Empty',
     L9: 'Empty',
   }, require('Storage').readJSON(FILE, true) || {});
+  // ClockFace lib: migrate "don't load widgets" to "hide widgets"
+  if (!("hideWidgets" in settings)) {
+    if (("loadWidgets" in settings) && !settings.loadWidgets) settings.hideWidgets = 1;
+    else settings.hideWidgets = 0;
+  }
+  delete settings.loadWidgets;
+  // ClockFace lib: migrate `powerSaving` to `powerSave`
+  if (!("powerSave" in settings)) {
+    if ("powerSaving" in settings) settings.powerSave = settings.powerSaving;
+    else settings.powerSave = true;
+  }
+  delete settings.powerSaving;
 
   function writeSettings() {
     require('Storage').writeJSON(FILE, settings);
@@ -63,25 +72,16 @@
           writeSettings();
         }
      },
-     'Show widgets': {
-        value: settings.loadWidgets,
-        onchange: v => {
-          settings.loadWidgets = v;
-          writeSettings();
-        }
-      },
-      'Power saving': {
-        value: settings.powerSaving,
-        onchange: v => {
-          settings.powerSaving = v;
-          writeSettings();
-          setTimeout(function() {
-            E.showMenu(getMainMenu());
-          },0);
-        }
-      }
     };
-    if(settings.powerSaving){
+    const save = (key, v) => {
+      settings[key] = v;
+      writeSettings();
+    };
+    require("ClockFace_menu").addItems(mainMenu, save, {
+      hideWidgets: settings.hideWidgets,
+      powerSave: settings.powerSave,
+    });
+    if(settings.powerSave){
       mainMenu['Power on interval'] = {
         value: settings.PowerOnInterval,
         min: 3, max: 60,

--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -47,12 +47,6 @@ function ClockFace(options) {
   if (this.hideWidgets===undefined && this.loadWidgets===false) this.hideWidgets = 1;
 
   let s = require("Storage").readJSON("setting.json",1)||{};
-  if ((global.__FILE__===undefined || global.__FILE__===s.clock)
-    && s.clockHasWidgets!==this.loadWidgets) {
-    // save whether we can Fast Load
-    s.clockHasWidgets = this.loadWidgets;
-    require("Storage").writeJSON("setting.json", s);
-  }
   // use global 24/12-hour setting if not set by clock-settings
   if (!('is12Hour' in this)) this.is12Hour = !!(s["12hour"]);
 }

--- a/modules/ClockFace.js
+++ b/modules/ClockFace.js
@@ -41,10 +41,11 @@ function ClockFace(options) {
       this[k] = settings[k];
     });
   }
-  // these default to true
-  ["showDate", "loadWidgets"].forEach(k => {
-    if (this[k]===undefined) this[k] = true;
-  });
+  // showDate defaults to true
+  if (this.showDate===undefined) this.showDate = true;
+  // if (old) setting was to not load widgets, default to hiding them
+  if (this.hideWidgets===undefined && this.loadWidgets===false) this.hideWidgets = 1;
+
   let s = require("Storage").readJSON("setting.json",1)||{};
   if ((global.__FILE__===undefined || global.__FILE__===s.clock)
     && s.clockHasWidgets!==this.loadWidgets) {
@@ -92,7 +93,9 @@ ClockFace.prototype.start = function() {
   .CLOCK is set by Bangle.setUI('clock') but we want to load widgets so we can check appRect and *then*
   call setUI. see #1864 */
   Bangle.CLOCK = 1;
-  if (this.loadWidgets) Bangle.loadWidgets();
+  Bangle.loadWidgets();
+  const widget_util = ["show", "hide", "swipeOn"][this.hideWidgets|0];
+  require("widget_utils")[widget_util]();
   if (this.init) this.init.apply(this);
   const uiRemove = this._remove ? () => this.remove() : undefined;
   if (this._upDown) {
@@ -133,6 +136,7 @@ ClockFace.prototype.resume = function() {
 };
 ClockFace.prototype.remove = function() {
   this._removed = true;
+  require("widget_utils").show();
   if (this._timeout) clearTimeout(this._timeout);
   Bangle.removeListener("lcdPower", this._onLcd);
   if (this._remove) this._remove.apply(this);

--- a/modules/ClockFace.md
+++ b/modules/ClockFace.md
@@ -140,7 +140,7 @@ For example:
    // now
    clock.showDate === false;
    clock.foo === 123;
-   clock.loadWidgets === true; // default when not in settings file
+   clock.hideWidgets === 0; // default when not in settings file
    clock.is12Hour === ??; // not in settings file: uses global setting
    clock.start();
 
@@ -152,13 +152,14 @@ The following properties are automatically set on the clock:
 * `is12Hour`: `true` if the "Time Format" setting is set to "12h", `false` for "24h".
 * `paused`: `true` while the clock is paused.  (You don't need to check this inside your `draw()` code)
 * `showDate`: `true` (if not overridden through the settings file.)
-* `loadWidgets`: `true` (if not overridden through the settings file.)   
-   If set to `false` before calling `start()`, the clock won't call `Bangle.loadWidgets();` for you.
-   Best is to add a setting for this, but if you never want to load widgets, you could do this:
+* `hideWidgets`: `0` (if not overridden through the settings file.)   
+   If set to `1` before calling `start()`, the clock calls `require("widget_utils")hide();` for you. 
+   (Bangle.js 2 only: `2` for swipe-down)
+   Best is to add a setting for this, but if you never want to show widgets, you could do this:
    ```js
    var ClockFace = require("ClockFace");
    var clock = new ClockFace({draw: function(){/*...*/}});
-   clock.loadWidgets = false; // prevent loading of widgets
+   clock.hideWidgets = 1; // hide widgets
    clock.start();
    ```
 
@@ -200,7 +201,7 @@ let menu = {
 };
 require("ClockFace_menu").addItems(menu, save, { 
   showDate: settings.showDate, 
-  loadWidgets: settings.loadWidgets,
+  hideWidgets: settings.hideWidgets,
 });
 E.showMenu(menu);
 
@@ -213,7 +214,7 @@ let menu = {
   /*LANG*/"< Back": back,  
 };
 require("ClockFace_menu").addSettingsFile(menu, "<appid>.settings.json", [ 
-  "showDate", "loadWidgets", "powerSave",
+  "showDate", "hideWidgets", "powerSave",
 ]);
 E.showMenu(menu);
 

--- a/modules/ClockFace_menu.js
+++ b/modules/ClockFace_menu.js
@@ -10,19 +10,29 @@ exports.addItems = function(menu, callback, items) {
     let value = items[key];
     const label = {
       showDate:/*LANG*/"Show date",
-      loadWidgets:/*LANG*/"Load widgets",
+      hideWidgets:/*LANG*/"Widgets",
       powerSave:/*LANG*/"Power saving",
     }[key];
     switch(key) {
       // boolean options which default to true
       case "showDate":
-      case "loadWidgets":
         if (value===undefined) value = true;
         // fall through
       case "powerSave":
         // same for all boolean options:
         menu[label] = {
           value: !!value,
+          onchange: v => callback(key, v),
+        };
+        break;
+
+      case "hideWidgets":
+        let options = [/*LANG*/"Show",/*LANG*/"Hide"];
+        if (process.env.HWVERSION===2) options.push(/*LANG*/"Swipe");
+        menu[label] = {
+          value: value|0,
+          min: 0, max: options.length-1,
+          format: v => options[v|0],
           onchange: v => callback(key, v),
         };
     }
@@ -38,6 +48,12 @@ exports.addItems = function(menu, callback, items) {
  */
 exports.addSettingsFile = function(menu, settingsFile, items) {
   let s = require("Storage").readJSON(settingsFile, true) || {};
+
+  // migrate "don't load widgets" to "hide widgets"
+  if (!("hideWidgets" in s) && ("loadWidgets" in s) && !s.loadWidgets) {
+    s.hideWidgets = 1;
+  }
+  delete s.loadWidgets;
 
   function save(key, value) {
     s[key] = value;


### PR DESCRIPTION
ClockFace now always calls `loadWidgets`, clocks can add a `hideWidgets` setting to hide widgets (Bangle.js 2: or only show on swipe)
This also means we can get rid of the `clockHasWidgets` hack 🙂

* Default: show widgets
* If `hideWidgets` setting is undefined, but `loadWidgets` was still false, default to hiding widgets instead
* Also updated (I think) all clocks that were using ClockFace to hide widgets