### PR TITLE
Iconlaunch - Use firmware E.showScroller

### DIFF
--- a/apps/iconlaunch/README.md
+++ b/apps/iconlaunch/README.md
@@ -6,7 +6,3 @@ This launcher shows 9 apps per screen, making it much faster to navigate versus 
 
 ![A screenshot](screenshot1.png)
 ![Another screenshot](screenshot2.png)
-
-## Technical note
-
-The app uses `E.showScroller`'s code in the app but not the function itself because `E.showScroller` doesn't report the position of a press to the select function.


### PR DESCRIPTION
This removes the copied and modified implementation of the scroller in favor of the one provided by the firmware since 2v16.

Do we have 2v16 in the wild for enough time, or should we wait for 2v17 before implementing this without a fallback for older firmwares?