### PR TITLE
android - Handle reconnects with fallback to internal GPS

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -20,3 +20,4 @@
 0.19: Add automatic translation for a couple of strings.
 0.20: Fix wrong event used for forwarded GPS data from Gadgetbridge and add mapper to map longitude value correctly.
 0.21: Fix broken 'Messages' button in menu
+0.22: Handle connection events for GPS forwarding from phone

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -207,12 +207,10 @@
   };
   // GPS overwrite logic
   if (settings.overwriteGps) { // if the overwrite option is set../
-    // Save current logic
-    const originalSetGpsPower = Bangle.setGPSPower;
     // Replace set GPS power logic to suppress activation of gps (and instead request it from the phone)
-    Bangle.setGPSPower = (isOn, appID) => {
+    Bangle.setGPSPower = (o => (isOn, appID) => {
       // if not connected, use old logic
-      if (!NRF.getSecurityStatus().connected) return originalSetGpsPower(isOn, appID);
+      if (!NRF.getSecurityStatus().connected) return o(isOn, appID);
       // Emulate old GPS power logic
       if (!Bangle._PWR) Bangle._PWR={};
       if (!Bangle._PWR.GPS) Bangle._PWR.GPS=[];
@@ -222,7 +220,7 @@
       let pwr = Bangle._PWR.GPS.length>0;
       gbSend({ t: "gps_power", status: pwr });
       return pwr;
-    }
+    })(Bangle.setGPSPower);
     // Replace check if the GPS is on to check the _PWR variable
     Bangle.isGPSOn = () => {
       return Bangle._PWR && Bangle._PWR.GPS && Bangle._PWR.GPS.length>0;

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -217,8 +217,8 @@
         Bangle._PWR.GPS = orig;
       }
     };
-    NRF.on('connect', ()=>{handleConnection(1);});
-    NRF.on('disconnect', ()=>{handleConnection(0);});
+    NRF.on('connect', ()=>{handleConnection(0);});
+    NRF.on('disconnect', ()=>{handleConnection(1);});
 
     // Work around Serial1 for GPS not working when connected to something
     let wrap = function(f){

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -221,15 +221,14 @@
     NRF.on('disconnect', ()=>{handleConnection(0);});
 
     // Work around Serial1 for GPS not working when connected to something
-    // 
-    Serial1.println = (o => s => {
-      origSetGPSPower(1,"android_gpsserial");
-      o(s);
-    })(Serial1.println);
-    Serial1.write = (o => s => {
-      origSetGPSPower(1,"android_gpsserial");
-      o(s);
-    })(Serial1.write);
+    let wrap = function(f){
+      return (s)=>{
+        origSetGPSPower(1,"android_gpsserial");
+        f(s);
+      };
+    }
+    Serial.println = wrap(Serial1.println);
+    Serial.write = wrap(Serial1.write);
 
     // Replace set GPS power logic to suppress activation of gps (and instead request it from the phone)
     Bangle.setGPSPower = (isOn, appID) => {

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -238,7 +238,7 @@
     Serial1.write = (o => s => {
       origSetGPSPower(1,"android_gpsserial");
       o(s);
-    })(Serial1.println);
+    })(Serial1.write);
 
     Bangle.setGBGPSPower = (isOn, appID) => {
       if (!Bangle._PWR) Bangle._PWR={};

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -178,7 +178,7 @@
       },options.timeout||30000)};
     });
     return promise;
-  }
+  };
 
   // Battery monitor
   function sendBattery() { gbSend({ t: "status", bat: E.getBattery(), chg: Bangle.isCharging()?1:0 }); }
