### PR TITLE
Sched: Fix crash in clock_info

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -21,3 +21,4 @@
 0.18: Update clock_info to avoid a redraw
 0.19: Update clock_info to refresh periodically on active alarms/timers
 0.20: Alarm dismiss and snooze events
+0.21: Fix crash in clock_info

--- a/apps/sched/clkinfo.js
+++ b/apps/sched/clkinfo.js
@@ -118,8 +118,8 @@
           this.switchTimeout = _doSwitchTimeout.call(this, a, switchTimeout);
         },
         hide: function() {
-          clearInterval(this.interval);
-          clearTimeout(this.switchTimeout);
+          if (this.interval) clearInterval(this.interval);
+          if (this.switchTimeout) clearTimeout(this.switchTimeout);
           this.interval = undefined;
           this.switchTimeout = undefined;
         },

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.20",
+  "version": "0.21",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",


### PR DESCRIPTION
I saw "Uncaught Error: clearInterval(undefined) not allowed" when scheduler / alarm was set as clock info item and starting the launcher.

This fixes the crash.

