### PR TITLE
[boxclk] - Update v0.05: Fix step count not resetting

### DIFF
--- a/apps/boxclk/ChangeLog
+++ b/apps/boxclk/ChangeLog
@@ -2,3 +2,4 @@
 0.02: New config options such as step, meridian, short/long formats, custom prefix/suffix
 0.03: Allows showing the month in short or long format by setting `"shortMonth"` to true or false
 0.04: Improves touchscreen drag handling for background apps such as Pattern Launcher
+0.05: Fixes step count not resetting after a new day starts

--- a/apps/boxclk/app.js
+++ b/apps/boxclk/app.js
@@ -249,7 +249,7 @@
         boxes.batt.string = modString(boxes.batt, E.getBattery());
       }
       if (boxes.step) {
-        boxes.step.string = modString(boxes.step, Bangle.getStepCount());
+        boxes.step.string = modString(boxes.step, Bangle.getHealthStatus("day").steps);
       }
       boxKeys.forEach((boxKey) => {
         let boxItem = boxes[boxKey];

--- a/apps/boxclk/metadata.json
+++ b/apps/boxclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boxclk",
   "name": "Box Clock",
-  "version": "0.04",
+  "version": "0.05",
   "description": "A customizable clock with configurable text boxes that can be positioned to show your favorite background",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
Use `Bangle.getHealthStatus("day").steps)` instead of `Bangle.getStepCount())`