### PR TITLE
[Light Switch Widget] handle and intercept swipe event

### DIFF
--- a/apps/lightswitch/ChangeLog
+++ b/apps/lightswitch/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Add masking widget input to other apps (using espruino/Espruino#2151), add a oversize option to increase the touch area.
 0.05: Prevent drawing into app area.
 0.06: Fix issue where .draw was being called by reference (not allowing widgets to be hidden)
+0.07: Handle the swipe event that is generated when draging to change light intensity, so it doesn't trigger some other swipe handler.

--- a/apps/lightswitch/metadata.json
+++ b/apps/lightswitch/metadata.json
@@ -2,7 +2,7 @@
   "id": "lightswitch",
   "name": "Light Switch Widget",
   "shortName": "Light Switch",
-  "version": "0.06",
+  "version": "0.07",
   "description": "A fast way to switch LCD backlight on/off, change the brightness and show the lock status. All in one widget.",
   "icon": "images/app.png",
   "screenshots": [

--- a/apps/lightswitch/widget.js
+++ b/apps/lightswitch/widget.js
@@ -165,13 +165,12 @@
       w.changeValue(value, event.b);
 
       // masks this drag event by messing up the event handler
-      // see https://github.com/espruino/Espruino/issues/2151
-      Bangle.removeListener("drag", w.dragListener);
-      Bangle["#ondrag"] = [w.dragListener].concat(Bangle["#ondrag"]);
+      E.stopEventPropagation&&E.stopEventPropagation();
 
       // on touch release remove drag listener and reset drag status to indicate stopped drag action
       if (!event.b) {
         Bangle.removeListener("drag", w.dragListener);
+        Bangle.removeListener("swipe", w.swipeListener);
         w.dragStatus = "off";
       }
 
@@ -179,6 +178,11 @@
       w = undefined;
       y = undefined;
       value = undefined;
+    },
+
+    swipeListener: function(_,__) {
+      // masks this swipe event by messing up the event handler
+      E.stopEventPropagation&&E.stopEventPropagation();
     },
 
     // listener function //
@@ -197,12 +201,14 @@
           Bangle.buzz(25);
           // check if drag is disabled
           if (w.dragDelay) {
-            // add drag listener at first position
+            // add drag and swipe listeners at respective first position
             Bangle["#ondrag"] = [w.dragListener].concat(Bangle["#ondrag"]);
+            Bangle["#onswipe"] = [w.swipeListener].concat(Bangle["#onswipe"]);
             // set drag timeout
             w.dragStatus = setTimeout((w) => {
-              // remove drag listener
+              // remove drag and swipe listeners
               Bangle.removeListener("drag", w.dragListener);
+              Bangle.removeListener("swipe", w.swipeListener);
               // clear drag timeout
               if (typeof w.dragStatus === "number") clearTimeout(w.dragStatus);
               // reset drag status to indicate stopped drag action


### PR DESCRIPTION
I've tried to use the same kind of logic present for the drag event. 

Don't know if it would be better to do some refactor to use the new `E.stopEventPropagation()` function?

Edit:

And to add, I don't really understand why this works, but from testing it it seems to at least.

Can be tested on my app loader: https://thyttan.github.io/BangleApps/?q=lightswitch