### PR TITLE
[mtnclock] Addressed undefined weather timestamp

### DIFF
--- a/apps/mtnclock/ChangeLog
+++ b/apps/mtnclock/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Get weather from weather.json
+0.03: Address unexpected undefined when reading weather.json

--- a/apps/mtnclock/app.js
+++ b/apps/mtnclock/app.js
@@ -326,7 +326,7 @@ function setWeather() {
 function readWeather() {
   var weatherJson = require("Storage").readJSON('weather.json', 1);
   // save updated weather data if available and it has been an hour since last updated
-  if (weatherJson !== undefined && (data.time === undefined || (data.time + 3600000) < weatherJson.weather.time)) {
+  if (weatherJson && weatherJson.weather && weatherJson.weather.time && (data.time === undefined || (data.time + 3600000) < weatherJson.weather.time)) {
     data = {
       time: weatherJson.weather.time,
       temp: weatherJson.weather.temp,

--- a/apps/mtnclock/metadata.json
+++ b/apps/mtnclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "mtnclock",
   "name": "Mountain Pass Clock",
   "shortName": "Mtn Clock",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A clock that changes scenery based on time and weather.",
   "readme":"README.md",
   "icon": "app.png",


### PR DESCRIPTION
Tested with different versions of weather.json that include or exclude the weather and time properties.