### PR TITLE
Add typings for `sched`, `locale` and expose via `require`

### DIFF
--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -279,7 +279,7 @@ function showEditRepeatMenu(repeat, day, dowChangeCallback) {
       }
     };
   } else {
-    var date = day; // eventually: detect day of date and configure a repeat e.g. 3rd Monday of Month
+    // var date = day; // eventually: detect day of date and configure a repeat e.g. 3rd Monday of Month
     dow = EVERY_DAY;
     repeat = repeat || {interval: "month", num: 1};
 

--- a/apps/btadv/app.ts
+++ b/apps/btadv/app.ts
@@ -1,7 +1,7 @@
 // ts helpers:
 const __assign = Object.assign;
 
-const Layout = require("Layout") as Layout_.Layout;
+const Layout = require("Layout");
 
 Bangle.loadWidgets();
 Bangle.drawWidgets();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,10 @@
 
     "module": "commonjs",
 
+    // toggle these to check everything (and optionally change the include below to "apps/myapp/*.js")
+    // "checkJs": true,
+    // "noEmit": true,
+
     // code-gen
     "declaration": false,
     "emitDeclarationOnly": false,
@@ -45,6 +49,7 @@
   },
   "include": [
     "*/*/*.ts",
+    "apps/*/*.js", // with checkJs: true
     "*/*/*.d.ts",
     "modules/*.d.ts",
     "typescript/types/*.d.ts"

--- a/typescript/types/locale.d.ts
+++ b/typescript/types/locale.d.ts
@@ -1,0 +1,19 @@
+declare module Locale {
+  type ShortBoolean = 0 | 1 | boolean;
+
+  type Locale = {
+    name: string,
+    currencySym: string,
+    dow(date: Date, short?: ShortBoolean): string,
+    month(date: Date, short?: ShortBoolean): string,
+    number(n: number): string,
+    currency(c: number): string,
+    distance(d: number): string,
+    speed(s: number): string,
+    temp(t: number): string,
+    translate(s: string): string,
+    date(date: Date, short?: ShortBoolean): string,
+    time(date: Date, short?: ShortBoolean): string,
+    meridian(date: Date): string,
+  }
+}

--- a/typescript/types/modules.d.ts
+++ b/typescript/types/modules.d.ts
@@ -1,0 +1,7 @@
+// locally declared modules
+declare function require(moduleName: "locale"): Locale.Locale;
+declare function require(moduleName: "sched"): typeof Sched;
+
+declare function require(moduleName: "ClockFace"): typeof ClockFace_.ClockFace;
+declare function require(moduleName: "clock_info"): typeof ClockInfo;
+declare function require(moduleName: "Layout"): typeof Layout_.Layout;

--- a/typescript/types/sched.d.ts
+++ b/typescript/types/sched.d.ts
@@ -1,0 +1,70 @@
+declare module Sched {
+  const enum Dow {
+    SUN = 1,
+    MON = 2,
+    TUE = 4,
+    WED = 8,
+    THU = 16,
+    FRI = 32,
+    SAT = 64,
+  }
+
+  type VibratePattern = "." | "," | "-" | ":" | ";" | "=";
+
+  type Sched = {
+    id?: string,
+    appid?: string,
+    on: boolean,
+    dow?: number,
+    date?: `${number}-${number}-${number}`,
+    msg: string,
+    last: number,
+    rp: boolean, // repeat
+    vibrate?: VibratePattern,
+    hidden?: boolean,
+    as?: boolean, // auto snooze
+    del?: boolean,
+    js?: string,
+    data?: unknown,
+  } & (
+    {
+      t: number, // time of day since midnight (in ms, set automatically when timer starts)
+    } | {
+      timer: number, // this is a timer - the time in ms
+    }
+  );
+
+  type SchedSettings = {
+    unlockAtBuzz: boolean,
+    defaultSnoozeMillis: number,
+    defaultAutoSnooze: boolean,
+    defaultDeleteExpiredTimers: boolean,
+    buzzCount: number,
+    buzzIntervalMillis: number,
+    defaultAlarmPattern: string,
+    defaultTimerPattern: string,
+  };
+
+  function getAlarms(): Sched[];
+
+  function setAlarms(alarms: readonly Sched[]): void;
+
+  function getAlarm(id: string): Sched | undefined;
+
+  function getActiveAlarms (alarms: Sched[], time?: Date): Sched[];
+
+  function setAlarm(id: string, alarm?: Sched): void;
+
+  function getTimeToAlarm(alarm: Sched, time?: Date): number | undefined;
+  function getTimeToAlarm(alarm?: undefined | null, time?: Date): undefined;
+
+  function reload(): void;
+
+  function newDefaultAlarm(): Sched;
+
+  function newDefaultTimer(): Sched;
+
+  function getSettings(): SchedSettings;
+
+  function setSettings(settings: SchedSettings): void;
+}

--- a/typescript/types/sched.d.ts
+++ b/typescript/types/sched.d.ts
@@ -16,10 +16,8 @@ declare module Sched {
     appid?: string,
     on: boolean,
     dow?: number,
-    date?: `${number}-${number}-${number}`,
     msg: string,
     last: number,
-    rp: boolean, // repeat
     vibrate?: VibratePattern,
     hidden?: boolean,
     as?: boolean, // auto snooze
@@ -32,7 +30,20 @@ declare module Sched {
     } | {
       timer: number, // this is a timer - the time in ms
     }
+  ) & (
+    {
+      date: `${number}-${number}-${number}`,
+      rp?: Repeat,
+    } | {
+      date: undefined,
+      rp: boolean,
+    }
   );
+
+  type Repeat = {
+    num: number,
+    interval: "day" | "week" | "month" | "year",
+  };
 
   type SchedSettings = {
     unlockAtBuzz: boolean,


### PR DESCRIPTION
I'd like to eventually make this opt-in, so if a user wants to, they can check JS files by popping a little `"apps/myapp/*.js"` into `tsconfig.json`. Currently this doesn't pick up any of the typescript bindings - something I'd like to address.