### PR TITLE
[folderlaunch] Add setting to disable vibration

### DIFF
--- a/apps/folderlaunch/ChangeLog
+++ b/apps/folderlaunch/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app!
 0.02: Handle files potentially not existing
+0.03: Add setting to disable vibration

--- a/apps/folderlaunch/README.md
+++ b/apps/folderlaunch/README.md
@@ -15,6 +15,8 @@ Swiping up and down will scroll. Swiping from the left, using the back button, o
 
 * Show clocks / Show launcher: Whether clock and launcher apps are displayed in the UI to be launched. The default is no.
 
+* Disable vibration: Whether vibration is disabled in the launcher. The default is no.
+
 * Hidden apps: Displays the list of installed apps, enabling them to be manually hidden. (Or unhidden, if hidden from here.) This may be convenient for apps that you have some other shortcut to access, or apps that are only shortcuts to an infrequently used settings menu. By default, no apps are hidden.
 
 * Display:

--- a/apps/folderlaunch/app.js
+++ b/apps/folderlaunch/app.js
@@ -133,12 +133,12 @@
         var entry = grid_1[x][y];
         switch (entry.type) {
             case "app":
-                Bangle.buzz();
+                buzz_1();
                 var infoFile = storage_1.readJSON(entry.id + '.info', false);
                 load(infoFile.src);
                 break;
             case "folder":
-                Bangle.buzz();
+                buzz_1();
                 resetTimeout_1();
                 page_1 = 0;
                 folderPath_1.push(entry.id);
@@ -160,7 +160,7 @@
         else if (ud == 1) {
             resetTimeout_1();
             if (page_1 == 0) {
-                Bangle.buzz(200);
+                buzz_1(200);
                 return;
             }
             else
@@ -169,7 +169,7 @@
         else if (ud == -1) {
             resetTimeout_1();
             if (page_1 == nPages_1 - 1) {
-                Bangle.buzz(200);
+                buzz_1(200);
                 return;
             }
             else
@@ -178,7 +178,7 @@
         render_1();
     };
     var onBackButton_1 = function () {
-        Bangle.buzz();
+        buzz_1();
         if (folderPath_1.length == 0)
             Bangle.showClock();
         else {
@@ -187,6 +187,13 @@
             resetTimeout_1();
             page_1 = 0;
             render_1();
+        }
+    };
+    var buzz_1 = function (length, strength) {
+        if (length === void 0) { length = undefined; }
+        if (strength === void 0) { strength = undefined; }
+        if (!config_1.disableVibration) {
+            Bangle.buzz(length, strength);
         }
     };
     Bangle.loadWidgets();

--- a/apps/folderlaunch/app.js
+++ b/apps/folderlaunch/app.js
@@ -189,13 +189,7 @@
             render_1();
         }
     };
