### PR TITLE
chargent: added threshold

### DIFF
--- a/apps/chargent/ChangeLog
+++ b/apps/chargent/ChangeLog
@@ -1,2 +1,3 @@
 0.01: First version
 0.02: Support BangleJS2
+0.03: Added threshold

--- a/apps/chargent/README.md
+++ b/apps/chargent/README.md
@@ -6,6 +6,8 @@ The first stage of charging Li-ion ends at ~80% capacity when the charge voltage
 
 This app has no UI and no configuration. To disable the app, you have to uninstall it.
 
+New in v0.03: before the very first buzz, the average value after the peak is written to chargent.json and used as threshold for future charges. This reduces the time spent in the second charge stage.
+
 Side notes
 - Full capacity is reached after charge current drops to an insignificant level. This is quite some time after charge voltage reached its peak / `E.getBattery()` returns 100.
 - This app starts buzzing some time after `E.getBattery()` returns 100 (~15min on my watch), and at least 5min after the peak to account for noise.

--- a/apps/chargent/boot.js
+++ b/apps/chargent/boot.js
@@ -6,19 +6,27 @@
     if (charging) {
       if (!id) {
         var max = 0;
-        var count = 0;
+        var cnt = 0;
+        var sum = 0;
+        var lim = (require('Storage').readJSON('chargent.json', true) || {}).limit || 0;
         id = setInterval(() => {
-          var battlvl = analogRead(pin);
-          if (max < battlvl) {
-            max = battlvl;
-            count = 0;
+          var val = analogRead(pin);
+          if (max < val) {
+            max = val;
+            cnt = 1;
+            sum = val;
           } else {
-            count++;
-            if (10 <= count) {  // 10 * 30s == 5 min  // TODO ? customizable
-              // TODO ? customizable
-              Bangle.buzz(500);
-              setTimeout(() => Bangle.buzz(500), 1000);
+            cnt++;
+            sum += val;
+          }
+          if (10 < cnt || (lim && lim <= max)) {  // 10 * 30s == 5 min  // TODO ? customizable
+            if (!lim) {
+              lim = sum / cnt;
+              require('Storage').writeJSON('chargent.json', {limit: lim});
             }
+            // TODO ? customizable
+            Bangle.buzz(500);
+            setTimeout(() => Bangle.buzz(500), 1000);
           }
         }, 30*1000);
       }

--- a/apps/chargent/metadata.json
+++ b/apps/chargent/metadata.json
@@ -1,6 +1,6 @@
 { "id": "chargent",
   "name": "Charge Gently",
-  "version": "0.02",
+  "version": "0.03",
   "description": "When charging, reminds you to disconnect the watch to prolong battery life.",
   "icon": "icon.png",
   "type": "bootloader",
@@ -9,5 +9,8 @@
   "readme": "README.md",
   "storage": [
     {"name": "chargent.boot.js", "url": "boot.js"}
+  ],
+  "data": [
+    {"name": "chargent.json"}
   ]
 }


### PR DESCRIPTION
Hi,

this changes the method so it would notify early instead of waiting for the peak to materialize. All charge curves I recorded so far show fast convergence at the peak, justifying this approach. *powermanager* does the same but relies on user supplied threshold, so I think this is not a duplicate.