### PR TITLE
[bootgatthrm] Added BLE sensor location and tuned HRM service advertisement settings

### DIFF
--- a/apps/bootgatthrm/ChangeLog
+++ b/apps/bootgatthrm/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial release.
+0.02: Added compatibility to OpenTracks and added HRM Location

--- a/apps/bootgatthrm/boot.js
+++ b/apps/bootgatthrm/boot.js
@@ -4,14 +4,30 @@
      * This function prepares BLE heart rate Advertisement.
      */
 
+    NRF.setAdvertising(
+      {
+        0x180d: undefined
+      },
+      {
+        // We need custom Advertisement settings for Apps like OpenTracks
+        connectable: true,
+        discoverable: true,
+        scannable: true,
+        whenConnected: true,
+      }
+    );
+
     NRF.setServices({
       0x180D: { // heart_rate
         0x2A37: { // heart_rate_measurement
           notify: true,
           value: [0x06, 0],
+        },
+        0x2A38: { // Sensor Location: Wrist
+          value: 0x02,
         }
       }
-    }, { advertise: [0x180d] });
+    });
 
   }
   function updateBLEHeartRate(hrm) {
@@ -23,11 +39,11 @@
       NRF.updateServices({
         0x180D: {
           0x2A37: {
-            value: [
-              0x06, //
-              hrm.bpm
-            ],
+            value: [0x06, hrm.bpm],
             notify: true
+          },
+          0x2A38: {
+            value: 0x02,
           }
         }
       });

--- a/apps/bootgatthrm/metadata.json
+++ b/apps/bootgatthrm/metadata.json
@@ -2,7 +2,7 @@
   "id": "bootgatthrm",
   "name": "BLE GATT HRM Service",
   "shortName": "BLE HRM Service",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Adds the GATT HRM Service to advertise the measured HRM over Bluetooth.\n",
   "icon": "bluetooth.png",
   "type": "bootloader",


### PR DESCRIPTION
This pull request includes two key changes to enhance the functionality of the BangleJs HRM device and improve compatibility with the OpenTracks app.

 - added BLE sensor location (0x2a38) with value "wrist":
    In this update, I have added the BLE sensor location characteristic with the value "wrist" (0x2a38). This addition provides important information about the placement of the HRM device on the user's body, specifically on the wrist. This information can be utilized by apps and services to accurately identify and interpret the sensor data from the BangleJs HRM device.

- Tuned HRM service advertisement settings for OpenTracks compatibility:
    To ensure that the BangleJs HRM device is discoverable and recognized by the OpenTracks app, I have made specific adjustments to the HRM service advertisement settings. These changes optimize the advertisement parameters and make them compatible with OpenTracks' scanning mechanisms. With these settings in place, OpenTracks will be able to detect and connect to the BangleJs HRM device seamlessly, enabling users to track their heart rate during physical activities.