### PR TITLE
Improvements to the stopwatch clockinfo

### DIFF
--- a/apps/btadv/app.js
+++ b/apps/btadv/app.js
@@ -1,4 +1,3 @@
-"use strict";
 var __assign = Object.assign;
 var Layout = require("Layout");
 Bangle.loadWidgets();

--- a/apps/clkinfostopw/ChangeLog
+++ b/apps/clkinfostopw/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New clkinfo!
+0.02: changed format to h:mm:ss, to reduce size of text string

--- a/apps/clkinfostopw/ChangeLog
+++ b/apps/clkinfostopw/ChangeLog
@@ -1,2 +1,2 @@
 0.01: New clkinfo!
-0.02: changed format to h:mm:ss, to reduce size of text string
+0.02: Added format option, reduced battery usage

--- a/apps/clkinfostopw/clkinfo.js
+++ b/apps/clkinfostopw/clkinfo.js
@@ -21,10 +21,10 @@
         var mins = seconds / 60;
         seconds %= 60;
         if (mins < 60)
-            return "".concat(pad2(mins), "m").concat(pad2(seconds), "s");
+            return "".concat(mins.toFixed(0)+":").concat(pad2(seconds));
         var hours = mins / 60;
         mins %= 60;
-        return "".concat(Math.round(hours), "h").concat(pad2(mins), "m").concat(pad2(seconds), "s");
+        return "".concat(hours.toFixed(0)+":").concat(pad2(mins)).concat(pad2(seconds));
     };
     var img = function () { return atob("GBiBAAAAAAB+AAB+AAAAAAB+AAH/sAOB8AcA4A4YcAwYMBgYGBgYGBg8GBg8GBgYGBgAGAwAMA4AcAcA4AOBwAH/gAB+AAAAAAAAAA=="); };
     return {

--- a/apps/clkinfostopw/clkinfo.js
+++ b/apps/clkinfostopw/clkinfo.js
@@ -3,6 +3,7 @@
     var durationOnPause = "---";
     var redrawInterval;
     var startTime;
+    var _a = (require("Storage").readJSON("clkinfostopw.setting.json", true) || {}).format, format = _a === void 0 ? 0 : _a;
     var unqueueRedraw = function () {
         if (redrawInterval)
             clearInterval(redrawInterval);
@@ -11,7 +12,7 @@
     var queueRedraw = function () {
         var _this = this;
         unqueueRedraw();
-        redrawInterval = setInterval(function () { return _this.emit('redraw'); }, 100);
+        redrawInterval = setInterval(function () { return _this.emit('redraw'); }, 1000);
     };
     var pad2 = function (s) { return ('0' + s.toFixed(0)).slice(-2); };
     var duration = function (start) {
@@ -21,10 +22,14 @@
         var mins = seconds / 60;
         seconds %= 60;
         if (mins < 60)
-            return "".concat(mins.toFixed(0)+":").concat(pad2(seconds));
+            return format === 0
+                ? "".concat(pad2(mins), "m").concat(pad2(seconds), "s")
+                : "".concat(mins.toFixed(0), ":").concat(pad2(seconds));
         var hours = mins / 60;
         mins %= 60;
-        return "".concat(hours.toFixed(0)+":").concat(pad2(mins)).concat(pad2(seconds));
+        return format === 0
+            ? "".concat(hours.toFixed(0), "h").concat(pad2(mins), "m").concat(pad2(seconds), "s")
+            : "".concat(hours.toFixed(0), ":").concat(pad2(mins), ":").concat(pad2(seconds));
     };
     var img = function () { return atob("GBiBAAAAAAB+AAB+AAAAAAB+AAH/sAOB8AcA4A4YcAwYMBgYGBgYGBg8GBg8GBgYGBgAGAwAMA4AcAcA4AOBwAH/gAB+AAAAAAAAAA=="); };
     return {
@@ -39,7 +44,14 @@
                         : durationOnPause,
                     img: img(),
                 }); },
