### PR TITLE
widhid: avoid clashing with other swipe/drag handlers

### DIFF
--- a/apps/widhid/ChangeLog
+++ b/apps/widhid/ChangeLog
@@ -1,0 +1,3 @@
+0.01: New widget - music control via a swipe
+0.02: Improve interactivity - avoid responding to swipes when a menu or
+      launcher is active.

--- a/apps/widhid/README.md
+++ b/apps/widhid/README.md
@@ -13,6 +13,7 @@ Swipe down to enable - note the icon changes from blue to orange, indicating it'
 
 All other watch interaction is disabled for 3 seconds, to prevent clashing taps/drags - this period is extended as you continue to alter the volume, play/pause and jump between tracks.
 
+Requires espruino firmware > 2v17 to avoid event handler clashes.
 
 # Setup / Technical details
 

--- a/apps/widhid/metadata.json
+++ b/apps/widhid/metadata.json
@@ -2,7 +2,7 @@
   "id": "widhid",
   "name": "Bluetooth Music Swipe Control Widget",
   "shortName": "BLE Swipe Widget",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Based on Swipe Bluetooth Music Controls (based on Bluetooth Music Controls). Swipe down to enable, then swipe up/down for volume, left/right for previous and next and tap for play/pause. Enable HID in settings, pair with your phone/computer, then use this widget to control music from your watch!",
   "icon": "icon.png",
   "readme": "README.md",

--- a/apps/widhid/wid.js
+++ b/apps/widhid/wid.js
@@ -19,8 +19,6 @@
         }
     });
     var onDrag = (function (e) {
-        if (Bangle.CLKINFO_FOCUS)
-            return;
         if (e.b === 0) {
             var wasDragging = dragging;
             dragging = false;

--- a/apps/widhid/wid.js
+++ b/apps/widhid/wid.js
@@ -10,8 +10,22 @@
     var dragging = false;
     var activeTimeout;
     var waitForRelease = true;
+    var menuShown = 0;
+    var origShowMenu = E.showMenu;
+    E.showMenu = (function (menu) {
+        menuShown++;
+        var origSetUI = Bangle.setUI;
+        Bangle.setUI = (function (mode, cb) {
+            menuShown--;
+            Bangle.setUI = origSetUI;
+            return origSetUI(mode, cb);
+        });
+        return origShowMenu(menu);
+    });
     var onSwipe = (function (_lr, ud) {
         if (Bangle.CLKINFO_FOCUS)
+            return;
+        if (menuShown)
             return;
         if (!activeTimeout && ud > 0) {
             listen();

--- a/apps/widhid/wid.ts
+++ b/apps/widhid/wid.ts
@@ -23,8 +23,6 @@
 	}) satisfies SwipeCallback;
 
 	const onDrag = (e => {
-		if((Bangle as BangleExt).CLKINFO_FOCUS) return;
-
 		if(e.b === 0){
 			// released
 			const wasDragging = dragging;


### PR DESCRIPTION
Particularly in menus, the widget's swipe handler would activate, preventing the menu from working. Tested now with a launcher active, on a clock, on a menu and on a few apps.