### PR TITLE
Add timers and non-date alarms to sched interface

### DIFF
--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -86,6 +86,16 @@ function eventToAlarm(event, offsetMs) {
 }
 
 function upload() {
+  // kick off all the (active) timers
+  const now = new Date();
+  const currentTime = now.getHours()*3600000
+    + now.getMinutes()*60000
+    + now.getSeconds()*1000;
+
+  for (const alarm of alarms)
+    if (alarm.timer != undefined && alarm.on)
+      alarm.t = currentTime + alarm.timer;
+
   Util.showModal("Saving...");
   Util.writeStorage("sched.json", JSON.stringify(alarms), () => {
     Puck.write(`\x10require("sched").reload();\n`, () => {
@@ -125,9 +135,7 @@ function renderAlarm(alarm, exists) {
       tdType.textContent = "Timer";
       inputTime.onchange = e => {
         alarm.timer = hmsToMs(inputTime.value);
-        const now = new Date();
-        const currentTime = (now.getHours()*3600000)+(now.getMinutes()*60000)+(now.getSeconds()*1000);
-        alarm.t = currentTime + alarm.timer;
+        // alarm.t is set on upload
       };
     } else {
       tdType.textContent = "Alarm";


### PR DESCRIPTION
This lets users add, edit and delete timers and non-date alarms in the sched interface. They can also turn alarms/timers on and off.

It also reloads the watch on upload, to ensure alarms are then queued.

Deployed on [my github branches](https://bobrippling.github.io/BangleApps/?q=sched) if you want to give it a whirl.

To test:
- [X] Adding a new event
- [X] Adding a new alarm
- [X] Adding a new timer
  - Doesn't seem to show up in active alarms, but still sounds. Might appear at midnight - probably need to set `.t`
  - Solved - set `.t` on upload
- [x] Modifying an event
  - doesn't seem to queue, despite `.on === true`
  - seems to appear as enabled (e.g. it's shown by [widalarmeta]) but never fires
  - [fixed - `t.last`](https://github.com/espruino/BangleApps/pull/2782/commits/aa8ecc7e2c4e3fc345ae3b1ba29ca8fabfd03bf0)
- [X] Modifying an alarm
- [X] Modifying a timer
  - [X] slightly offset - clock drift between host & watch

---

- [X] Side/non-blocker bug: new timers show up in [alarms], but not in [multitimer]
  - [Intentional behaviour in multitimer](https://github.com/bobrippling/BangleApps/blob/855f196fd360a002b430523a36a6d7f4c8d2c3bd/apps/multitimer/app.js#L61-L61)

[alarms]: https://github.com/bobrippling/BangleApps/tree/master/apps/alarm
[multitimer]: https://github.com/bobrippling/BangleApps/tree/master/apps/multitimer
[widalarmeta]: https://github.com/espruino/BangleApps/tree/master/apps/widalarmeta