### PR TITLE
remove null check, since mapping is now down on app side

### DIFF
--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -134,10 +134,8 @@
         event.satellites = NaN;
         event.course = NaN;
         event.fix = 1;
-        if (event.long!==undefined) {
-          event.lon = event.long;
-          delete event.long;
-        }
+        event.lon = event.long;
+        delete event.long;
         Bangle.emit('GPS', event);
       },
       "is_gps_active": function() {

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -134,8 +134,6 @@
         event.satellites = NaN;
         event.course = NaN;
         event.fix = 1;
-        event.lon = event.long;
-        delete event.long;
         Bangle.emit('GPS', event);
       },
       "is_gps_active": function() {


### PR DESCRIPTION
With the [Gadgetbridge PR](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3019), the mapping of "long -> lon" will be done on the app side and therfore this guard is not needed anymore.

If you want to keep it as backward compatibility, just close this PR.