### PR TITLE
[Fastload Utils] Add app history functionality

### DIFF
--- a/apps/fastload/ChangeLog
+++ b/apps/fastload/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Allow redirection of loads to the launcher
 0.03: Allow hiding the fastloading info screen
+0.04: (WIP) Allow use of app history when going back (`load()` or `Bangle.load()` calls without specified app).

--- a/apps/fastload/README.md
+++ b/apps/fastload/README.md
@@ -8,8 +8,15 @@ This allows fast loading of all apps with two conditions:
 
 ## Settings
 
+* Activate app history and navigate back through recent apps instead of immediately loading the clock face
+* If Quick Launch is installed it can be excluded from app history
 * Allows to redirect all loads usually loading the clock to the launcher instead
 * The "Fastloading..." screen can be switched off
+
+## App history
+
+* Long press of hardware button clears the app history and loads the clock face
+* Installing the 'Fast Reset' app allows doing fastloads directly to the clock face by pressing the hardware button for one second. Useful if there are many apps in the history and the user want to access the clock quickly.
 
 ## Technical infos
 
@@ -19,3 +26,6 @@ It checks the app to be loaded for widget use and stores the result of that and 
 # Creator
 
 [halemmerich](https://github.com/halemmerich)
+
+# Contributors
+[thyttan](https://github.com/thyttan)

--- a/apps/fastload/boot.js
+++ b/apps/fastload/boot.js
@@ -1,5 +1,6 @@
 {
-const SETTINGS = require("Storage").readJSON("fastload.json") || {};
+const s = require("Storage");
+const SETTINGS = s.readJSON("fastload.json") || {};
 
 let loadingScreen = function(){
   g.reset();
@@ -16,26 +17,26 @@ let loadingScreen = function(){
   g.flip(true);
 };
 
-let cache = require("Storage").readJSON("fastload.cache") || {};
+let cache = s.readJSON("fastload.cache") || {};
 
 let checkApp = function(n){
   // no widgets, no problem
   if (!global.WIDGETS) return true;
-  let app = require("Storage").read(n);
+  let app = s.read(n);
   if (cache[n] && E.CRC32(app) == cache[n].crc)
-    return cache[n].fast
+    return cache[n].fast;
   cache[n] = {};
   cache[n].fast = app.includes("Bangle.loadWidgets");
   cache[n].crc = E.CRC32(app);
-  require("Storage").writeJSON("fastload.cache", cache);
+  s.writeJSON("fastload.cache", cache);
   return cache[n].fast;
-}
+};
 
 global._load = load;
 
 let slowload = function(n){
   global._load(n);
-}
+};
 
 let fastload = function(n){
   if (!n || checkApp(n)){
@@ -50,17 +51,40 @@ let fastload = function(n){
 };
 global.load = fastload;
 
+let appHistory, resetHistory, recordHistory;
+if (SETTINGS.useAppHistory){
+  appHistory  = s.readJSON("fastload.history.json",true)||[];
+  resetHistory = ()=>{appHistory=[];s.writeJSON("fastload.history.json",appHistory);};
+  recordHistory = ()=>{s.writeJSON("fastload.history.json",appHistory);};
+}
+
 Bangle.load = (o => (name) => {
   if (Bangle.uiRemove && !SETTINGS.hideLoading) loadingScreen();
+  if (SETTINGS.useAppHistory){
+    if (name && name!=".bootcde" && !(name=="quicklaunch.app.js" && SETTINGS.disregardQuicklaunch)) {
+      // store the name of the app to launch
+      appHistory.push(name);
+    } else if (name==".bootcde") { // when Bangle.showClock is called
+      resetHistory();
+    } else if (name=="quicklaunch.app.js" && SETTINGS.disregardQuicklaunch) {
+      // do nothing with history
+    } else {
+      // go back in history
+      appHistory.pop();
+      name = appHistory[appHistory.length-1];
+    }
+  }
   if (SETTINGS.autoloadLauncher && !name){
     let orig = Bangle.load;
     Bangle.load = (n)=>{
       Bangle.load = orig;
       fastload(n);
-    }
+    };
     Bangle.showLauncher();
     Bangle.load = orig;
-  } else 
+  } else
     o(name);
 })(Bangle.load);
+
+if (SETTINGS.useAppHistory) E.on('kill', ()=>{if (!BTN.read()) recordHistory(); else resetHistory();}); // Usually record history, but reset it if long press of HW button was used.
 }

--- a/apps/fastload/metadata.json
+++ b/apps/fastload/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastload",
   "name": "Fastload Utils",
   "shortName" : "Fastload Utils",
-  "version": "0.03",
+  "version": "0.04",
   "icon": "icon.png",
   "description": "Enable experimental fastloading for more apps",
   "type":"bootloader",

--- a/apps/fastload/settings.js
+++ b/apps/fastload/settings.js
@@ -1,7 +1,8 @@
 (function(back) {
   var FILE="fastload.json";
   var settings;
-  
+  var isQuicklaunchPresent = !!require('Storage').read("quicklaunch.app.js", 0, 1);
+
   function writeSettings(key, value) {
     var s = require('Storage').readJSON(FILE, true) || {};
     s[key] = value;
@@ -12,25 +13,52 @@
   function readSettings(){
     settings = require('Storage').readJSON(FILE, true) || {};
   }
-  
+
   readSettings();
 
   function buildMainMenu(){
-    var mainmenu = {
-      '': { 'title': 'Fastload', back: back },
-      'Force load to launcher': {
+    var mainmenu = {};
+
+    mainmenu[''] = { 'title': 'Fastload', back: back };
+
+    mainmenu['Activate app history'] = {
+        value: !!settings.useAppHistory,
+        onchange: v => {
+          writeSettings("useAppHistory",v);
+          if (v && settings.autoloadLauncher) {
+            writeSettings("autoloadLauncher",!v);  // Don't use app history and load to launcher together.
+            setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
+          }
+        }
+      };
+
+    if (isQuicklaunchPresent) {
+      mainmenu['Exclude Quick Launch from history'] = {
+        value: !!settings.disregardQuicklaunch,
+        onchange: v => {
+          writeSettings("disregardQuicklaunch",v);
+        }
+      };
+    }
+
+    mainmenu['Force load to launcher'] = {
         value: !!settings.autoloadLauncher,
         onchange: v => {
           writeSettings("autoloadLauncher",v);
+          if (v && settings.useAppHistory) {
+            writeSettings("useAppHistory",!v);
+            setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
+          } // Don't use app history and load to launcher together.
         }
-      },
-      'Hide "Fastloading..."': {
+      };
+
+    mainmenu['Hide "Fastloading..."'] = {
         value: !!settings.hideLoading,
         onchange: v => {
           writeSettings("hideLoading",v);
         }
-      }
-    };
+      };
+
     return mainmenu;
   }
 


### PR DESCRIPTION
WIP

@halemmerich 

The app history is used to navigate back to previous apps when going back from the current app.

To do before converting PR from draft:
- [x] Run it at home for a while.
- [x] remove widget draws inside timeouts.
- [x] Clean up after testing.
- [x] Clear the app history if the user chosen clock app is loaded? - if `.bootcde` is loaded history is reset.
- [x] fix the situation: 1) Clock face is active, the app history isn't cleared. 2) Message arrives and auto-opens. 3) Message auto-closes. 4) The app to load is pulled from the history, when ideally the clock would be displayed again instead.

Can be loaded here in the meantime: https://thyttan.github.io/BangleApps/?q=fastload

Should this be a separate new app, does the added code contribute too much to loading times? (Not in my experience so far. No timings done)