### PR TITLE
Fix `widhid`'s HID sending errors and handling of #ondrag

### DIFF
--- a/apps/widhid/ChangeLog
+++ b/apps/widhid/ChangeLog
@@ -1,3 +1,5 @@
 0.01: New widget - music control via a swipe
 0.02: Improve interactivity - avoid responding to swipes when a menu or
       launcher is active.
+0.03: Handle errors when sending input over BLE and the special-case of
+      replacing a single handler

--- a/apps/widhid/metadata.json
+++ b/apps/widhid/metadata.json
@@ -2,7 +2,7 @@
   "id": "widhid",
   "name": "Bluetooth Music Swipe Control Widget",
   "shortName": "BLE Swipe Widget",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Based on Swipe Bluetooth Music Controls (based on Bluetooth Music Controls). Swipe down to enable, then swipe up/down for volume, left/right for previous and next and tap for play/pause. Enable HID in settings, pair with your phone/computer, then use this widget to control music from your watch!",
   "icon": "icon.png",
   "readme": "README.md",

--- a/apps/widhid/wid.js
+++ b/apps/widhid/wid.js
@@ -81,7 +81,10 @@
         if (!wasActive) {
             waitForRelease = true;
             Bangle.on("drag", onDrag);
-            Bangle["#ondrag"] = [onDrag].concat(Bangle["#ondrag"].filter(function (f) { return f !== onDrag; }));
+            var dragHandlers = Bangle["#ondrag"];
+            if (dragHandlers && typeof dragHandlers !== "function") {
+                Bangle["#ondrag"] = [onDrag].concat(dragHandlers.filter(function (f) { return f !== onDrag; }));
+            }
             redraw();
         }
         if (activeTimeout)

--- a/apps/widhid/wid.js
+++ b/apps/widhid/wid.js
@@ -123,7 +123,12 @@
         redraw();
     });
     var sendHid = function (code) {
-        NRF.sendHIDReport([1, code], function () { return NRF.sendHIDReport([1, 0]); });
+        try {
+            NRF.sendHIDReport([1, code], function () { return NRF.sendHIDReport([1, 0]); });
+        }
+        catch (e) {
+            console.log("sendHIDReport:", e);
+        }
     };
     var next = function () { return sendHid(0x01); };
     var prev = function () { return sendHid(0x02); };

--- a/apps/widhid/wid.ts
+++ b/apps/widhid/wid.ts
@@ -23,7 +23,7 @@
 
 	const onDrag = (e => {
 		// Espruino/35c8cb9be11
-		(E as any).stopEventPropagation && (E as any).stopEventPropagation();
+		E.stopEventPropagation && E.stopEventPropagation();
 
 		if(e.b === 0){
 			// released
@@ -84,10 +84,15 @@
 			waitForRelease = true; // wait for first touch up before accepting gestures
 
 			Bangle.on("drag", onDrag);
+
 			// move our drag to the start of the event listener array
-			(Bangle as any)["#ondrag"] = [onDrag].concat(
-				(Bangle as any)["#ondrag"].filter((f: unknown) => f !== onDrag)
-			);
+			const dragHandlers = (Bangle as BangleEvents)["#ondrag"]
+
+			if(dragHandlers && typeof dragHandlers !== "function"){
+				(Bangle as BangleEvents)["#ondrag"] = [onDrag as undefined | typeof onDrag].concat(
+					dragHandlers.filter((f: unknown) => f !== onDrag)
+				);
+			}
 
 			redraw();
 		}

--- a/apps/widhid/wid.ts
+++ b/apps/widhid/wid.ts
@@ -145,10 +145,14 @@
 	//const DEBUG = true;
 	const sendHid = (code: number) => {
 		//if(DEBUG) return;
-		NRF.sendHIDReport(
-			[1, code],
-			() => NRF.sendHIDReport([1, 0]),
-		);
+		try{
+			NRF.sendHIDReport(
+				[1, code],
+				() => NRF.sendHIDReport([1, 0]),
+			);
+		}catch(e){
+			console.log("sendHIDReport:", e);
+		}
 	};
 
 	const next = () => /*DEBUG ? console.log("next") : */ sendHid(0x01);

--- a/typescript/types/bangle_extensions.d.ts
+++ b/typescript/types/bangle_extensions.d.ts
@@ -1,0 +1,10 @@
+type BangleHandler<T extends (...args: any[]) => any> = T | (T | undefined)[];
+
+type BangleEvents = {
+  ["#ontap"]?: BangleHandler<(data: { dir: "left" | "right" | "top" | "bottom" | "front" | "back", double: boolean, x: TapAxis, y: TapAxis, z: TapAxis }) => void>,
+  ["#ongesture"]?: BangleHandler<(xyz: Int8Array) => void>,
+  ["#onswipe"]?: BangleHandler<SwipeCallback>,
+  ["#ontouch"]?: BangleHandler<TouchCallback>,
+  ["#ondrag"]?: BangleHandler<DragCallback>,
+  ["#onstroke"]?: BangleHandler<(event: { xy: Uint8Array, stroke?: string }) => void>,
+};


### PR DESCRIPTION
- `sendHIDReport` sometimes errors if it can't send a HID - we now handle this to stop it bailing out the whole event handler chain.
- We also now handle the special case of `Bangle["#ondrag"]` being a function, catching this error with typings
- This also updates `main.d.ts` from the espruino repo (for `E.stopEventPropagation()`)