### PR TITLE
powermanager: format seconds into days/hours/minutes/seconds

### DIFF
--- a/apps/powermanager/interface.html
+++ b/apps/powermanager/interface.html
@@ -108,7 +108,7 @@ function viewDeferredTable(filename) {
           for (var i in rows) {
             let c = rows[i];
             tableRows += `<tr>
-            <td>${(c.time/1000).toFixed(2)}s</td>
+            <td>${timeFormat(c.time)}</td>
             <td>${(c.time/sum*100).toFixed(2)}%</td>
             <td><pre>${c.func}</pre></td>`
           }
@@ -118,7 +118,7 @@ function viewDeferredTable(filename) {
           var htmlOverview = `<h1>Deferred function calls</h1>
             <button class="btn btn-primary" id="back" style="float: right;margin-right: 5px;margin-left: 10px;">Back</button>
             <div>
-              This are functions used in timeouts and intervals and their accumulated execution times. Recorded in a time span of <b>${Math.round((duration)/1000)}s</b>. Timeouts/intervals have run for <b>${Math.round(sum/1000)}s (${(sum/duration*100).toFixed(2)}%)</b>. Percentages are calculated from summarized timeout/interval running time.
+              This are functions used in timeouts and intervals and their accumulated execution times. Recorded in a time span of <b>${timeFormat(duration)}</b>. Timeouts/intervals have run for <b>${timeFormat(sum)} (${(sum/duration*100).toFixed(2)}%)</b>. Percentages are calculated from summarized timeout/interval running time.
             </div>
             <table class="table table-striped table-hover">
             <thead>
@@ -185,7 +185,7 @@ function viewHardwareTable(filename) {
           for (var i in rows) {
             let c = rows[i];
             tableRows += `<tr>
-            <td>${(c.time/1000).toFixed(2)}s</td>
+            <td>${timeFormat(c.time)}</td>
             <td>${(c.time/duration*100).toFixed(2)}%</td>
             <td>${c.func}</td>`
           }
@@ -194,7 +194,7 @@ function viewHardwareTable(filename) {
           var htmlOverview = `<h1>Hardware power</h1>
             <button class="btn btn-primary" id="back" style="float: right;margin-right: 5px;margin-left: 10px;">Back</button>
             <div>
-              Recorded in a time span of <b>${Math.round(duration/1000)}s</b>. Percentages are calculated from recording time.
+              Recorded in a time span of <b>${timeFormat(duration)}</b>. Percentages are calculated from recording time.
             </div>
             <table class="table table-striped table-hover">
             <thead>
@@ -261,6 +261,27 @@ function viewDetailsTable(filename) {
 
 function onInit() {
   show();
+}
+
+function timeFormat(time) {
+  let secs = time / 1000;
+
+  if (secs < 60)
+    return secs.toFixed(2) + "s";
+
+  let mins = secs / 60;
+  secs %= 60;
+  if (mins < 60)
+    return mins.toFixed(0) + "m" + secs.toFixed(0) + "s";
+
+  let hrs = mins / 60;
+  mins %= 60;
+  if (hrs < 24)
+    return hrs.toFixed(0) + "h" + mins.toFixed(0) + "m" + secs.toFixed(0) + "s";
+
+  let days = hrs / 24;
+  hrs %= 24;
+  return days.toFixed(0) + "d" + hrs.toFixed(0) + "h" + mins.toFixed(0) + "m" + secs.toFixed(0) + "s";
 }
 
     </script>


### PR DESCRIPTION
@halemmerich if you're happy with this, I'd like to add a small tweak to powermanager's `interface.html`, to show the durations in minutes / hours / days.

[Deployed here](https://bobrippling.github.io/BangleApps/?q=powermanager) if you want to check it out.

For example:

<img width="628" alt="pwrmgr-deferred" src="https://user-images.githubusercontent.com/205673/233139029-64ca8028-be06-41b3-b9d0-4b30020bbe08.png">
<img width="618" alt="pwrmgr-hardware" src="https://user-images.githubusercontent.com/205673/233139040-77fa98b2-bf58-44dd-b8f5-4363a17f4a01.png">