-    var buzz_1 = function (length, strength) {
-        if (length === void 0) { length = undefined; }
-        if (strength === void 0) { strength = undefined; }
-        if (!config_1.disableVibration) {
-            Bangle.buzz(length, strength);
-        }
-    };
+    var buzz_1 = config_1.disableVibration ? function () { } : Bangle.buzz;
     Bangle.loadWidgets();
     Bangle.drawWidgets();
     Bangle.setUI({

--- a/apps/folderlaunch/app.ts
+++ b/apps/folderlaunch/app.ts
@@ -255,12 +255,7 @@
   /**
    * Vibrate the watch if vibration is enabled
    */
-  let buzz = (length: number | undefined = undefined, strength: number | undefined = undefined) => {
-    if (!config.disableVibration) {
-      Bangle.buzz(length, strength);
-    }
-  }
-
+  let buzz = config.disableVibration ? () => {} : Bangle.buzz;
 
   Bangle.loadWidgets();
   Bangle.drawWidgets();

--- a/apps/folderlaunch/app.ts
+++ b/apps/folderlaunch/app.ts
@@ -185,12 +185,12 @@
     let entry: GridEntry = grid[x]![y]!;
     switch (entry.type) {
       case "app":
-        Bangle.buzz();
+        buzz();
         let infoFile = storage.readJSON(entry.id + '.info', false) as AppInfo;
         load(infoFile.src);
         break;
       case "folder":
-        Bangle.buzz();
+        buzz();
         resetTimeout();
         page = 0;
         folderPath.push(entry.id);
@@ -221,13 +221,13 @@
     } else if (ud == 1) {
       resetTimeout();
       if (page == 0) {
-        Bangle.buzz(200);
+        buzz(200);
         return;
       } else page--;
     } else if (ud == -1) {
       resetTimeout();
       if (page == nPages - 1) {
-        Bangle.buzz(200);
+        buzz(200);
         return;
       } else page++;
     }
@@ -240,7 +240,7 @@
    * Go back up a level. If already at the root folder, exit the launcher
    */
   let onBackButton = () => {
-    Bangle.buzz();
+    buzz();
     if (folderPath.length == 0)
       Bangle.showClock();
     else {
@@ -249,6 +249,15 @@
       resetTimeout();
       page = 0;
       render();
+    }
+  }
+
+  /**
+   * Vibrate the watch if vibration is enabled
+   */
+  let buzz = (length: number | undefined = undefined, strength: number | undefined = undefined) => {
+    if (!config.disableVibration) {
+      Bangle.buzz(length, strength);
     }
   }
 

--- a/apps/folderlaunch/configLoad.js
+++ b/apps/folderlaunch/configLoad.js
@@ -3,6 +3,7 @@ var SETTINGS_FILE = "folderlaunch.json";
 var DEFAULT_CONFIG = {
     showClocks: false,
     showLaunchers: false,
+    disableVibration: false,
     hidden: [],
     display: {
         rows: 2,

--- a/apps/folderlaunch/configLoad.ts
+++ b/apps/folderlaunch/configLoad.ts
@@ -5,6 +5,7 @@ const SETTINGS_FILE: string = "folderlaunch.json";
 const DEFAULT_CONFIG: Config = {
     showClocks: false,
     showLaunchers: false,
+    disableVibration: false,
     hidden: [],
     display: {
         rows: 2,

--- a/apps/folderlaunch/metadata.json
+++ b/apps/folderlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "folderlaunch",
     "name": "Folder launcher",
-    "version": "0.02",
+    "version": "0.03",
     "description": "Launcher that allows you to put your apps into folders",
     "icon": "icon.png",
     "type": "launch",

--- a/apps/folderlaunch/settings.js
+++ b/apps/folderlaunch/settings.js
@@ -23,7 +23,6 @@
             var appInfo = storage.readJSON(app_1 + '.info', false);
             menu[appInfo.name] = {
                 value: config.hidden.includes(app_1),
-                format: function (value) { return (value ? 'Yes' : 'No'); },
                 onchange: eval("(value) => { onchange(value, \"".concat(app_1, "\"); }"))
             };
         }
@@ -180,16 +179,14 @@
                 }
             },
             'Show clocks': {
-                value: config.showClocks,
-                format: function (value) { return (value ? 'Yes' : 'No'); },
+                value: !!config.showClocks,
                 onchange: function (value) {
                     config.showClocks = value;
                     changed = true;
                 }
             },
             'Show launchers': {
-                value: config.showLaunchers,
-                format: function (value) { return (value ? 'Yes' : 'No'); },
+                value: !!config.showLaunchers,
                 onchange: function (value) {
                     config.showLaunchers = value;
                     changed = true;
@@ -197,7 +194,6 @@
             },
             'Disable vibration': {
                 value: !!config.disableVibration,
-                format: function (value) { return (value ? 'Yes' : 'No'); },
                 onchange: function (value) {
                     config.disableVibration = value;
                     changed = true;
@@ -220,7 +216,6 @@
                     },
                     'Show icons?': {
                         value: config.display.icon,
-                        format: function (value) { return (value ? 'Yes' : 'No'); },
                         onchange: function (value) {
                             config.display.icon = value;
                             changed = true;

--- a/apps/folderlaunch/settings.js
+++ b/apps/folderlaunch/settings.js
@@ -195,6 +195,14 @@
                     changed = true;
                 }
             },
+            'Disable vibration': {
+                value: !!config.disableVibration,
+                format: function (value) { return (value ? 'Yes' : 'No'); },
+                onchange: function (value) {
+                    config.disableVibration = value;
+                    changed = true;
+                }
+            },
             'Hidden apps': hiddenAppsMenu,
             'Display': function () {
                 E.showMenu({

--- a/apps/folderlaunch/settings.ts
+++ b/apps/folderlaunch/settings.ts
@@ -211,6 +211,14 @@
                     changed = true;
                 }
             },
+            'Disable vibration': {
+                value: !!config.disableVibration,
+                format: (value: boolean) => (value ? 'Yes' : 'No'),
+                onchange: (value: boolean) => {
+                    config.disableVibration = value;
+                    changed = true;
+                }
+            },
             'Hidden apps': hiddenAppsMenu,
             'Display': () => {
                 E.showMenu({

--- a/apps/folderlaunch/settings.ts
+++ b/apps/folderlaunch/settings.ts
@@ -27,7 +27,6 @@
             let appInfo = storage.readJSON(app + '.info', false) as AppInfo;
             menu[appInfo.name] = {
                 value: config.hidden.includes(app),
-                format: (value: boolean) => (value ? 'Yes' : 'No'),
                 onchange: eval(`(value) => { onchange(value, "${app}"); }`)
             }
         }
@@ -196,24 +195,21 @@
                 }
             },
             'Show clocks': {
-                value: config.showClocks,
-                format: value => (value ? 'Yes' : 'No'),
-                onchange: value => {
+                value: !!config.showClocks,
+                onchange: (value: boolean) => {
                     config.showClocks = value;
                     changed = true;
                 }
             },
             'Show launchers': {
-                value: config.showLaunchers,
-                format: value => (value ? 'Yes' : 'No'),
-                onchange: value => {
+                value: !!config.showLaunchers,
+                onchange: (value: boolean) => {
                     config.showLaunchers = value;
                     changed = true;
                 }
             },
             'Disable vibration': {
                 value: !!config.disableVibration,
-                format: (value: boolean) => (value ? 'Yes' : 'No'),
                 onchange: (value: boolean) => {
                     config.disableVibration = value;
                     changed = true;
@@ -236,7 +232,6 @@
                     },
                     'Show icons?': {
                         value: config.display.icon,
-                        format: value => (value ? 'Yes' : 'No'),
                         onchange: value => {
                             config.display.icon = value;
                             changed = true;

--- a/apps/folderlaunch/types.d.ts
+++ b/apps/folderlaunch/types.d.ts
@@ -10,6 +10,7 @@ type FolderList = Array<string>;
 type Config = {
     showClocks: boolean,            // Whether clocks are shown
     showLaunchers: boolean,         // Whether launchers are shown
+    disableVibration: boolean,      // Whether vibration is disabled
     hidden: Array<String>,          // IDs of apps to explicitly hide
     display: {
         rows: number,               // Display an X by X grid of apps


### PR DESCRIPTION
This PR adds a new option in the settings menu of Folder Launcher to disable vibrations in the launcher. Some users (myself included) might find the vibrations annoying so it would be nice to have an option to disable it. 

I wasn't sure whether to open this PR against the official repo or the app's fork so @bruceblore if you would rather have me open this PR against your repo instead I can do that too. 

Thank you!