### PR TITLE
slopeclockpp: minutes slide in with style (ease-in)

### DIFF
--- a/apps/slopeclockpp/app.js
+++ b/apps/slopeclockpp/app.js
@@ -100,7 +100,7 @@ let animate = function(isIn, callback) {
   minuteX = isAnimIn ? -g2.getWidth() : 0;
   drawMinute();
   animInterval = setInterval(function() {
-    minuteX += 8;
+    minuteX += 8 - 8 * Math.pow((x + minuteX + g2.getWidth() / 2) / R.w, 3);
     let stop = false;
     if (isAnimIn && minuteX>=0) {
       minuteX=0;


### PR DESCRIPTION
This let's the minutes in the slopeclockpp slide in with an ease-in effect, slowing down on arrival. Looks even cooler.