### PR TITLE
[Kbtouch] Disregard touch screen calibration

### DIFF
--- a/apps/kbtouch/ChangeLog
+++ b/apps/kbtouch/ChangeLog
@@ -1,2 +1,4 @@
 0.01: New App!
 0.02: Introduced settings to customize the layout and functionality of the keyboard.
+0.03: Disregard touch screen calibration as to not risk some characters being
+inaccessible.

--- a/apps/kbtouch/lib.js
+++ b/apps/kbtouch/lib.js
@@ -3,6 +3,10 @@ exports.input = function(options) {
   var text = options.text;
   if ("string"!=typeof text) text="";
 
+  // Disregard touch screen calibration when using the keyboard. Otherwise it can be impossible to access some characters. Calibration is restored when done writing.
+  let touchCalibrationBackup = {touchX1: Bangle.getOptions().touchX1, touchY1: Bangle.getOptions().touchY1, touchX2: Bangle.getOptions().touchX2, touchY2: Bangle.getOptions().touchY2};
+  Bangle.setOptions({touchX1: 0, touchY1: 0, touchX2: 160, touchY2: 160});
+
   // Key Maps for Keyboard
 var KEYMAPLOWER = [
   "`1234567890-=\b",
@@ -115,6 +119,7 @@ function draw() {
   return new Promise((resolve,reject) => {
 
     Bangle.setUI({mode:"custom", drag:e=>{
+      "ram";
       if (settings.oneToOne) {
         kbx = Math.max(Math.min(Math.floor((e.x-16) / (6*2)) , 13) , 0);
         kby = Math.max(Math.min(Math.floor((e.y-120) / (8*2)) , 3) , 0);
@@ -162,6 +167,7 @@ function draw() {
       clearInterval(flashInterval);
       Bangle.setUI();
       g.clearRect(Bangle.appRect);
+      Bangle.setOptions(touchCalibrationBackup);
       resolve(text);
     }});
   });

--- a/apps/kbtouch/metadata.json
+++ b/apps/kbtouch/metadata.json
@@ -1,6 +1,6 @@
 { "id": "kbtouch",
   "name": "Touch keyboard",
-  "version":"0.02",
+  "version":"0.03",
   "description": "A library for text input via onscreen keyboard",
   "icon": "app.png",
   "type":"textinput",


### PR DESCRIPTION
... as to not risk having some characters be inaccessible.

>  The solution then I guess is to have sufficiently large borders where input is not needed for the apps functionality. These could be hardcoded or depend on the users touch screen calibration.
> 
> Another solution can be to remove the touch screen calibration on apps where access to the edges is needed and restore it when the app is closed.

_Originally posted by @thyttan in https://github.com/espruino/BangleApps/issues/2457#issuecomment-1418022051_

