### PR TITLE
Don't send app_stats on disconnect

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -72,6 +72,7 @@ var submittedUsageInfo = "";
 function sendUsageStats() {
   if (!SETTINGS.sendUsageStats) return; // not allowed!
   if (device.uid === undefined) return; // no data yet!
+  if (!device.appsInstalled.length) return; // no installed apps or disconnected
   /* Work out what we'll send:
   * A suitably garbled UID so we can avoid too many duplicates
   * firmware version


### PR DESCRIPTION
Hopefully fix #2405

`sendUsageStats` is also called in case of a disconnect.
But then no apps are available anymore