### PR TITLE
[clockcal] fixed typo in settings.js for DRAGDOWN

### DIFF
--- a/apps/clockcal/ChangeLog
+++ b/apps/clockcal/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Improved colors (connected vs disconnected)
 0.06: Tell clock widgets to hide.
 0.07: Convert Yes/No On/Off in settings to checkboxes
+0.08: Fixed typo in settings.js for DRAGDOWN to make option work

--- a/apps/clockcal/metadata.json
+++ b/apps/clockcal/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "clockcal",
   "name": "Clock & Calendar",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Clock with Calendar",
   "readme":"README.md",
   "icon": "app.png",

--- a/apps/clockcal/settings.js
+++ b/apps/clockcal/settings.js
@@ -93,7 +93,7 @@
             value: actions.indexOf(settings.DRAGDOWN),
             format: v => actions[v],
             onchange: v => {
-                settings.DRGDOWN = actions[v];
+                settings.DRAGDOWN = actions[v];
                 writeSettings();
             }
         },


### PR DESCRIPTION
fixed typo in settings.js for DRAGDOWN that did cause the setting to not be saved correctly and hence wasn't settable