### PR TITLE
Fix `wid_edit`'s `draw()` - pass `WIDGET` as first argument

### DIFF
--- a/apps/wid_edit/ChangeLog
+++ b/apps/wid_edit/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Wrap loadWidgets instead of replacing to keep original functionality intact
       Change back entry to menu option
       Allow changing widgets into all areas, including bottom widget bar
+0.03: Fix editing widgets whose draw method takes the widget

--- a/apps/wid_edit/metadata.json
+++ b/apps/wid_edit/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "wid_edit",
-  "version": "0.02",
+  "version": "0.03",
   "name": "Widget Editor",
   "icon": "icon.png",
   "description": "Customize widget locations",

--- a/apps/wid_edit/settings.js
+++ b/apps/wid_edit/settings.js
@@ -67,7 +67,7 @@
     function highlight() {
       if (WIDGET.width > 0) {
         // draw widget, then draw a highlighted border on top
-        WIDGET.draw();
+        WIDGET.draw(WIDGET);
         g.setColor(g.theme.fgH)
           .drawRect(WIDGET.x, WIDGET.y, WIDGET.x+WIDGET.width-1, WIDGET.y+23);
       } else {

--- a/apps/widalarmeta/ChangeLog
+++ b/apps/widalarmeta/ChangeLog
@@ -10,3 +10,4 @@
       Redraw only every hour when no alarm in next 24h
 0.07: Fix when no alarms are present
 0.08: Selectable font. Allow to disable hour padding.
+0.09: Match draw() API e.g. to allow wid_edit to alter this widget

--- a/apps/widalarmeta/metadata.json
+++ b/apps/widalarmeta/metadata.json
@@ -2,7 +2,7 @@
   "id": "widalarmeta",
   "name": "Alarm & Timer ETA",
   "shortName": "Alarm ETA",
-  "version": "0.08",
+  "version": "0.09",
   "description": "A widget that displays the time to the next Alarm or Timer in hours and minutes, maximum 24h (configurable).",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -25,7 +25,7 @@
     }
   } // getNextAlarm
 
-  function draw(fromInterval) {
+  function draw(_w, fromInterval) {
     if (this.nextAlarm === undefined) {
       let alarm = getNextAlarm();
       if (alarm === undefined) {
@@ -101,8 +101,9 @@
       clearTimeout(this.timeoutId);
     }
     this.timeoutId = setTimeout(()=>{
-      WIDGETS["widalarmeta"].timeoutId = undefined;
-      WIDGETS["widalarmeta"].draw(true);
+      var w = WIDGETS["widalarmeta"];
+      w.timeoutId = undefined;
+      w.draw(w, true);
     }, timeout);
   } /* draw */
 

--- a/apps/widbatpc/ChangeLog
+++ b/apps/widbatpc/ChangeLog
@@ -16,3 +16,4 @@
 0.17: Add option 'Remove Jitter'='Drop only' to prevent percentage from getting up again when not charging
       Add option to disable vibration when charger connects
 0.18: Only redraw when values change
+0.19: Match draw() API e.g. to allow wid_edit to alter this widget

--- a/apps/widbatpc/metadata.json
+++ b/apps/widbatpc/metadata.json
@@ -2,7 +2,7 @@
   "id": "widbatpc",
   "name": "Battery Level Widget (with percentage)",
   "shortName": "Battery Widget",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Show the current battery level and charging status in the top right of the clock, with charge percentage",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widbatpc/widget.js
+++ b/apps/widbatpc/widget.js
@@ -181,7 +181,7 @@
     if (on) update();
   });
 
-  var id = setInterval(()=>WIDGETS["batpc"].draw(true), intervalLow);
+  var id = setInterval(()=>WIDGETS["batpc"].draw(WIDGETS["batpc"], true), intervalLow);
 
   WIDGETS["batpc"]={area:"tr",width:40,draw:draw,reload:reload};
   setWidth();

--- a/apps/widmessages/ChangeLog
+++ b/apps/widmessages/ChangeLog
@@ -3,3 +3,4 @@
       Remove library stub
 0.03: Fix messages not showing if UI auto-open is disabled
 0.04: Now shows message icons again (#2416)
+0.05: Match draw() API e.g. to allow wid_edit to alter this widget

--- a/apps/widmessages/metadata.json
+++ b/apps/widmessages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widmessages",
   "name": "Message Widget",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Widget showing new messages",
   "icon": "app.png",
   "type": "widget",

--- a/apps/widmessages/widget.js
+++ b/apps/widmessages/widget.js
@@ -11,7 +11,7 @@
   // the name still needs to be "messages": the library calls WIDGETS["messages'].hide()/show()
   // see e.g. widmsggrid
   WIDGETS["messages"] = {
-    area: "tl", width: 0, srcs: [], draw: function(recall) {
+    area: "tl", width: 0, srcs: [], draw: function(_w, recall) {
       // If we had a setTimeout queued from the last time we were called, remove it
       if (WIDGETS["messages"].i) {
         clearTimeout(WIDGETS["messages"].i);
@@ -42,7 +42,7 @@
             this.x+12+i*24, this.y+12, {rotate: 0/*force centering*/});
         }
       }
-      WIDGETS["messages"].i = setTimeout(() => WIDGETS["messages"].draw(true), 1000);
+      WIDGETS["messages"].i = setTimeout(() => WIDGETS["messages"].draw(WIDGETS["messages"], true), 1000);
       if (process.env.HWVERSION>1) Bangle.on("touch", this.touch);
     }, onMsg: function(type, msg) {
       if (this.hidden) return;


### PR DESCRIPTION
When attempting to edit a widget whose `draw` function takes the widget as an argument, we get an exception from that `draw` function. This fixes that by catering for both APIs.

The back button widget expects this, as does [`widsleepstatus`], [`widlock`] and [`widlockunlock`].

However, there are other widgets ([`widmessages`], [`widbatpc`] and [`widalarmeta`]) which use something else for the first parameter. So I'm thinking we change the behaviour of the first three (to use `this` instead of an argument, and revert this `wid_edit` change), but we'd also need to change the back widget - but I'm not sure where this comes from.

Before I dig into that, does this sound like a good approach?


[`widsleepstatus`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widsleepstatus/widget.js#L20
[`widlock`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widlock/widget.js#L5
[`widlockunlock`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widlockunlock/widget.js#L27

[`widmessages`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widmessages/widget.js#L14
[`widbatpc`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widbatpc/widget.js#L89
[`widalarmeta`]: https://github.com/espruino/BangleApps/blob/2f6862024d6b92a11fd05a5183a1dd9a53dc5e48/apps/widalarmeta/widget.js#L28
