### PR TITLE
[messagesoverlay] scroll six lines per swipe, on Bangle2 this leaves the previous first…

### DIFF
--- a/apps/messagesoverlay/ChangeLog
+++ b/apps/messagesoverlay/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial fork from messages_light
 0.02: Fix touch/drag/swipe handlers not being restored correctly if a message is removed
+0.03: Scroll six lines per swipe, leaving the previous top/bottom row visible.

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -279,6 +279,8 @@ let drawTriangleDown = function(ovr) {
   ovr.fillPoly([ovr.getWidth()-9, ovr.getHeight()-6, ovr.getWidth()-14, ovr.getHeight()-16, ovr.getWidth()-4, ovr.getHeight()-16]);
 };
 
+let linesScroll = 6;
+
 let scrollUp = function(ovr) {
   msg = eventQueue[0];
   LOG("up", msg);
@@ -289,7 +291,7 @@ let scrollUp = function(ovr) {
 
   if (!msg.CanscrollUp) return;
 
-  msg.FirstLine = msg.FirstLine > 0 ? msg.FirstLine - 1 : 0;
+  msg.FirstLine = msg.FirstLine > 0 ? msg.FirstLine - linesScroll : 0;
 
   drawMessage(ovr, msg);
 };
@@ -304,7 +306,7 @@ let scrollDown = function(ovr) {
 
   if (!msg.CanscrollDown) return;
 
-  msg.FirstLine = msg.FirstLine + 1;
+  msg.FirstLine = msg.FirstLine + linesScroll;
   drawMessage(ovr, msg);
 };
 

--- a/apps/messagesoverlay/metadata.json
+++ b/apps/messagesoverlay/metadata.json
@@ -1,17 +1,35 @@
 {
   "id": "messagesoverlay",
   "name": "Messages Overlay",
-  "version": "0.02",
+  "version": "0.03",
   "description": "An overlay based implementation of a messages UI (display notifications from iOS and Gadgetbridge/Android)",
   "icon": "app.png",
   "type": "bootloader",
   "tags": "tool,system",
-  "supports": ["BANGLEJS2"],
-  "dependencies" : { "messageicons":"module","messages":"app" },
+  "supports": [
+    "BANGLEJS2"
+  ],
+  "dependencies": {
+    "messageicons": "module",
+    "messages": "app"
+  },
   "readme": "README.md",
   "storage": [
-    {"name":"messagesoverlay","url":"lib.js"},
-    {"name":"messagesoverlay.boot.js","url":"boot.js"}
+    {
+      "name": "messagesoverlay",
+      "url": "lib.js"
+    },
+    {
+      "name": "messagesoverlay.boot.js",
+      "url": "boot.js"
+    }
   ],
-  "screenshots": [{"url":"screen_call.png"} ,{"url":"screen_message.png"} ]
+  "screenshots": [
+    {
+      "url": "screen_call.png"
+    },
+    {
+      "url": "screen_message.png"
+    }
+  ]
 }


### PR DESCRIPTION
…/last line visible so the user know they got to see all text.

Not tested on Bangle 1.

@halemmerich 