### PR TITLE
Revert "remove workaround fixed by a0e2d92"

### DIFF
--- a/apps/wrkmem/ChangeLog
+++ b/apps/wrkmem/ChangeLog
@@ -1,1 +1,2 @@
 1.00: Implement Working Memory Helper app
+1.01: Fix issue with rendering in 2v18

--- a/apps/wrkmem/metadata.json
+++ b/apps/wrkmem/metadata.json
@@ -2,7 +2,7 @@
   "id"            : "wrkmem",
   "name"          : "Working Memory Helper",
   "shortName"     : "Work Mem",
-  "version"       : "1.00",
+  "version"       : "1.01",
   "description"   : "Externalize your working memory to help stay on task.",
   "dependencies"  : {"textinput": "type"},
   "icon"          : "icon.png",


### PR DESCRIPTION
This reverts commit f947105677ea2bcdece8317bfdbaee6fae0d9a0e. 
I didn't realize this wouldn't be fixed until 2v19 was available, which isn't quite yet! Adding the workaround back in until 2v19 is out.