### PR TITLE
[backswipe] check for existing swipe/drag handlers

### DIFF
--- a/apps/backswipe/ChangeLog
+++ b/apps/backswipe/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Don't fire if the app uses swipes already.

--- a/apps/backswipe/README.md
+++ b/apps/backswipe/README.md
@@ -1,0 +1,16 @@
+Service that allows you to use an app's back button using left to right swipe gesture.
+
+## Settings
+
+Mode: Blacklist/Whitelist/Always On/Disabled
+App List: Black-/whitelisted apps
+standard # of swipe handlers: 0-10
+standard # of drag handlers: 0-10
+
+Standard # of handlers settings are used to fine tune when backswipe should trigger the back function. E.g. when using a keyboard that works on drags, we don't want the backswipe to trigger when we just wanted to select a letter. This might not be able to cover all cases however.
+
+## Creator
+Kedlub
+
+## Contributors
+thyttan

--- a/apps/backswipe/README.md
+++ b/apps/backswipe/README.md
@@ -4,8 +4,9 @@ Service that allows you to use an app's back button using left to right swipe ge
 
 Mode: Blacklist/Whitelist/Always On/Disabled
 App List: Black-/whitelisted apps
-Standard # of swipe handlers: 0-10
-Standard # of drag handlers: 0-10
+Standard # of swipe handlers: 0-10 (Default: 0, must be changed for backswipe to work at all)
+Standard # of drag handlers: 0-10 (Default: 0, must be changed for backswipe to work at all)
+
 
 Standard # of handlers settings are used to fine tune when backswipe should trigger the back function. E.g. when using a keyboard that works on drags, we don't want the backswipe to trigger when we just wanted to select a letter. This might not be able to cover all cases however.
 

--- a/apps/backswipe/README.md
+++ b/apps/backswipe/README.md
@@ -4,8 +4,8 @@ Service that allows you to use an app's back button using left to right swipe ge
 
 Mode: Blacklist/Whitelist/Always On/Disabled
 App List: Black-/whitelisted apps
-standard # of swipe handlers: 0-10
-standard # of drag handlers: 0-10
+Standard # of swipe handlers: 0-10
+Standard # of drag handlers: 0-10
 
 Standard # of handlers settings are used to fine tune when backswipe should trigger the back function. E.g. when using a keyboard that works on drags, we don't want the backswipe to trigger when we just wanted to select a letter. This might not be able to cover all cases however.
 

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -16,7 +16,7 @@
     var currentFile = global.__FILE__ || "";
 
     if (global.BACK) delete global.BACK;
-    if (options && options.back && enabledForApp(currentFile) && !((Bangle["#onswipe"] instanceof Array)&&Bangle["#onswipe"].length>1 )) {
+    if (options && options.back && enabledForApp(currentFile)) {
       global.BACK = options.back;
     }
     setUI(mode, cb);

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -22,11 +22,21 @@
     setUI(mode, cb);
   };
 
+  function countHandlers(eventType) {
+    if (Bangle["#on"+eventType] === undefined) {
+      return 0;
+    } else if (Bangle["#on"+eventType] instanceof Array) {
+      return Bangle["#on"+eventType].length;
+    } else if (Bangle["#on"+eventType] !== undefiened) {
+      return 1;
+    }
+  }
+
   function goBack(lr, _) {
     // if it is a left to right swipe
     if (lr === 1) {
       // if we're in an app that has a back button, run the callback for it
-      if (global.BACK) {
+      if (global.BACK && countHandlers("swipe")<4 && countHandlers("drag")<1) { // # of allowed handlers should be user configurable in settings
         global.BACK();
       }
     }

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -27,7 +27,7 @@
       return 0;
     } else if (Bangle["#on"+eventType] instanceof Array) {
       return Bangle["#on"+eventType].length;
-    } else if (Bangle["#on"+eventType] !== undefiened) {
+    } else if (Bangle["#on"+eventType] !== undefined) {
       return 1;
     }
   }
