### PR TITLE
Berlin Clock - Adds fullscreen mode

### DIFF
--- a/apps/berlinc/ChangeLog
+++ b/apps/berlinc/ChangeLog
@@ -5,3 +5,4 @@
       Now show widgets
       Make compatible with themes, and Bangle.js 2
 0.06: Enable fastloading
+0.07: Adds fullscreen mode setting

--- a/apps/berlinc/berlin-clock.js
+++ b/apps/berlinc/berlin-clock.js
@@ -40,11 +40,11 @@ let draw = () => {
   let width = Math.min(Bangle.appRect.w,Bangle.appRect.h);
   let height = width;
   let offset = g.getHeight() - height;
-  let x = (g.getWidth() - width)/2;
+  let x = Math.floor((g.getWidth() - width)/2);
 
-  if (show_date) height -= 10;
-  let rowHeight = height / 4;
-
+  if (show_date) height -= 8;
+  let rowHeight = (height - 1) / 4;
+  g.setBgColor(g.theme.bg);
   g.reset().clearRect(Bangle.appRect);
   var now = new Date();
 
@@ -69,10 +69,11 @@ let draw = () => {
   time_digit[2] = Math.floor(now.getMinutes() / 10);
   time_digit[3] = now.getMinutes() % 10;
 
+  g.setColor(g.theme.fg);
   g.drawRect(x, offset, x + width - 1, height + offset - 1);
   for (row = 0; row < 4; row++) {
     nfields = fields[row];
-    boxWidth = width / nfields;
+    boxWidth = (width - 1) / nfields;
 
     for (col = 0; col < nfields; col++) {
       x1 = col * boxWidth + x;

--- a/apps/berlinc/berlin-clock.js
+++ b/apps/berlinc/berlin-clock.js
@@ -1,11 +1,21 @@
 {
 // Berlin Clock see https://en.wikipedia.org/wiki/Mengenlehreuhr
 // https://github.com/eska-muc/BangleApps
+
+var settings = require('Storage').readJSON("berlinc.json", true) || {};
 const fields = [4, 4, 11, 4];
-const offset = 24;
-const width = g.getWidth() - 2 * offset;
-const height = g.getHeight() - 2 * offset;
-const rowHeight = height / 4;
+
+let fullscreen = !!settings.fullscreen;
+
+g.clear();
+Bangle.loadWidgets();
+
+if (fullscreen){
+  if (process.env.HWVERSION == 2) require("widget_utils").swipeOn();
+  else require("widget_utils").hide();
+}
+
+Bangle.drawWidgets();
 
 let show_date = false;
 let show_time = false;
@@ -24,10 +34,18 @@ let queueDraw = () => {
     drawTimeout = undefined;
     draw();
   }, 60000 - (Date.now() % 60000));
-}
+};
 
 let draw = () => {
-  g.reset().clearRect(0,24,g.getWidth(),g.getHeight());
+  let width = Math.min(Bangle.appRect.w,Bangle.appRect.h);
+  let height = width;
+  let offset = g.getHeight() - height;
+  let x = (g.getWidth() - width)/2;
+
+  if (show_date) height -= 10;
+  let rowHeight = height / 4;
+
+  g.reset().clearRect(Bangle.appRect);
   var now = new Date();
 
   // show date below the clock
@@ -38,7 +56,7 @@ let draw = () => {
     var dateString = `${yr}-${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}`;
     var strWidth = g.stringWidth(dateString);
     g.setColor(g.theme.fg).setFontAlign(-1,-1);
-    g.drawString(dateString, ( g.getWidth() - strWidth ) / 2, height + offset + 4);
+    g.drawString(dateString, ( Bangle.appRect.x + Bangle.appRect.w - strWidth ) / 2, Bangle.appRect.y2 - 5);
   }
 
   rowlights[0] = Math.floor(now.getHours() / 5);
@@ -51,15 +69,15 @@ let draw = () => {
   time_digit[2] = Math.floor(now.getMinutes() / 10);
   time_digit[3] = now.getMinutes() % 10;
 
-  g.drawRect(offset, offset, width + offset, height + offset);
+  g.drawRect(x, offset, x + width, height + offset);
   for (row = 0; row < 4; row++) {
     nfields = fields[row];
     boxWidth = width / nfields;
 
     for (col = 0; col < nfields; col++) {
-      x1 = col * boxWidth + offset;
+      x1 = col * boxWidth + x;
       y1 = row * rowHeight + offset;
-      x2 = (col + 1) * boxWidth + offset;
+      x2 = (col + 1) * boxWidth + x;
       y2 = (row + 1) * rowHeight + offset;
 
       g.setColor(g.theme.fg).drawRect(x1, y1, x2, y2);
@@ -111,6 +129,7 @@ let onLcdPower = on => {
 let cleanup = () => {
   clear();
   Bangle.removeListener("lcdPower", onLcdPower);
+  require("widget_utils").show();
 }
 
 // Stop updates when LCD is off, restart when on
@@ -122,8 +141,5 @@ Bangle.setUI({mode: "clockupdown", remove: cleanup}, dir=> {
   if (dir>0) toggleDate();
 });
 
-g.clear();
-Bangle.loadWidgets();
-Bangle.drawWidgets();
 draw();
 }

--- a/apps/berlinc/berlin-clock.js
+++ b/apps/berlinc/berlin-clock.js
@@ -7,16 +7,6 @@ const fields = [4, 4, 11, 4];
 
 let fullscreen = !!settings.fullscreen;
 
-g.clear();
-Bangle.loadWidgets();
-
-if (fullscreen){
-  if (process.env.HWVERSION == 2) require("widget_utils").swipeOn();
-  else require("widget_utils").hide();
-}
-
-Bangle.drawWidgets();
-
 let show_date = false;
 let show_time = false;
 let yy = 0;
@@ -141,6 +131,16 @@ Bangle.setUI({mode: "clockupdown", remove: cleanup}, dir=> {
   if (dir<0) toggleTime();
   if (dir>0) toggleDate();
 });
+
+g.clear();
+Bangle.loadWidgets();
+
+if (fullscreen){
+  if (process.env.HWVERSION == 2) require("widget_utils").swipeOn();
+  else require("widget_utils").hide();
+}
+
+Bangle.drawWidgets();
 
 draw();
 }

--- a/apps/berlinc/berlin-clock.js
+++ b/apps/berlinc/berlin-clock.js
@@ -69,7 +69,7 @@ let draw = () => {
   time_digit[2] = Math.floor(now.getMinutes() / 10);
   time_digit[3] = now.getMinutes() % 10;
 
-  g.drawRect(x, offset, x + width, height + offset);
+  g.drawRect(x, offset, x + width - 1, height + offset - 1);
   for (row = 0; row < 4; row++) {
     nfields = fields[row];
     boxWidth = width / nfields;

--- a/apps/berlinc/metadata.json
+++ b/apps/berlinc/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "berlinc",
   "name": "Berlin Clock",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Berlin Clock (see https://en.wikipedia.org/wiki/Mengenlehreuhr)",
   "icon": "berlin-clock.png",
   "type": "clock",

--- a/apps/berlinc/metadata.json
+++ b/apps/berlinc/metadata.json
@@ -12,6 +12,8 @@
   "screenshots": [{"url":"berlin-clock-screenshot.png"}],
   "storage": [
     {"name":"berlinc.app.js","url":"berlin-clock.js"},
+    {"name":"berlinc.settings.js","url":"settings.js"},
     {"name":"berlinc.img","url":"berlin-clock-icon.js","evaluate":true}
-  ]
+  ],
+  "data": [{"name":"berlinc.json"}]
 }

--- a/apps/berlinc/settings.js
+++ b/apps/berlinc/settings.js
@@ -1,5 +1,3 @@
-// Settings menu for the enhanced Anton clock
-
 (function(back) {
   var FILE = "berlinc.json";
   var settings = Object.assign({

--- a/apps/berlinc/settings.js
+++ b/apps/berlinc/settings.js
@@ -1,0 +1,28 @@
+// Settings menu for the enhanced Anton clock
+
+(function(back) {
+  var FILE = "berlinc.json";
+  var settings = Object.assign({
+    fullscreem: false,
+  }, require('Storage').readJSON(FILE, true) || {});
+
+  function writeSettings() {
+    require('Storage').writeJSON(FILE, settings);
+  }
+
+  var mainmenu = {
+    "": {
+      "title": "Berlin clock"
+    },
+    "< Back": () => back(),
+    "Fullscreen": {
+      value: !!settings.fullscreen,
+      onchange: v => {
+        settings.fullscreen = v;
+        writeSettings();
+      }
+    }
+  };
+  E.showMenu(mainmenu);
+
+});


### PR DESCRIPTION
This uses sliding widgets on B2 and just plain hidden widgets on B1. Also respects the appRect for compatibility with bottom widgets and dynamically changes size on showing the date.