### PR TITLE
Fix `d888b80ea` - correctly bump ratchet launcher's version

### DIFF
--- a/apps/powermanager/ChangeLog
+++ b/apps/powermanager/ChangeLog
@@ -9,4 +9,4 @@
 0.07: Convert Yes/No On/Off in settings to checkboxes
 0.08: Fix the wrapping of intervals/timeouts with parameters
       Fix the widget drawing if widgets are hidden and Bangle.setLCDBrightness is called
-0.09: Cache the app-launch info
+0.09: Accidental version bump

--- a/apps/ratchet_launch/ChangeLog
+++ b/apps/ratchet_launch/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial release
+0.02: Cache the app-launch info

--- a/apps/ratchet_launch/metadata.json
+++ b/apps/ratchet_launch/metadata.json
@@ -2,7 +2,7 @@
   "id": "ratchet_launch",
   "name": "Ratchet Launcher",
   "shortName": "Ratchet",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Launcher with discrete scrolling for quicker app selection",
   "icon": "app.png",
   "type": "launch",


### PR DESCRIPTION
I had a file open from another branch and accidentally changed its version for #2719, not ratchet launcher's.