### PR TITLE
[Home Assistant Sensors] inline config, add icons, quotes unification

### DIFF
--- a/apps/hasensors/ChangeLog
+++ b/apps/hasensors/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app!
-0.02: Customize code directly, remove config file
+0.02: Add sensor icons
+      Customize code directly, remove config file

--- a/apps/hasensors/ChangeLog
+++ b/apps/hasensors/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New app!
+0.02: Customize code directly, remove config file

--- a/apps/hasensors/boot.js
+++ b/apps/hasensors/boot.js
@@ -1,5 +1,5 @@
 (function () {
-    const sb = () => require('hasensors').sendBattery();
+    const sb = () => require("hasensors").sendBattery();
     Bangle.on("charging", sb);
     NRF.on("connect", () => setTimeout(sb, 2000));
     setInterval(sb, 10 * 60 * 1000);

--- a/apps/hasensors/custom.html
+++ b/apps/hasensors/custom.html
@@ -39,14 +39,27 @@
         <a href="https://my.home-assistant.io/redirect/profile/" target="_blank">your user profile</a>.</span></label>
 </form>
 <p>
-    <button id="upload" class="btn btn-primary">Upload</button>
+    <button id="upload" class="btn btn-primary" disabled>Upload</button>
 </p>
 <script src="../../core/lib/customize.js"></script>
 <script>
     const STORAGE_KEY = 'hasensors-config';
     const fields = ['id', 'name', 'url', 'token'];
     const form = document.getElementById('sensorform');
+    const LIBRARY_URL = './lib.js';
 
+    // fetch library code template, enable upload button once we've got it
+    let libTpl;
+    fetch(LIBRARY_URL).then(response=>{
+        if (! response.ok) return;
+console.log(response);
+        response.text().then(code=>{
+            libTpl = code;
+            document.getElementById('upload').disabled = false;
+        });
+    });
+
+    // try to pre-fill form with values previously saved in localStorage
     let stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
         try {
@@ -62,7 +75,7 @@
     }
 
     document.getElementById("upload").addEventListener("click", function () {
-        let config = {};
+        // validate form fields or bail out
         for (const field of fields) {
             if (!form[field].validity.valid) {
                 form[field].focus();
@@ -70,18 +83,21 @@
                 return;
             }
         }
+        let config = {};
         for (const field of fields) {
-            config[field] = form[field].value
+            config[field] = form[field].value;
         }
-        console.log('config:', config, JSON.stringify(config));
+        // save config to localStorage for re-use next time
         localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+        // replace {placeholders} in library code template
+        const lib = libTpl.replace(/\{(\w+)\}/g, (_,f) => config[f]);
+        console.log('config:', config, JSON.stringify(config));
         sendCustomizedApp({
             id: "hasensors",
             storage: [
                 {name: "hasensors.boot.js", url: "boot.js"},
-                {name: "hasensors", url: "lib.js"},
-                {name: "hasensors.settings.json", content: JSON.stringify(config)},
-            ]
+                {name: "hasensors", content: lib},
+            ],
         });
     });
 </script>

--- a/apps/hasensors/custom.html
+++ b/apps/hasensors/custom.html
@@ -43,19 +43,19 @@
 </p>
 <script src="../../core/lib/customize.js"></script>
 <script>
-    const STORAGE_KEY = 'hasensors-config';
-    const fields = ['id', 'name', 'url', 'token'];
-    const form = document.getElementById('sensorform');
-    const LIBRARY_URL = './lib.js';
+    const STORAGE_KEY = "hasensors-config";
+    const fields = ["id", "name", "url", "token"];
+    const form = document.getElementById("sensorform");
+    const LIBRARY_URL = "./lib.js";
 
-    // fetch library code template, enable upload button once we've got it
+    // fetch library code template, enable upload button once we"ve got it
     let libTpl;
     fetch(LIBRARY_URL).then(response=>{
         if (! response.ok) return;
 console.log(response);
         response.text().then(code=>{
             libTpl = code;
-            document.getElementById('upload').disabled = false;
+            document.getElementById("upload").disabled = false;
         });
     });
 
@@ -91,7 +91,7 @@ console.log(response);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
         // replace {placeholders} in library code template
         const lib = libTpl.replace(/\{(\w+)\}/g, (_,f) => config[f]);
-        console.log('config:', config, JSON.stringify(config));
+        console.log("config:", config, JSON.stringify(config));
         sendCustomizedApp({
             id: "hasensors",
             storage: [

--- a/apps/hasensors/lib.js
+++ b/apps/hasensors/lib.js
@@ -14,19 +14,30 @@ function post(sensor, data) {
 
 exports.sendBattery = function () {
     if (!NRF.getSecurityStatus().connected) return;
+    const b = E.getBattery(), 
+        c = Bangle.isCharging();
+    let i = "mdi:battery";
+    if (c) i += "-charging";
+
+    post('battery_state', {
+        state: c ? 'charging' : 'discharging',
+        attributes: {
+            friendly_name: "{name} Battery State",
+            icon: i + (c ? "" : "-minus"),
+        }
+    });
+
+    if (b<10) i += "-outline"; // there is no battery-0
+    else if (b<100 || c) i += "-" + Math.floor(b/10)*10; // no battery-100 either
+
     post('battery_level', {
-        state: E.getBattery(),
+        state: b,
         attributes: {
             friendly_name: "{name} Battery Level",
             unit_of_measurement: "%",
             device_class: "battery",
             state_class: "measurement",
-        }
-    });
-    post('battery_state', {
-        state: Bangle.isCharging() ? 'charging' : 'discharging',
-        attributes: {
-            friendly_name: "{name} Battery State",
+            icon: i,
         }
     });
 }

--- a/apps/hasensors/lib.js
+++ b/apps/hasensors/lib.js
@@ -1,16 +1,13 @@
 // split out into a separate file to keep bootcode short.
-function s(key) {
-    return (require('Storage').readJSON('hasensors.settings.js', true) || {})[key];
-}
-
+// placeholders are replaced by custom.html before upload
 function post(sensor, data) {
-    const url = s('url') + '/api/states/sensor.' + s('id') + '_' + sensor;
+    const url = '{url}/api/states/sensor.{id}_' + sensor;
     Bangle.http(url, {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {
             'Content-Type': 'application/json',
-            Authorization: 'Bearer ' + s('token'),
+            Authorization: 'Bearer {token}',
         }
     });
 }
@@ -20,7 +17,7 @@ exports.sendBattery = function () {
     post('battery_level', {
         state: E.getBattery(),
         attributes: {
-            friendly_name: s('name') + " Battery Level",
+            friendly_name: "{name} Battery Level",
             unit_of_measurement: "%",
             device_class: "battery",
             state_class: "measurement",
@@ -29,7 +26,7 @@ exports.sendBattery = function () {
     post('battery_state', {
         state: Bangle.isCharging() ? 'charging' : 'discharging',
         attributes: {
-            friendly_name: s('name') + " Battery State",
+            friendly_name: "{name} Battery State",
         }
     });
 }

--- a/apps/hasensors/lib.js
+++ b/apps/hasensors/lib.js
@@ -1,13 +1,13 @@
 // split out into a separate file to keep bootcode short.
 // placeholders are replaced by custom.html before upload
 function post(sensor, data) {
-    const url = '{url}/api/states/sensor.{id}_' + sensor;
+    const url = "{url}/api/states/sensor.{id}_" + sensor;
     Bangle.http(url, {
-        method: 'POST',
+        method: "POST",
         body: JSON.stringify(data),
         headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer {token}',
+            "Content-Type": "application/json",
+            Authorization: "Bearer {token}",
         }
     });
 }
@@ -19,8 +19,8 @@ exports.sendBattery = function () {
     let i = "mdi:battery";
     if (c) i += "-charging";
 
-    post('battery_state', {
-        state: c ? 'charging' : 'discharging',
+    post("battery_state", {
+        state: c ? "charging" : "discharging",
         attributes: {
             friendly_name: "{name} Battery State",
             icon: i + (c ? "" : "-minus"),
@@ -30,7 +30,7 @@ exports.sendBattery = function () {
     if (b<10) i += "-outline"; // there is no battery-0
     else if (b<100 || c) i += "-" + Math.floor(b/10)*10; // no battery-100 either
 
-    post('battery_level', {
+    post("battery_level", {
         state: b,
         attributes: {
             friendly_name: "{name} Battery Level",

--- a/apps/hasensors/metadata.json
+++ b/apps/hasensors/metadata.json
@@ -2,7 +2,7 @@
   "id": "hasensors",
   "name": "Home Assistant Sensors",
   "shortName": "HA sensors",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Send sensor values to Home Assistant using the Android Integration.",
   "icon": "ha.png",
   "type": "bootloader",
@@ -14,8 +14,5 @@
   "storage": [
     {"name":"hasensors","url":"lib.js"},
     {"name":"hasensors.boot.js","url":"boot.js"}
-  ],
-  "data": [
-    {"name":"hasensors.settings.json"}
   ]
 }


### PR DESCRIPTION
* Instead of uploading a separate config file, adjust the code directly during customization.   
* Add icons depending on level+state: Home Assistant already uses a level-dependent icon, but doesn't know the sensors belong together, so doesn't add a charging indicator.
* Cleanup: use double quotes everywhere, instead of randomly mixed `'` and `"`