@@ -209,20 +209,16 @@
   if (settings.overwriteGps) { // if the overwrite option is set../
     const origSetGPSPower = Bangle.setGPSPower;
     // migrate all GPS clients to the other variant on connection events
-    let handleConnect = () => {
-      let orig = Bangle._PWR.GPS;
-      delete Bangle._PWR.GPS;
-      origSetGPSPower(0);
-      Bangle._PWR.GPS = orig;
+    let handleConnection = (state) => {
+      if (Bangle.isGPSOn()){
+        let orig = Bangle._PWR.GPS;
+        delete Bangle._PWR.GPS;
+        origSetGPSPower(state);
+        Bangle._PWR.GPS = orig;
+      }
     };
-    let handleDisconnect = () => {
-      let orig = Bangle._PWR.GPS;
-      delete Bangle._PWR.GPS;
-      origSetGPSPower(1);
-      Bangle._PWR.GPS = orig;
-    };
-    NRF.on('connect', handleConnect);
-    NRF.on('disconnect', handleDisconnect);
+    NRF.on('connect', ()=>{handleConnection(1);});
+    NRF.on('disconnect', ()=>{handleConnection(0);});
 
     // Work around Serial1 for GPS not working when connected to something
     // 

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -227,6 +227,10 @@
     Bangle.isGPSOn = () => {
       return Bangle._PWR && Bangle._PWR.GPS && Bangle._PWR.GPS.length>0;
     }
+    // stop GPS on boot if not activated
+    setTimeout(()=>{
+      if (!Bangle.isGPSOn()) gbSend({ t: "gps_power", status: false });
+    },3000);
   }
 
   // remove settings object so it's not taking up RAM

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -141,7 +141,7 @@
         Bangle.emit('GPS', event);
       },
       "is_gps_active": function() {
-        gbSend({ t: "gps_power", status: Bangle.isGBGPSOn() });
+        gbSend({ t: "gps_power", status: Bangle.isGPSOn() });
       }
     };
     var h = HANDLERS[event.t];
@@ -207,24 +207,19 @@
   };
   // GPS overwrite logic
   if (settings.overwriteGps) { // if the overwrite option is set../
-    const origIsGPSOn = Bangle.isGPSOn;
     const origSetGPSPower = Bangle.setGPSPower;
     // migrate all GPS clients to the other variant on connection events
     let handleConnect = () => {
-      if (origIsGPSOn()){
-        for (let c of Bangle._PWR.GPS){
-          Bangle.setGBGPSPower(1, c);
-          origSetGPSPower(0, c);
-        }
-      }
+      let orig = Bangle._PWR.GPS;
+      delete Bangle._PWR.GPS;
+      origSetGPSPower(0);
+      Bangle._PWR.GPS = orig;
     };
     let handleDisconnect = () => {
-      if (Bangle.isGBGPSOn()){
-        for (let c of Bangle._PWR.GBGPS){
-          origSetGPSPower(1, c);
-          Bangle.setGBGPSPower(0, c);
-        }
-      }
+      let orig = Bangle._PWR.GPS;
+      delete Bangle._PWR.GPS;
+      origSetGPSPower(1);
+      Bangle._PWR.GPS = orig;
     };
     NRF.on('connect', handleConnect);
     NRF.on('disconnect', handleDisconnect);
@@ -240,35 +235,28 @@
       o(s);
     })(Serial1.write);
 
