### PR TITLE
[dragboard] disregard touch screen calibration

### DIFF
--- a/apps/dragboard/ChangeLog
+++ b/apps/dragboard/ChangeLog
@@ -5,3 +5,5 @@
 0.05: Now scrolls text when string gets longer than screen width.
 0.06: The code is now more reliable and the input snappier. Widgets will be drawn if present.
 0.07: Settings for display colors
+0.08: Disregard touch screen calibration as to not risk being unable to access
+some characters.

--- a/apps/dragboard/lib.js
+++ b/apps/dragboard/lib.js
@@ -2,7 +2,11 @@ exports.input = function(options) {
   options = options||{};
   var text = options.text;
   if ("string"!=typeof text) text="";
-  let settings = require('Storage').readJSON('dragboard.json',1)||{}
+  let settings = require('Storage').readJSON('dragboard.json',1)||{};
+
+  // Disregard touch screen calibration when using dragboard. Otherwise it can be impossible to access some characters. Calibration is restored when done writing.
+  let touchCalibrationBackup = {touchX1: Bangle.getOptions().touchX1, touchY1: Bangle.getOptions().touchY1, touchX2: Bangle.getOptions().touchX2, touchY2: Bangle.getOptions().touchY2};
+  Bangle.setOptions({touchX1: 0, touchY1: 0, touchX2: 160, touchY2: 160});
 
   var R = Bangle.appRect;
   const paramToColor = (param) => g.toColor(`#${settings[param].toString(16).padStart(3,0)}`);
@@ -120,6 +124,7 @@ exports.input = function(options) {
       back: ()=>{
         Bangle.setUI();
         g.clearRect(Bangle.appRect);
+        Bangle.setOptions(touchCalibrationBackup);
         resolve(text);
       },
       drag: function(event) {

--- a/apps/dragboard/metadata.json
+++ b/apps/dragboard/metadata.json
@@ -1,6 +1,6 @@
 { "id": "dragboard",
   "name": "Dragboard",
-  "version":"0.07",
+  "version":"0.08",
   "description": "A library for text input via swiping keyboard",
   "icon": "app.png",
   "type":"textinput",


### PR DESCRIPTION
>  The solution then I guess is to have sufficiently large borders where input is not needed for the apps functionality. These could be hardcoded or depend on the users touch screen calibration.
> 
> Another solution can be to remove the touch screen calibration on apps where access to the edges is needed and restore it when the app is closed.

_Originally posted by @thyttan in https://github.com/espruino/BangleApps/issues/2457#issuecomment-1418022051_

