### PR TITLE
qcenter - Cleanup timeout

### DIFF
--- a/apps/qcenter/ChangeLog
+++ b/apps/qcenter/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Fix fast loading on swipe to clock
 0.03: Adds a setting for going back to clock on a timeout
+0.04: Fix timeouts closing fast loaded apps

--- a/apps/qcenter/app.js
+++ b/apps/qcenter/app.js
@@ -111,6 +111,7 @@ let layout = new Layout({
   remove: ()=>{
     Bangle.removeListener("swipe", onSwipe);
     Bangle.removeListener("touch", updateTimeout);
+    if (timeout) clearTimeout(timeout);
     delete Graphics.prototype.setFont8x12;
   }
 });

--- a/apps/qcenter/metadata.json
+++ b/apps/qcenter/metadata.json
@@ -2,7 +2,7 @@
   "id": "qcenter",
   "name": "Quick Center",
   "shortName": "QCenter",
-  "version": "0.03",
+  "version": "0.04",
   "description": "An app for quickly launching your favourite apps, inspired by the control centres of other watches.",
   "icon": "app.png",
   "tags": "",


### PR DESCRIPTION
This prevents loading the clock after the timeout when an app was fastloaded from qcenter.