-    Bangle.setGBGPSPower = (isOn, appID) => {
-      if (!Bangle._PWR) Bangle._PWR={};
-      if (!Bangle._PWR.GBGPS) Bangle._PWR.GBGPS=[];
-      if (!appID) appID="?";
-      if (isOn && !Bangle._PWR.GBGPS.includes(appID)) Bangle._PWR.GBGPS.push(appID);
-      if (!isOn && Bangle._PWR.GBGPS.includes(appID)) Bangle._PWR.GBGPS.splice(Bangle._PWR.GBGPS.indexOf(appID),1);
-      let pwr = Bangle._PWR.GBGPS.length>0;
-      gbSend({ t: "gps_power", status: pwr });
-      return pwr;
-    };
     // Replace set GPS power logic to suppress activation of gps (and instead request it from the phone)
     Bangle.setGPSPower = (isOn, appID) => {
-      // disable our own request for GPS power first
+      // disable our own request for GPS power first and always
       if (!isOn) origSetGPSPower(0,"android_gpsserial");
       // if not connected use internal GPS power function
       if (!NRF.getSecurityStatus().connected) return origSetGPSPower(isOn, appID);
-      return Bangle.setGBGPSPower(isOn, appID);
+      if (!Bangle._PWR) Bangle._PWR={};
+      if (!Bangle._PWR.GPS) Bangle._PWR.GPS=[];
+      if (!appID) appID="?";
+      if (isOn && !Bangle._PWR.GPS.includes(appID)) Bangle._PWR.GPS.push(appID);
+      if (!isOn && Bangle._PWR.GPS.includes(appID)) Bangle._PWR.GPS.splice(Bangle._PWR.GPS.indexOf(appID),1);
+      let pwr = Bangle._PWR.GPS.length>0;
+      gbSend({ t: "gps_power", status: pwr });
+      return pwr;
     };
     // Allow checking for GPS via GadgetBridge
-    Bangle.isGBGPSOn = () => {
-      return !!(Bangle._PWR && Bangle._PWR.GBGPS && Bangle._PWR.GBGPS.length>0);
-    };
-    // Replace check if the GPS is on to check both internal and external GPS
     Bangle.isGPSOn = () => {
-      return Bangle.isGBGPSOn() || origIsGPSOn();
+      return !!(Bangle._PWR && Bangle._PWR.GPS && Bangle._PWR.GPS.length>0);
     };
     // stop GPS on boot if not activated
     setTimeout(()=>{
-      if (!Bangle.isGBGPSOn()) gbSend({ t: "gps_power", status: false });
+      if (!Bangle.isGPSOn()) gbSend({ t: "gps_power", status: false });
     },3000);
   }
 

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -225,12 +225,12 @@
     let wrap = function(f){
       return (s)=>{
         if (serialTimeout) clearTimeout(serialTimeout);
-        origSetGPSPower(1,"android_gpsserial");
+        handleConnection(1);
         f(s);
         serialTimeout = setTimeout(()=>{
           serialTimeout = undefined;
-          origSetGPSPower(0,"android_gpsserial");
-        },5000);
+          if (NRF.getSecurityStatus().connected) handleConnection(0);
+        }, 10000);
       };
     };
     Serial1.println = wrap(Serial1.println);
