### PR TITLE
settings: permit temporarily allowing a BLE connection

### DIFF
--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -363,17 +363,6 @@ function showWhitelistMenu() {
     };
   }
 
-  if (settings.whitelist) settings.whitelist.forEach(function(d){
-    menu[d.substr(0,17)] = function() {
-      E.showPrompt(/*LANG*/'Remove\n'+d).then((v) => {
-        if (v) {
-          settings.whitelist.splice(settings.whitelist.indexOf(d),1);
-          updateSettings();
-        }
-        setTimeout(showWhitelistMenu, 50);
-      });
-    }
-  });
   menu[/*LANG*/'Add Device']=function() {
     E.showAlert(/*LANG*/"Connect device\nto add to\nwhitelist",/*LANG*/"Whitelist").then(function() {
       NRF.removeAllListeners('connect');
@@ -389,6 +378,30 @@ function showWhitelistMenu() {
       showWhitelistMenu();
     });
   };
+
+  menu[/*LANG*/'Temporarily Add Device']=function() {
+    E.showAlert(/*LANG*/"Whitelist disabled\nConnect device",/*LANG*/"Whitelist").then(function() {
+      NRF.removeAllListeners('connect');
+      showWhitelistMenu();
+    });
+    NRF.removeAllListeners('connect'); // this is sufficient to allow any device to connect
+    NRF.on('connect', function(addr) {
+      showWhitelistMenu();
+    });
+  };
+
+  if (settings.whitelist) settings.whitelist.forEach(function(d){
+    menu[d.substr(0,17)] = function() {
+      E.showPrompt(/*LANG*/'Remove\n'+d).then((v) => {
+        if (v) {
+          settings.whitelist.splice(settings.whitelist.indexOf(d),1);
+          updateSettings();
+        }
+        setTimeout(showWhitelistMenu, 50);
+      });
+    }
+  });
+
   E.showMenu(menu);
 }
 


### PR DESCRIPTION
I find my phone (Android) changes its mac address most times I toggle bluetooth, whereas my desktop, laptop and raspberry pi are fine.

[As mentioned on a previous PR](https://github.com/espruino/BangleApps/pull/2607#issuecomment-1446047423), this is a potential issue - I'd like to keep my whitelist but be able to allow one-shot connections (e.g. if I'm doing a [GPS update](https://espruino.github.io/BangleApps/?q=agps) from my phone).

This PR adds a setting menu for bluetooth that temporarily disables the whitelist check on NRF connection, allowing me to connect temporarily, without having to remember to re-enable the whitelist afterwards. Happy to hear other's thoughts on this of course.

---

Seem to have some trouble testing this - I can't upload the JS to my watch:
```
Error: Unreachable point. logically broken. in widget_utils
```