### PR TITLE
Fix DST's settings.js IIFE

### DIFF
--- a/apps/widdst/settings.js
+++ b/apps/widdst/settings.js
@@ -179,4 +179,4 @@
 
   E.showMenu(dstMenu);
 
-});
+})


### PR DESCRIPTION
When loading DST, it presents an [invalid settings] error.
The trailing `;` prevents the DST settings function from being returned to the settings app. Removing this resolves being unable to view DST settings.

[invalid settings]: https://github.com/espruino/BangleApps/blob/0a2f308d2bda3b1562e008c4f0da37914372a960/apps/setting/settings.js#L818-L820
