### PR TITLE
Handle E.kill() not being called when exiting bikespeedo app

### DIFF
--- a/apps/bikespeedo/app.js
+++ b/apps/bikespeedo/app.js
@@ -449,7 +449,12 @@ function onGPS(fix) {
 }
 
 function setButtons(){
-  setWatch(_=>load(), BTN1);
+  setWatch(_=>{
+    if (cfg.recordStopOnExit && WIDGETS["recorder"])
+      WIDGETS["recorder"].setRecording(false);
+
+    load();
+  }, BTN1);
 
 onGPS(lf);
 }


### PR DESCRIPTION
I might've been using `E.kill()` incorrectly - [the existing code](https://github.com/espruino/BangleApps/blob/8a65bc9c7b498e4bf9a918dae9e100a57130ba5d/apps/bikespeedo/app.js#L572-L573) doesn't seem to cancel GPS recording when exiting the app, this lets us catch that case.