### PR TITLE
widmsggrid: Don't turn on LCD

### DIFF
--- a/apps/widmsggrid/ChangeLog
+++ b/apps/widmsggrid/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Adjust to message icons moving to messageicons lib
 0.03: Use new message library
 0.04: Remove library stub
+0.05: Don't turn on LCD

--- a/apps/widmsggrid/metadata.json
+++ b/apps/widmsggrid/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widmsggrid",
   "name": "Messages Grid Widget",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Widget that displays notification icons in a grid",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widmsggrid/widget.js
+++ b/apps/widmsggrid/widget.js
@@ -70,7 +70,6 @@
       w.total = w.srcs.length;
       w.srcs = w.srcs.filter((src, i, uniq) => uniq.indexOf(src) === i); // keep unique entries only
       Bangle.drawWidgets();
-      Bangle.setLCDPower(1); // turns screen on
     }, hide: function () {
       w.hidden = true;
       w.width = 0;


### PR DESCRIPTION
There's really no need for the widget to turn on the screen.

Fixes #2704 