### PR TITLE
widalarmeta - Do not set thousands of timeouts

### DIFF
--- a/apps/widalarmeta/ChangeLog
+++ b/apps/widalarmeta/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Change font to 5x9 7 segment-style
       Add settings page
       Add option to show seconds
+0.03: Fix settings thousands of timeouts and slowing down everything if no next alarm found

--- a/apps/widalarmeta/metadata.json
+++ b/apps/widalarmeta/metadata.json
@@ -2,7 +2,7 @@
   "id": "widalarmeta",
   "name": "Alarm & Timer ETA",
   "shortName": "Alarm ETA",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A widget that displays the time to the next Alarm or Timer in hours and minutes, maximum 24h (configurable).",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -7,7 +7,7 @@
     showSeconds: 0, // 0=never, 1=only when display is unlocked, 2=for less than a minute
   }, require("Storage").readJSON("widalarmeta.json",1) || {});
 
-  function draw() {
+  function draw(widget) {
     const times = alarms.map(alarm => require("sched").getTimeToAlarm(alarm)).filter(a => a !== undefined);
     const next = Math.min.apply(null, times);
     let calcWidth = 0;
@@ -48,13 +48,16 @@
 
     // redraw next full minute or second
     const period = drawSeconds ? 1000 : 60000;
-    let timeout = next > 0 ? next % period : period - (Date.now() % period);
+    let timeout = (isFinite(next) && next > 0) ? next % period : period - (Date.now() % period);
     if (timeout === 0) {
       timeout += period;
     }
-    setTimeout(()=>{
-      WIDGETS["widalarmeta"].draw(WIDGETS["widalarmeta"]);
-    }, timeout);
+    if (widget.drawTimeout) clearTimeout(widget.drawTimeout);
+    widget.drawTimeout = setTimeout((w)=>{
+      widget.drawTimeout = undefined;
+      w.draw(w);
+    }, timeout, widget);
+    
   } /* draw */
 
   if (config.maxhours > 0) {


### PR DESCRIPTION
The widget calculates the timeout as NaN if there is no next alarm and effectively sets timeouts as fast as it can.

FYI @nxdefiant 