### PR TITLE
btadv: manually setup TS helpers - use Object.assign()

### DIFF
--- a/apps/btadv/app.js
+++ b/apps/btadv/app.js
@@ -1,15 +1,5 @@
 "use strict";
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
+var __assign = Object.assign;
 var Layout = require("Layout");
 Bangle.loadWidgets();
 Bangle.drawWidgets();

--- a/apps/btadv/app.ts
+++ b/apps/btadv/app.ts
@@ -1,3 +1,6 @@
+// ts helpers:
+const __assign = Object.assign;
+
 const Layout = require("Layout") as Layout_.Layout;
 
 Bangle.loadWidgets();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "removeComments": true,
 
     "newLine": "lf",
-    "noEmitHelpers": false,
+    "noEmitHelpers": true, // we link to specific banglejs implementations
     "noEmitOnError": false,
     "preserveConstEnums": false,
     "importsNotUsedAsValues": "error",


### PR DESCRIPTION
Currently we have `tsc` [generate code for es5], because we don't yet have es6 destructuring support in JSV (used [here], for example).                                            
                                                                                                                                                                                         
As a follow on from #2587, this disables the TS poiyfill and points it at our `Object.assign`, so we benefit from these new features, while still keeping the target at es5. 
                                                                                                                                                                                         
[generate code for es5]: https://github.com/espruino/BangleApps/blob/380af9c600121f50b940b83cdb83a5f83914b8a6/tsconfig.json#L4-L4                                                  
[here]: https://github.com/espruino/BangleApps/blob/380af9c600121f50b940b83cdb83a5f83914b8a6/apps/btadv/app.ts#L235                                                                
