### PR TITLE
chargent: show alert when charge peak reached

### DIFF
--- a/apps/chargent/boot.js
+++ b/apps/chargent/boot.js
@@ -27,6 +27,7 @@
             // TODO ? customizable
             Bangle.buzz(500);
             setTimeout(() => Bangle.buzz(500), 1000);
+            E.showAlert("Charge peak reached").then(() => load());
           }
         }, 30*1000);
       }


### PR DESCRIPTION
This causes `chargent` to display an alert when charged.

I will occasionally be away from my desk and hear what I think is my watch buzzing while charging. Sometimes it's other clattering - I'd like for `chargent` to display a little alert (`E.showAlert()`) so I don't have to wait 30 seconds to check. @notEvil, is this something you wouldn't mind me adding in?

Currently chargent is "zero-config" although there is [a comment](https://github.com/espruino/BangleApps/blob/master/apps/chargent/boot.js#L27-L29) about making the buzz customisable. I feel adding an option just for showing the alert might not be worth it, but equally don't want to jar people's use-cases.