@@ -36,7 +36,7 @@
     // if it is a left to right swipe
     if (lr === 1) {
       // if we're in an app that has a back button, run the callback for it
-      if (global.BACK && countHandlers("swipe")<4 && countHandlers("drag")<1) { // # of allowed handlers should be user configurable in settings
+      if (global.BACK && countHandlers("swipe")<=settings.standardNumSwipeHandlers && countHandlers("drag")<=settings.standardNumDragHandlers) {
         global.BACK();
       }
     }

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -15,8 +15,8 @@
 
     var currentFile = global.__FILE__ || "";
 
-    if(global.BACK) delete global.BACK;
-    if (options && options.back && enabledForApp(currentFile)) {
+    if (global.BACK) delete global.BACK;
+    if (options && options.back && enabledForApp(currentFile) && (Bangle["#onswipe"] instanceof Array)&&Bangle["#onswipe"].length>1 ) {
       global.BACK = options.back;
     }
     setUI(mode, cb);

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -16,7 +16,7 @@
     var currentFile = global.__FILE__ || "";
 
     if (global.BACK) delete global.BACK;
-    if (options && options.back && enabledForApp(currentFile) && (Bangle["#onswipe"] instanceof Array)&&Bangle["#onswipe"].length>1 ) {
+    if (options && options.back && enabledForApp(currentFile) && !((Bangle["#onswipe"] instanceof Array)&&Bangle["#onswipe"].length>1 )) {
       global.BACK = options.back;
     }
     setUI(mode, cb);

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -22,7 +22,7 @@
     setUI(mode, cb);
   };
 
-  function goBack(lr, ud) {
+  function goBack(lr, _) {
     // if it is a left to right swipe
     if (lr === 1) {
       // if we're in an app that has a back button, run the callback for it

--- a/apps/backswipe/metadata.json
+++ b/apps/backswipe/metadata.json
@@ -1,7 +1,7 @@
 { "id": "backswipe",
   "name": "Back Swipe",
   "shortName":"BackSwipe",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Service that allows you to use an app's back button using left to right swipe gesture",
   "icon": "app.png",
   "tags": "back,gesture,swipe",

--- a/apps/backswipe/settings.js
+++ b/apps/backswipe/settings.js
@@ -4,19 +4,21 @@
   // Apps is an array of app info objects, where all the apps that are there are either blocked or allowed, depending on the mode
   var DEFAULTS = {
     'mode': 0,
-    'apps': []
+    'apps': [],
+    'standardNumSwipeHandlers': 0,
+    'standardNumDragHandlers': 0
   };
-  
+
   var settings = {};
-  
+
   var loadSettings = function() {
     settings = require('Storage').readJSON(FILE, 1) || DEFAULTS;
-  }
-  
+  };
+
   var saveSettings = function(settings) {
     require('Storage').write(FILE, settings);
-  }
-  
+  };
+
   // Get all app info files
   var getApps = function() {
     var apps = require('Storage').list(/\.info$/).map(appInfoFileName => {
@@ -35,8 +37,8 @@
       return 0;
     });
     return apps;
-  }
-  
+  };
+
   var showMenu = function() {
     var menu = {
       '': { 'title': 'Backswipe' },
@@ -55,11 +57,31 @@
       },
       'App List': () => {
         showAppSubMenu();
+      },
+      'standard # of swipe handlers' : { // If more than this many handlers are present backswipe will not go back
+        value: 0|settings.standardNumSwipeHandlers,
+        min: 0,
+        max: 10,
+        format: v=>v,
+        onchange: v => {
+          settings.standardNumSwipeHandlers = v;
+          saveSettings(settings);
+        },
+      },
+      'standard # of drag handlers' : { // If more than this many handlers are present backswipe will not go back
+        value: 0|settings.standardNumDragHandlers,
+        min: 0,
+        max: 10,
+        format: v=>v,
+        onchange: v => {
+          settings.standardNumDragHandlers = v;
+          saveSettings(settings);
+        },
       }
     };
-    
+
     E.showMenu(menu);
-  }
+  };
   
   var showAppSubMenu = function() {
     var menu = {

--- a/apps/backswipe/settings.js
+++ b/apps/backswipe/settings.js
@@ -58,7 +58,7 @@
       'App List': () => {
         showAppSubMenu();
       },
-      'standard # of swipe handlers' : { // If more than this many handlers are present backswipe will not go back
+      'Standard # of swipe handlers' : { // If more than this many handlers are present backswipe will not go back
         value: 0|settings.standardNumSwipeHandlers,
         min: 0,
         max: 10,
@@ -68,7 +68,7 @@
           saveSettings(settings);
         },
       },
-      'standard # of drag handlers' : { // If more than this many handlers are present backswipe will not go back
+      'Standard # of drag handlers' : { // If more than this many handlers are present backswipe will not go back
         value: 0|settings.standardNumDragHandlers,
         min: 0,
         max: 10,


### PR DESCRIPTION
@Kedlub

As per:

> You can do stuff like:
> 
> ```
> (Bangle["#onswipe"] instanceof Array)&&Bangle["#onswipe"].length>1
> ```
> 
> to detect if there's >1 handler. It's not documented but honestly at this point it's unlikely to change :)

_Originally posted by @gfwilliams in https://github.com/espruino/BangleApps/issues/2524#issuecomment-1406230564_

I'll test it in just a minute.