### PR TITLE
notify: improve title bg colour for dark theme

### DIFF
--- a/apps/notify/ChangeLog
+++ b/apps/notify/ChangeLog
@@ -9,3 +9,4 @@
 0.10: Improvements to help notifications work with themes
 0.11: Fix regression that caused no notifications and corrupted background
 0.12: Add Bangle.js 2 support with Bangle.setLCDOverlay
+0.13: Add a default title background for the dark theme

--- a/apps/notify/metadata.json
+++ b/apps/notify/metadata.json
@@ -2,7 +2,7 @@
   "id": "notify",
   "name": "Notifications (default)",
   "shortName": "Notifications",
-  "version": "0.12",
+  "version": "0.13",
   "description": "Provides the default `notify` module used by applications to display notifications on the screen. This module is installed by default by client applications such as the Gadgetbridge app.  Installing `Fullscreen Notifications` replaces this module with a version that displays the notifications using the full screen",
   "icon": "notify.png",
   "type": "notify",

--- a/apps/notify/notify_bjs1.js
+++ b/apps/notify/notify_bjs1.js
@@ -103,7 +103,7 @@ exports.show = function(options) {
   b -= 2;h -= 2;
   // title bar
   if (options.title || options.src) {
-    g.setColor(options.titleBgColor||0x39C7).fillRect(x,y, r,y+20);
+    g.setColor("titleBgColor" in options ? options.titleBgColor : g.theme.dark ? 0x1 : 0x39C7).fillRect(x,y, r,y+20);
     const title = options.title||options.src;
     g.setColor(g.theme.fg).setFontAlign(-1, -1, 0).setFont("6x8", 2);
     g.drawString(title.trim().substring(0, 13), x+25,y+3);

--- a/apps/notify/notify_bjs2.js
+++ b/apps/notify/notify_bjs2.js
@@ -100,7 +100,7 @@ exports.show = function(options) {
   gg.clearRect(x,y, r,b);
   // title bar
   if (options.title || options.src) {
-    gg.setColor(options.titleBgColor||0x39C7).fillRect(x,y, r,y+20);
+    gg.setColor("titleBgColor" in options ? options.titleBgColor : g.theme.dark ? 0x1 : 0x39C7).fillRect(x,y, r,y+20);
     const title = options.title||options.src;
     gg.setColor(g.theme.fg).setFontAlign(-1, -1, 0).setFont("6x8", 2);
     gg.drawString(title.trim().substring(0, 13), x+25,y+3);


### PR DESCRIPTION
This permits `0x0` as a `titleBgColor` for notifications, and sets the notification's default title bg-colour depending on the user's theme.

## More details

Previously, a dark theme would display the below notification on a bangle2:

![image](https://github.com/espruino/BangleApps/assets/205673/ff404cf4-1b4d-4d66-8b18-26216c2e056e)

Which is readable here, but on a real device, looks like this:

![image](https://github.com/espruino/BangleApps/assets/205673/9f734a0b-0f5f-4c6d-9441-be3f8867c1bc)

This tweaks the background colour for the dark theme to almost-black, making the notification easier to read.