### PR TITLE
Fix a menu crash in alarms app

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -43,3 +43,4 @@
       Display alarm label in delete prompt
 0.39: Dated event repeat option
 0.40: Use substring of message when it's longer than fits the designated menu entry.
+0.40: Fix a menu bug affecting alarms with empty messages.

--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -43,4 +43,4 @@
       Display alarm label in delete prompt
 0.39: Dated event repeat option
 0.40: Use substring of message when it's longer than fits the designated menu entry.
-0.40: Fix a menu bug affecting alarms with empty messages.
+0.41: Fix a menu bug affecting alarms with empty messages.

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -56,6 +56,16 @@ function trimLabel(label, maxLength) {
       : label.substring(0,maxLength));
 }
 
+function formatAlarmMessage(msg) {
+  if (msg == null) {
+    return msg;
+  } else if (msg.length > 7) {
+    return msg.substring(0,6)+"...";
+  } else {
+    return msg.substring(0,7);
+  }
+}
+
 function showMainMenu() {
   const menu = {
     "": { "title": /*LANG*/"Alarms & Timers" },
@@ -145,9 +155,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     },
     /*LANG*/"Message": {
       value: alarm.msg,
-      format: v => (v.length > 7
-                    ? (v.substring(0,6)+"...")
-                    : v.substring(0,7)),
+      format: formatAlarmMessage,
       onchange: () => {
         setTimeout(() => {
           keyboard.input({text:alarm.msg}).then(result => {
@@ -379,9 +387,7 @@ function showEditTimerMenu(selectedTimer, timerIndex) {
     },
     /*LANG*/"Message": {
       value: timer.msg,
-      format: v => (v.length > 7
-                    ? (v.substring(0,6)+"...")
-                    : v.substring(0,7)),
+      format: formatAlarmMessage,
       onchange: () => {
         setTimeout(() => {
           keyboard.input({text:timer.msg}).then(result => {

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.40",
+  "version": "0.41",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
The alarm app menu was "crashing" when trying to create a new alarm that didn't yet have a message. This seems to fix that issue.