### PR TITLE
Pause health HRM readings when stationary

### DIFF
--- a/apps/health/ChangeLog
+++ b/apps/health/ChangeLog
@@ -21,3 +21,4 @@
 0.20: Fix the settings page, it would not update settings correctly.
 0.21: Update boot.min.js.
 0.22: Fix timeout for heartrate sensor on 3 minute setting (#2435)
+0.23: Pause HRM overnight

--- a/apps/health/ChangeLog
+++ b/apps/health/ChangeLog
@@ -21,4 +21,4 @@
 0.20: Fix the settings page, it would not update settings correctly.
 0.21: Update boot.min.js.
 0.22: Fix timeout for heartrate sensor on 3 minute setting (#2435)
-0.23: Pause HRM overnight
+0.23: Pause HRM when there's no movement for a while

--- a/apps/health/boot.js
+++ b/apps/health/boot.js
@@ -1,22 +1,13 @@
 (function(){
   var settings = require("Storage").readJSON("health.json",1)||{};
   var hrm = 0|settings.hrm;
-  let lastSuccess = 0;
   let paused = false;
 
   if (hrm == 1 || hrm == 2) {
    function onHealth() {
-     if (paused) {
-       // paused - 6am or earlier, remain paused
-       const now = new Date();
-       if (now.getHours() <= 6)
-         return;
-
-       paused = false;
-     }
-
-     Bangle.setHRMPower(1, "health");
      setTimeout(()=>Bangle.setHRMPower(0, "health"),hrm*60000); // give it 1 minute detection time for 3 min setting and 2 minutes for 10 min setting
+     if (paused) return; // allow the above code to turn hrm off
+     Bangle.setHRMPower(1, "health");
      if (hrm == 1){
        for (var i = 1; i <= 2; i++){
          setTimeout(()=>{
@@ -28,35 +19,42 @@
        }
      }
    }
-   function onLock(locked) {
-     // assert(paused)
-     Bangle.removeListener("lock", onLock);
-     // user interaction, unpause
-     paused = false;
-   }
-
    Bangle.on("health", onHealth);
    Bangle.on('HRM', h => {
-     if (h.confidence>80) {
-       lastSuccess = Date.now();
-       Bangle.setHRMPower(0, "health");
-     } else {
-       const now = new Date();
-       // has it been half an hour with no success?
-       if ((now.getTime() - lastSuccess) > 1800000) {
-         // is it past midnight and 6am or before?
-         if (0 <= now.getHours() && now.getHours() <= 6) {
-           // if so, pause our recordings until 7am
-           Bangle.setHRMPower(0, "health");
-           paused = true;
-           Bangle.on("lock", onLock);
-         }
-       }
-     }
+     if (h.confidence>80) Bangle.setHRMPower(0, "health");
    });
    if (Bangle.getHealthStatus().bpmConfidence) return;
    onHealth();
   } else Bangle.setHRMPower(hrm!=0, "health");
+  if (settings.withRecentMovement) {
+    let x, y, z, hadMovement = false;
+    const onAccel = (a) => {
+      const x2 = Math.round(a.x * 100),
+        y2 = Math.round(a.y * 100),
+        z2 = Math.round(a.z * 100);
+      if (x != null && (Math.abs(x - x2) > 1 || Math.abs(y - y2) > 1 || Math.abs(z - z2) > 1)) {
+        hadMovement = true;
+        Bangle.removeListener('accel', onAccel);
+      }
+      x = x2, y = y2, z = z2;
+    };
+    // look for movement over 5 seconds
+    const lookForMovement = () => {
+      hadMovement = false;
+      x = null;
+      Bangle.on('accel', onAccel);
+      setTimeout(
+        () => {
+          Bangle.removeListener('accel', onAccel);
+          paused = !hadMovement;
+          // check again in 15 or 5 minutes
+          setTimeout(lookForMovement, hadMovement ? 900000 : 300000);
+        },
+        5000
+      );
+    };
+    lookForMovement();
+  }
 })();
 
 Bangle.on("health", health => {

--- a/apps/health/metadata.json
+++ b/apps/health/metadata.json
@@ -2,7 +2,7 @@
   "id": "health",
   "name": "Health Tracking",
   "shortName": "Health",
-  "version": "0.22",
+  "version": "0.23",
   "description": "Logs health data and provides an app to view it",
   "icon": "app.png",
   "tags": "tool,system,health",

--- a/apps/health/settings.js
+++ b/apps/health/settings.js
@@ -2,7 +2,8 @@
   var settings = Object.assign({
     hrm: 0,
     stepGoal: 10000,
-    stepGoalNotification: false
+    stepGoalNotification: false,
+    withRecentMovement: false,
   }, require("Storage").readJSON("health.json", true) || {});
 
   function setSettings() {
@@ -44,6 +45,15 @@
       format: () => (settings.stepGoalNotification ? 'Yes' : 'No'),
       onchange: () => {
         settings.stepGoalNotification = !settings.stepGoalNotification;
+        setSettings();
+      }
+    },
+
+    /*LANG*/"Only detect when moving": {
+      value: settings.withRecentMovement,
+      format: () => settings.withRecentMovement ? 'Yes' : 'No',
+      onchange: () => {
+        settings.withRecentMovement = !settings.withRecentMovement;
         setSettings();
       }
     }


### PR DESCRIPTION
I'm not sure about how useful this will be, hence the draft state - originally I'd thought about pausing HRM overnight, but doing it based on movement feels more reliable, for example if someone leaves their watch on a bedside table.

A few unknowns:
- [ ] Perhaps I'm being too stingy with the `'accel'` readings and could leave them on for longer - I don't think it draws too much battery
- [ ] The `Math.round(x * 100)` seems to be about right, changes in that by more than a single digit seem to indicate movement for me - I "calibrated" using the [BLE streaming example](https://www.espruino.com/Bangle.js+Data+Streaming)
- [ ] Is saving on HRM overnight (~8 hours) worth having this feature?