-                show: queueRedraw,
+                show: function () {
+                    if (startTime) {
+                        queueRedraw.call(this);
+                    }
+                    else {
+                        this.emit('redraw');
+                    }
+                },
                 hide: unqueueRedraw,
                 run: function () {
                     if (startTime) {

--- a/apps/clkinfostopw/clkinfo.js
+++ b/apps/clkinfostopw/clkinfo.js
@@ -1,4 +1,3 @@
-"use strict";
 (function () {
     var durationOnPause = "---";
     var redrawInterval;

--- a/apps/clkinfostopw/clkinfo.ts
+++ b/apps/clkinfostopw/clkinfo.ts
@@ -53,7 +53,13 @@
             : durationOnPause,
           img: img(),
         }),
-        show: queueRedraw,
+        show: function(this: ClockInfo.MenuItem) {
+          if(startTime){ // only queue if active
+            queueRedraw.call(this);
+          }else{
+            this.emit('redraw')
+          }
+        },
         hide: unqueueRedraw,
         run: function() { // tapped
           if (startTime) {

--- a/apps/clkinfostopw/clkinfo.ts
+++ b/apps/clkinfostopw/clkinfo.ts
@@ -2,6 +2,8 @@
   let durationOnPause = "---";
   let redrawInterval: number | undefined;
   let startTime: number | undefined;
+  let { format = StopWatchFormat.HMS }: StopWatchSettings
+    = require("Storage").readJSON("clkinfostopw.setting.json", true) || {};
 
   const unqueueRedraw = () => {
     if (redrawInterval) clearInterval(redrawInterval);
@@ -25,12 +27,16 @@
     seconds %= 60;
 
     if (mins < 60)
-      return `${pad2(mins)}m${pad2(seconds)}s`;
+      return format === StopWatchFormat.HMS
+        ? `${pad2(mins)}m${pad2(seconds)}s`
+        : `${mins.toFixed(0)}:${pad2(seconds)}`;
 
     let hours = mins / 60;
     mins %= 60;
 
-    return `${Math.round(hours)}h${pad2(mins)}m${pad2(seconds)}s`;
+    return format === StopWatchFormat.HMS
+      ? `${hours.toFixed(0)}h${pad2(mins)}m${pad2(seconds)}s`
+      : `${hours.toFixed(0)}:${pad2(mins)}:${pad2(seconds)}`;
   };
 
   const img = () => atob("GBiBAAAAAAB+AAB+AAAAAAB+AAH/sAOB8AcA4A4YcAwYMBgYGBgYGBg8GBg8GBgYGBgAGAwAMA4AcAcA4AOBwAH/gAB+AAAAAAAAAA==");

--- a/apps/clkinfostopw/clkinfo.ts
+++ b/apps/clkinfostopw/clkinfo.ts
@@ -12,7 +12,7 @@
 
   const queueRedraw = function(this: ClockInfo.MenuItem) {
     unqueueRedraw();
-    redrawInterval = setInterval(() => this.emit('redraw'), 100);
+    redrawInterval = setInterval(() => this.emit('redraw'), 1000);
   };
 
   const pad2 = (s: number) => ('0' + s.toFixed(0)).slice(-2);

--- a/apps/clkinfostopw/metadata.json
+++ b/apps/clkinfostopw/metadata.json
@@ -10,6 +10,7 @@
   "readme":"README.md",
   "allow_emulator": true,
   "storage": [
-    {"name":"stopw.clkinfo.js","url":"clkinfo.js"}
+    {"name":"stopw.clkinfo.js","url":"clkinfo.js"},
+    {"name":"stopw.settings.js","url":"settings.js"}
   ]
 }

--- a/apps/clkinfostopw/metadata.json
+++ b/apps/clkinfostopw/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "clkinfostopw",
   "name": "Stop Watch Clockinfo",
-  "version":"0.01",
+  "version":"0.02",
   "description": "A simple stopwatch, shown via clockinfo",
   "icon": "app.png",
   "type": "clkinfo",

--- a/apps/clkinfostopw/settings.js
+++ b/apps/clkinfostopw/settings.js
@@ -1,4 +1,3 @@
-"use strict";
 (function (back) {
     var _a;
     var SETTINGS_FILE = "clkinfostopw.setting.json";

--- a/apps/clkinfostopw/settings.js
+++ b/apps/clkinfostopw/settings.js
@@ -13,9 +13,11 @@
         "< Back": back,
         "Format": {
             value: settings.format,
-            format: function () { return settings.format == 0 ? "12h34m56s" : "12:34:56"; },
-            onchange: function () {
-                settings.format = (settings.format + 1) % 2;
+            min: 0,
+            max: 1,
+            format: function (v) { return v === 0 ? "12m34s" : "12:34"; },
+            onchange: function (v) {
+                settings.format = v;
                 save();
             },
         },

--- a/apps/clkinfostopw/settings.js
+++ b/apps/clkinfostopw/settings.js
@@ -1,0 +1,23 @@
+"use strict";
+(function (back) {
+    var _a;
+    var SETTINGS_FILE = "clkinfostopw.setting.json";
+    var storage = require("Storage");
+    var settings = storage.readJSON(SETTINGS_FILE, true) || {};
+    (_a = settings.format) !== null && _a !== void 0 ? _a : (settings.format = 0);
+    var save = function () {
+        storage.writeJSON(SETTINGS_FILE, settings);
+    };
+    E.showMenu({
+        "": { "title": "stopwatch" },
+        "< Back": back,
+        "Format": {
+            value: settings.format,
+            format: function () { return settings.format == 0 ? "12h34m56s" : "12:34:56"; },
+            onchange: function () {
+                settings.format = (settings.format + 1) % 2;
+                save();
+            },
+        },
+    });
+});

--- a/apps/clkinfostopw/settings.ts
+++ b/apps/clkinfostopw/settings.ts
@@ -22,9 +22,11 @@ type StopWatchSettings = {
     "< Back": back,
     "Format": {
       value: settings.format,
-      format: () => settings.format == StopWatchFormat.HMS ? "12h34m56s" : "12:34:56",
-      onchange: () => {
-        settings.format = (settings.format + 1) % 2;
+      min: StopWatchFormat.HMS,
+      max: StopWatchFormat.Colon,
+      format: v => v === StopWatchFormat.HMS ? "12m34s" : "12:34",
+      onchange: v => {
+        settings.format = v;
         save();
       },
     },

--- a/apps/clkinfostopw/settings.ts
+++ b/apps/clkinfostopw/settings.ts
@@ -1,0 +1,32 @@
+const enum StopWatchFormat {
+  HMS,
+  Colon,
+}
+type StopWatchSettings = {
+  format: StopWatchFormat,
+};
+
+((back: () => void) => {
+  const SETTINGS_FILE = "clkinfostopw.setting.json";
+
+  const storage = require("Storage");
+  const settings: StopWatchSettings = storage.readJSON(SETTINGS_FILE, true) || {};
+  settings.format ??= StopWatchFormat.HMS;
+
+  const save = () => {
+    storage.writeJSON(SETTINGS_FILE, settings)
+  };
+
+  E.showMenu({
+    "": { "title": "stopwatch" },
+    "< Back": back,
+    "Format": {
+      value: settings.format,
+      format: () => settings.format == StopWatchFormat.HMS ? "12h34m56s" : "12:34:56",
+      onchange: () => {
+        settings.format = (settings.format + 1) % 2;
+        save();
+      },
+    },
+  });
+})

--- a/apps/widChargingStatus/widget.js
+++ b/apps/widChargingStatus/widget.js
@@ -1,4 +1,3 @@
-"use strict";
 (function () {
     var icon = require('heatshrink').decompress(atob('ikggMAiEAgYIBmEAg4EB+EAh0AgPggEeCAIEBnwQBAgP+gEP//x///j//8f//k///H//4BYOP/4lBv4bDvwEB4EAvAEBwEAuA7DCAI7BgAQBhEAA'));
     var iconWidth = 18;

--- a/apps/widbtstates/widget.js
+++ b/apps/widbtstates/widget.js
@@ -1,4 +1,3 @@
-"use strict";
 (function () {
     "ram";
     var _a;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "declaration": false,
     "emitDeclarationOnly": false,
     "removeComments": true,
+    "noImplicitUseStrict": true, // disable "use strict"
 
     "newLine": "lf",
     "noEmitHelpers": true, // we link to specific banglejs implementations
@@ -35,7 +36,14 @@
     "noImplicitOverride": true,
     "exactOptionalPropertyTypes": true,
     "useUnknownInCatchVariables": true,
-    "strict": true,
+    //"strict": true, // can't have this with noImplicitUseStrict, instead:
+    "strictNullChecks": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
 
     // simple type checking
     "noUnusedLocals": true,


### PR DESCRIPTION
Several improvements to the stopwatch clockinfo, inspired by #2692 and #2686:

- Format option added, to reduce space used (see [forum thread on various clocks](https://forum.espruino.com/conversations/384497/))
- Reduced interval to 1s, no point redrawing the same thing 10x per second
- Don't queue the redraw when shown, if we're paused
  - This was a large drain on the battery, shown in the [`powermanager`](https://github.com/espruino/BangleApps/tree/master/apps/powermanager) app (`this.emit(...)`)