### PR TITLE
[Not Analog] Respect system time format setting

### DIFF
--- a/apps/notanalog/ChangeLog
+++ b/apps/notanalog/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Use alarm for timer instead of own alarm implementation.
 0.05: Use internal step counter if no widget is available.
 0.06: Use widget_utils.
+0.07: Respect system setting for 12h or 24h time

--- a/apps/notanalog/metadata.json
+++ b/apps/notanalog/metadata.json
@@ -3,7 +3,7 @@
   "name": "Not Analog",
   "shortName":"Not Analog",
   "icon": "notanalog.png",
-  "version":"0.06",
+  "version":"0.07",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "An analog watch face for people that can not read analog watch faces.",

--- a/apps/notanalog/notanalog.app.js
+++ b/apps/notanalog/notanalog.app.js
@@ -13,6 +13,9 @@ let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || settings;
 for (const key in saved_settings) {
     settings[key] = saved_settings[key]
 }
+const is12Hour = (require("Storage").readJSON("setting.json", 1) || {})[
+  "12hour"
+];
 
 /*
  * Set some important constants such as width, height and center
@@ -199,6 +202,9 @@ function drawTime(){
 
     // Hour
     var h = state.currentDate.getHours();
+    if (is12Hour && h > 12) {
+      h = h - 12;
+    }
     var h1 = parseInt(h / 10);
     var h2 = h < 10 ? h : h - h1*10;
     drawTextCleared(h1, cx, posY+8);


### PR DESCRIPTION
Quick update to the Not Analog clock to respect the system time format setting for 12h time. Utilizing the ClockFace module is probably a better solution, but a much bigger lift than this quick fix :shrug: 

@peerdavid