### PR TITLE
agpsdata - Switch off GPS after use

### DIFF
--- a/apps/agpsdata/ChangeLog
+++ b/apps/agpsdata/ChangeLog
@@ -5,3 +5,4 @@
 0.04: Write AGPS data chunks with delay to improve reliability
 0.05: Show last success date
       Do not start A-GPS update automatically
+0.06: Switch off gps after updating

--- a/apps/agpsdata/lib.js
+++ b/apps/agpsdata/lib.js
@@ -10,20 +10,22 @@ readSettings();
 
 function setAGPS(b64) {
   return new Promise(function(resolve, reject) {
-    var initCommands = "Bangle.setGPSPower(1);\n"; // turn GPS on
     const gnsstype = settings.gnsstype || 1;       // default GPS
-    initCommands += `Serial1.println("${CASIC_CHECKSUM("$PCAS04," + gnsstype)}")\n`; // set GNSS mode
     // What about:
     // NAV-TIMEUTC (0x01 0x10)
     // NAV-PV (0x01 0x03)
     // or AGPS.zip uses AID-INI (0x0B 0x01)
-
-    eval(initCommands);
+    Bangle.setGPSPower(1,"agpsdata"); // turn GPS on
+    Serial1.println(CASIC_CHECKSUM("$PCAS04," + gnsstype)); // set GNSS mode
 
     try {
-      writeChunks(atob(b64), resolve);
+      writeChunks(atob(b64), ()=>{
+        Bangle.setGPSPower(0,"agpsdata");
+        resolve();
+      });
     } catch (e) {
       console.log("error:", e);
+      Bangle.setGPSPower(0,"agpsdata");
       reject();
     }
   });
@@ -36,9 +38,8 @@ function writeChunks(bin, resolve) {
     setTimeout(function() {
       if (chunkI < bin.length) {
         var chunk = bin.substr(chunkI, chunkSize);
-        js = `Serial1.write(atob("${btoa(chunk)}"))\n`;
-        eval(js);
-
+        Serial1.write(atob(btoa(chunk)));
+        
         chunkI += chunkSize;
         writeChunks(bin, resolve);
       } else {

--- a/apps/agpsdata/lib.js
+++ b/apps/agpsdata/lib.js
@@ -20,8 +20,10 @@ function setAGPS(b64) {
 
     try {
       writeChunks(atob(b64), ()=>{
-        Bangle.setGPSPower(0,"agpsdata");
-        resolve();
+        setTimeout(()=>{
+          Bangle.setGPSPower(0,"agpsdata");
+          resolve();
+        }, 1000);
       });
     } catch (e) {
       console.log("error:", e);

--- a/apps/agpsdata/metadata.json
+++ b/apps/agpsdata/metadata.json
@@ -2,7 +2,7 @@
   "name": "A-GPS Data Downloader App",
   "shortName":"A-GPS Data",
   "icon": "agpsdata.png",
-  "version":"0.05",
+  "version":"0.06",
   "description": "Once installed, this app allows you to download assisted GPS (A-GPS) data directly to your Bangle.js **via Gadgetbridge on an Android phone** when you run the app. If you just want to upload the latest AGPS data from this app loader, please use the `Assisted GPS Update (AGPS)` app.",
   "tags": "boot,tool,assisted,gps,agps,http",
   "allow_emulator":true, 


### PR DESCRIPTION
Previously GPS was left on and needed a reload to be switched off. When updating through the app this is not a problem. Automatic updates in the background while on clock however left GPS on until the next reload and caused substantial battery draw.