### PR TITLE
`clock_info.d.ts` `.app` addition

### DIFF
--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -44,6 +44,7 @@ declare module ClockInfo {
     w: number,
     h: number,
     draw(itm: MenuItem, info: Item, options: InteractiveOptions): void,
+    app?: string, // used to remember clock_info locations, per app
   };
 
   type InteractiveOptions =


### PR DESCRIPTION
Clock info can remember the app a clock info was associated with this - now tracked in typescript