### PR TITLE
chargent: support BangleJS2

### DIFF
--- a/apps/chargent/ChangeLog
+++ b/apps/chargent/ChangeLog
@@ -1,1 +1,2 @@
 0.01: First version
+0.02: Support BangleJS2

--- a/apps/chargent/boot.js
+++ b/apps/chargent/boot.js
@@ -1,4 +1,6 @@
 (() => {
+  const pin = process.env.HWVERSION === 2 ? D3 : D30;
+
   var id;
   Bangle.on('charging', (charging) => {
     if (charging) {
@@ -6,9 +8,9 @@
         var max = 0;
         var count = 0;
         id = setInterval(() => {
-          var d30 = analogRead(D30);
-          if (max < d30) {
-            max = d30;
+          var battlvl = analogRead(pin);
+          if (max < battlvl) {
+            max = battlvl;
             count = 0;
           } else {
             count++;

--- a/apps/chargent/boot.min.js
+++ b/apps/chargent/boot.min.js
@@ -1,1 +1,0 @@
-(function(){var a;Bangle.on("charging",function(e){if(e){if(!a){var c=0,b=0;a=setInterval(function(){var d=analogRead(D30);c<d?(c=d,b=0):(b++,10<=b&&(Bangle.buzz(500),setTimeout(function(){return Bangle.buzz(500)},1E3)))},3E4)}}else a&&(clearInterval(a),a=void 0)})})()

--- a/apps/chargent/metadata.json
+++ b/apps/chargent/metadata.json
@@ -1,13 +1,13 @@
 { "id": "chargent",
   "name": "Charge Gently",
-  "version": "0.01",
+  "version": "0.02",
   "description": "When charging, reminds you to disconnect the watch to prolong battery life.",
   "icon": "icon.png",
   "type": "bootloader",
   "tags": "battery",
-  "supports": ["BANGLEJS"],
+  "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",
   "storage": [
-    {"name": "chargent.boot.js", "url": "boot.min.js"}
+    {"name": "chargent.boot.js", "url": "boot.js"}
   ]
 }


### PR DESCRIPTION
This configures `chargent` to work with BangleJS2 and drops the minified JS, as mentioned in the [previous PR](https://github.com/espruino/BangleApps/pull/2506)