### PR TITLE
Small stlapview menu fixes

### DIFF
--- a/apps/stlapview/ChangeLog
+++ b/apps/stlapview/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app!
 0.02: Submitted to the app loader
+0.03: Fix going back from a lap view, and add a main-menu back button

--- a/apps/stlapview/app.js
+++ b/apps/stlapview/app.js
@@ -93,11 +93,8 @@ function showMainMenu() {
     }
   };
 
-  //I know eval is evil, but I can't think of any other way to do this.
   for (let lapFile of LAP_FILES) {
-    mainMenu[fileNameToDateString(lapFile)] = eval(`(function() {
-      view('${lapFile}');
-    })`);
+    mainMenu[fileNameToDateString(lapFile)] = () => view(lapFile);
   }
 
   if (LAP_FILES.length == 0) {

--- a/apps/stlapview/app.js
+++ b/apps/stlapview/app.js
@@ -53,7 +53,7 @@ function view(fileName) {
   let lapMenu = {
     '': {
       'title': fileNameToDateString(fileName),
-      'back': () => { E.showMenu(mainMenu); }
+      'back': showMainMenu
     },
   };
   lapMenu[`Total time: ${msToHumanReadable(fileData[fileData.length - 1])}`] = () => { };

--- a/apps/stlapview/app.js
+++ b/apps/stlapview/app.js
@@ -95,7 +95,10 @@ function showMainMenu() {
   };
 
   for (let lapFile of LAP_FILES) {
-    mainMenu[fileNameToDateString(lapFile)] = () => view(lapFile);
+    // `let` variables in JS have special behaviour in loops,
+    // where capturing them captures that instance of the variable,
+    // but for espruino we need to do a slightly older trick:
+    mainMenu[fileNameToDateString(lapFile)] = ((lapFile) => () => view(lapFile))(lapFile);
   }
 
   if (LAP_FILES.length == 0) {

--- a/apps/stlapview/app.js
+++ b/apps/stlapview/app.js
@@ -53,7 +53,7 @@ function view(fileName) {
   let lapMenu = {
     '': {
       'title': fileNameToDateString(fileName),
-      'back': showMainMenu
+      'back': () => showMainMenu()
     },
   };
   lapMenu[`Total time: ${msToHumanReadable(fileData[fileData.length - 1])}`] = () => { };

--- a/apps/stlapview/app.js
+++ b/apps/stlapview/app.js
@@ -89,7 +89,8 @@ function showMainMenu() {
 
   let mainMenu = {
     '': {
-      'title': 'Sessions'
+      'title': 'Sessions',
+      'back': () => load()
     }
   };
 

--- a/apps/stlapview/metadata.json
+++ b/apps/stlapview/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "stlapview",
   "name": "Stopwatch laps",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Optional lap viewer for my stopwatch app",
   "icon": "icon.png",
   "type": "app",


### PR DESCRIPTION
This fixes referencing a variable that's not in scope for `stlapview`, letting the user go back from a lap view.

It also removes the `eval` previously mentioned in a comment, and adds a back button to the main menu - @bruceblore hope these are ok, happy to revert them or change if you'd prefer