### PR TITLE
quicklaunch: do not react if clkinfo is focused

### DIFF
--- a/apps/quicklaunch/ChangeLog
+++ b/apps/quicklaunch/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Use Bangle.load() to allow 'fast switch' for apps where it's available.
 0.07: Revert version 0.06. This version is the same as 0.05.
 0.08: Respect appRect on touch events
+0.09: Do not react if clkinfo is focused

--- a/apps/quicklaunch/boot.js
+++ b/apps/quicklaunch/boot.js
@@ -10,6 +10,7 @@
 
   Bangle.on("touch", (_,e) => {
     if (!Bangle.CLOCK) return;
+    if (Bangle.CLKINFO_FOCUS) return;
     let R = Bangle.appRect;
     if (e.x < R.x || e.x > R.x2 || e.y < R.y || e.y > R.y2 ) return;
     if (settings.tapapp.src){ if (!storage.read(settings.tapapp.src)) reset("tapapp"); else load(settings.tapapp.src); }
@@ -17,6 +18,7 @@
 
   Bangle.on("swipe", (lr,ud) => {
     if (!Bangle.CLOCK) return;
+    if (Bangle.CLKINFO_FOCUS) return;
 
     if (lr == -1 && settings.leftapp && settings.leftapp.src){ if (settings.leftapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.leftapp.src)) reset("leftapp"); else load(settings.leftapp.src); }
     if (lr == 1 && settings.rightapp && settings.rightapp.src){ if (settings.rightapp.name == "Show Launcher") Bangle.showLauncher(); else if (!storage.read(settings.rightapp.src)) reset("rightapp"); else load(settings.rightapp.src); }

--- a/apps/quicklaunch/metadata.json
+++ b/apps/quicklaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "quicklaunch",
   "name": "Quick Launch",
   "icon": "app.png",
-  "version":"0.08",
+  "version":"0.09",
   "description": "Tap or swipe left/right/up/down on your clock face to launch up to five apps of your choice. Configurations can be accessed through Settings->Apps.",
   "type": "bootloader",
   "tags": "tools, system",

--- a/modules/clock_info.js
+++ b/modules/clock_info.js
@@ -273,6 +273,7 @@ exports.addInteractive = function(menu, options) {
     lockHandler = function() {
       if(options.focus) {
         options.focus=false;
+        delete Bangle.CLKINFO_FOCUS;
         options.redraw();
       }
     };
@@ -281,18 +282,21 @@ exports.addInteractive = function(menu, options) {
           e.x>(options.x+options.w) || e.y>(options.y+options.h)) {
         if (options.focus) {
           options.focus=false;
+          delete Bangle.CLKINFO_FOCUS;
           options.redraw();
         }
         return; // outside area
       }
       if (!options.focus) {
         options.focus=true; // if not focussed, set focus
+        Bangle.CLKINFO_FOCUS=true;
         options.redraw();
       } else if (menu[options.menuA].items[options.menuB].run) {
         Bangle.buzz(100, 0.7);
         menu[options.menuA].items[options.menuB].run(); // allow tap on an item to run it (eg home assistant)
       } else {
         options.focus=true;
+        Bangle.CLKINFO_FOCUS=true;
       }
     };
     Bangle.on("touch",touchHandler);
@@ -305,6 +309,7 @@ exports.addInteractive = function(menu, options) {
     Bangle.removeListener("swipe",swipeHandler);
     if (touchHandler) Bangle.removeListener("touch",touchHandler);
     if (lockHandler) Bangle.removeListener("lock", lockHandler);
+    delete Bangle.CLKINFO_FOCUS;
     menuHideItem(menu[options.menuA].items[options.menuB]);
     exports.loadCount--;
   };


### PR DESCRIPTION
Allows the swipe actions from the quicklaunch not to run together with actions in clkinfo, making the two work fine together.
I'm not sure this is the right way to do this (setting an attribute in the `Bangle` object), but it's the simplest way I could think of