@@ -238,7 +238,6 @@
 
     // Replace set GPS power logic to suppress activation of gps (and instead request it from the phone)
     Bangle.setGPSPower = (isOn, appID) => {
-      // disable our own request for GPS power first and always
       // if not connected use internal GPS power function
       if (!NRF.getSecurityStatus().connected) return origSetGPSPower(isOn, appID);
       if (!Bangle._PWR) Bangle._PWR={};

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.21",
+  "version": "0.22",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",

--- a/apps/android/test.js
+++ b/apps/android/test.js
@@ -19,6 +19,10 @@ function assertNotEmpty(array, text) {
   assertTrue(array && array.length > 0, text);
 }
 
+let internalOn = () => {
+  return getPinMode((process.env.HWVERSION==2)?D30:D26) == "input";
+};
+
 let sec = {
   connected: false
 };
@@ -35,15 +39,17 @@ setTimeout(() => {
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
 
-  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+  assertTrue(Bangle.setGPSPower(1, "test"), "Switch GPS on");
 
   assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertTrue(internalOn(), "Internal GPS on");
 
-  assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+  assertFalse(Bangle.setGPSPower(0, "test"), "Switch GPS off");
 
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
   print("Connected, should use GB GPS");
   sec.connected = true;
@@ -52,16 +58,19 @@ setTimeout(() => {
 
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
-  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+  assertTrue(Bangle.setGPSPower(1, "test"), "Switch GPS on");
 
   assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
-  assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+  assertFalse(Bangle.setGPSPower(0, "test"), "Switch GPS off");
 
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
   print("Connected, then reconnect cycle");
   sec.connected = true;
@@ -70,39 +79,45 @@ setTimeout(() => {
 
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
-  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+  assertTrue(Bangle.setGPSPower(1, "test"), "Switch GPS on");
 
   assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(internalOn(), "Internal GPS off");
 
-  print("disconnect");
   NRF.emit("disconnect", {});
+  print("disconnect");
   sec.connected = false;
 
   setTimeout(() => {
 
     assertNotEmpty(Bangle._PWR.GPS, "GPS");
     assertTrue(Bangle.isGPSOn(), "isGPSOn");
+    assertTrue(internalOn(), "Internal GPS on");
 
     print("connect");
-    NRF.emit("connect", {});
     sec.connected = true;
+    NRF.emit("connect", {});
 
     setTimeout(() => {
       assertNotEmpty(Bangle._PWR.GPS, "GPS");
       assertTrue(Bangle.isGPSOn(), "isGPSOn");
+      assertFalse(internalOn(), "Internal GPS off");
 
-      assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+      assertFalse(Bangle.setGPSPower(0, "test"), "Switch GPS off");
 
       assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
       assertFalse(Bangle.isGPSOn(), "isGPSOn");
+      assertFalse(internalOn(), "Internal GPS off");
 
       setTimeout(() => {
         print("Test disconnect without gps on");
 
         assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
         assertFalse(Bangle.isGPSOn(), "isGPSOn");
+        assertFalse(internalOn(), "Internal GPS off");
 
         print("Result Overall is " + (result ? "OK" : "FAIL"));
       }, 0);

--- a/apps/android/test.js
+++ b/apps/android/test.js
@@ -26,84 +26,55 @@ let sec = {
 NRF.getSecurityStatus = () => sec;
 
 setTimeout(() => {
-  print(Bangle._PWR);
+  // add an empty starting point to make the asserts work
+  Bangle._PWR={};
 
   print("Not connected, should use internal GPS");
   assertTrue(!NRF.getSecurityStatus().connected, "Not connected");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
-
-  assertTrue(Bangle.setGBGPSPower(1), "Switch GBGPS on");
-
-  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
-  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
-  assertTrue(Bangle.isGPSOn(), "isGPSOn");
-  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
-
-  assertFalse(Bangle.setGBGPSPower(0), "Switch GBGPS off");
-
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
-  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
-  assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   print("Connected, should use GB GPS");
   sec.connected = true;
 
   assertTrue(NRF.getSecurityStatus().connected, "Connected");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
-  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+  assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
-  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   print("Connected, then reconnect cycle");
   sec.connected = true;
 
   assertTrue(NRF.getSecurityStatus().connected, "Connected");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
   assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
   assertFalse(Bangle.isGPSOn(), "isGPSOn");
-  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
 
-  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
-  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+  assertNotEmpty(Bangle._PWR.GPS, "GPS");
   assertTrue(Bangle.isGPSOn(), "isGPSOn");
-  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
 
   print("disconnect");
   NRF.emit("disconnect", {});
@@ -112,34 +83,26 @@ setTimeout(() => {
   setTimeout(() => {
 
     assertNotEmpty(Bangle._PWR.GPS, "GPS");
-    assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
     assertTrue(Bangle.isGPSOn(), "isGPSOn");
-    assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
     print("connect");
     NRF.emit("connect", {});
     sec.connected = true;
 
     setTimeout(() => {
-      assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
-      assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+      assertNotEmpty(Bangle._PWR.GPS, "GPS");
       assertTrue(Bangle.isGPSOn(), "isGPSOn");
-      assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
 
       assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
 
-      assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
       assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
       assertFalse(Bangle.isGPSOn(), "isGPSOn");
-      assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
       setTimeout(() => {
         print("Test disconnect without gps on");
 
-        assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
         assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
         assertFalse(Bangle.isGPSOn(), "isGPSOn");
-        assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
         print("Result Overall is " + (result ? "OK" : "FAIL"));
       }, 0);

--- a/apps/android/test.js
+++ b/apps/android/test.js
@@ -133,8 +133,16 @@ setTimeout(() => {
       assertFalse(Bangle.isGPSOn(), "isGPSOn");
       assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
 
+      setTimeout(() => {
+        print("Test disconnect without gps on");
 
-      print("Result Overall is " + (result ? "OK" : "FAIL"));
+        assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+        assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+        assertFalse(Bangle.isGPSOn(), "isGPSOn");
+        assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+        print("Result Overall is " + (result ? "OK" : "FAIL"));
+      }, 0);
     }, 0);
   }, 0);
 }, 5000);

--- a/apps/android/test.js
+++ b/apps/android/test.js
@@ -1,0 +1,140 @@
+let result = true;
+
+function assertTrue(condition, text) {
+  if (!condition) {
+    result = false;
+    print("FAILURE: " + text);
+  } else print("OK: " + text);
+}
+
+function assertFalse(condition, text) {
+  assertTrue(!condition, text);
+}
+
+function assertUndefinedOrEmpty(array, text) {
+  assertTrue(!array || array.length == 0, text);
+}
+
+function assertNotEmpty(array, text) {
+  assertTrue(array && array.length > 0, text);
+}
+
+let sec = {
+  connected: false
+};
+
+NRF.getSecurityStatus = () => sec;
+
+setTimeout(() => {
+  print(Bangle._PWR);
+
+  print("Not connected, should use internal GPS");
+  assertTrue(!NRF.getSecurityStatus().connected, "Not connected");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertNotEmpty(Bangle._PWR.GPS, "GPS");
+  assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertTrue(Bangle.setGBGPSPower(1), "Switch GBGPS on");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+  assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertFalse(Bangle.setGBGPSPower(0), "Switch GBGPS off");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  print("Connected, should use GB GPS");
+  sec.connected = true;
+
+  assertTrue(NRF.getSecurityStatus().connected, "Connected");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+  assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  print("Connected, then reconnect cycle");
+  sec.connected = true;
+
+  assertTrue(NRF.getSecurityStatus().connected, "Connected");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertFalse(Bangle.isGPSOn(), "isGPSOn");
+  assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  assertTrue(Bangle.setGPSPower(1), "Switch GPS on");
+
+  assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+  assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+  assertTrue(Bangle.isGPSOn(), "isGPSOn");
+  assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+  print("disconnect");
+  NRF.emit("disconnect", {});
+  sec.connected = false;
+
+  setTimeout(() => {
+
+    assertNotEmpty(Bangle._PWR.GPS, "GPS");
+    assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+    assertTrue(Bangle.isGPSOn(), "isGPSOn");
+    assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+    print("connect");
+    NRF.emit("connect", {});
+    sec.connected = true;
+
+    setTimeout(() => {
+      assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+      assertNotEmpty(Bangle._PWR.GBGPS, "GBGPS");
+      assertTrue(Bangle.isGPSOn(), "isGPSOn");
+      assertTrue(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+      assertFalse(Bangle.setGPSPower(0), "Switch GPS off");
+
+      assertUndefinedOrEmpty(Bangle._PWR.GBGPS, "No GBGPS");
+      assertUndefinedOrEmpty(Bangle._PWR.GPS, "No GPS");
+      assertFalse(Bangle.isGPSOn(), "isGPSOn");
+      assertFalse(Bangle.isGBGPSOn(), "isGBGPSOn");
+
+
+      print("Result Overall is " + (result ? "OK" : "FAIL"));
+    }, 0);
+  }, 0);
+}, 5000);


### PR DESCRIPTION
This handles connection events and switches all GPS clients over from GPS to GBGPS and viceversa.
@gfwilliams I have written some manually executed code to test the transition, is there a way to run something like that automatically?