### PR TITLE
Update typescript & remove "use strict"s

### DIFF
--- a/apps/clkinfostopw/clkinfo.ts
+++ b/apps/clkinfostopw/clkinfo.ts
@@ -1,4 +1,4 @@
-((): ClockInfo.Menu => {
+(() => {
   let durationOnPause = "---";
   let redrawInterval: number | undefined;
   let startTime: number | undefined;
@@ -74,4 +74,4 @@
       }
     ]
   };
-})
+}) satisfies ClockInfoFunc

--- a/apps/clkinfostopw/settings.ts
+++ b/apps/clkinfostopw/settings.ts
@@ -6,7 +6,7 @@ type StopWatchSettings = {
   format: StopWatchFormat,
 };
 
-((back: () => void) => {
+(back => {
   const SETTINGS_FILE = "clkinfostopw.setting.json";
 
   const storage = require("Storage");
@@ -31,4 +31,4 @@ type StopWatchSettings = {
       },
     },
   });
-})
+}) satisfies SettingsFunc

--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -1,4 +1,3 @@
-"use strict";
 var app = "drained";
 if (typeof drainedInterval !== "undefined")
     drainedInterval = clearInterval(drainedInterval);

--- a/apps/drained/boot.js
+++ b/apps/drained/boot.js
@@ -1,4 +1,3 @@
-"use strict";
 {
     var _a = require("Storage").readJSON("drained.setting.json", true) || {}, _b = _a.battery, threshold_1 = _b === void 0 ? 5 : _b, _c = _a.interval, interval = _c === void 0 ? 10 : _c, _d = _a.disableBoot, disableBoot_1 = _d === void 0 ? false : _d;
     drainedInterval = setInterval(function () {

--- a/apps/drained/settings.js
+++ b/apps/drained/settings.js
@@ -1,4 +1,3 @@
-"use strict";
 (function (back) {
     var _a, _b, _c, _d;
     var SETTINGS_FILE = "drained.setting.json";

--- a/apps/drained/settings.ts
+++ b/apps/drained/settings.ts
@@ -5,7 +5,7 @@ type DrainedSettings = {
   disableBoot?: ShortBoolean,
 };
 
-((back: () => void) => {
+(back => {
   const SETTINGS_FILE = "drained.setting.json";
 
   const storage = require("Storage")
@@ -64,4 +64,4 @@ type DrainedSettings = {
       },
     },
   });
-})
+}) satisfies SettingsFunc

--- a/typescript/types/funcs.d.ts
+++ b/typescript/types/funcs.d.ts
@@ -1,0 +1,2 @@
+type SettingsFunc = (back: () => void) => void;
+type ClockInfoFunc = () => ClockInfo.Menu;


### PR DESCRIPTION
Including using typescript's [`satisfies` feature](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) to avoid having to manually type settings or clockinfo functions.