### PR TITLE
weather: added monochrome parameter to `drawIcon`

### DIFF
--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -21,3 +21,4 @@
 0.22: Automatic translation of strings, some left untranslated.
 0.23: Update clock_info to avoid a redraw
 0.24: Redraw clock_info on update and provide color field for condition
+0.25: Added monochrome parameter to drawIcon in lib

--- a/apps/weather/clkinfo.js
+++ b/apps/weather/clkinfo.js
@@ -22,7 +22,7 @@
 
     function weatherIcon(code) {
       var ovr = Graphics.createArrayBuffer(24,24,1,{msb:true});
-      weatherLib.drawIcon({code:code},12,12,12,ovr);
+      weatherLib.drawIcon({code:code},12,12,12,ovr,true);
       var img = ovr.asImage();
       img.transparent = 0;
       return img;

--- a/apps/weather/lib.js
+++ b/apps/weather/lib.js
@@ -155,14 +155,11 @@ exports.getColor = function(code) {
  * @param y Top
  * @param r Icon Size
  * @param ovr Graphics instance (or undefined for g)
+ * @param monochrome If true, produce a monochromatic icon
  */
-exports.drawIcon = function(cond, x, y, r, ovr) {
+exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
   var palette;
-  var monochrome=1;
-  if(!ovr) {
-    ovr = g;
-    monochrome=0;
-  }
+  if(!ovr) ovr = g;
 
   palette = getPalette(monochrome, ovr);
 

--- a/apps/weather/metadata.json
+++ b/apps/weather/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "weather",
   "name": "Weather",
-  "version": "0.24",
+  "version": "0.25",
   "description": "Show Gadgetbridge weather report",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
The `drawIcon` function used to draw the weather icon directly on the screen, long ago I changed it to optionally draw on a supplied Graphic object to be able to transform it in an image.
As the mechanism was used just by the `clkinfo` (which needs monochromatic images), the function was always using a single colour palette in case a Graphic object was supplied.
With this (small) update, calling this function without the monochrome parameter set to true will still draw a coloured icon even on the supplied Graphic object, as needed by apps like weatherClock (#2617).