### PR TITLE
spotrem: Send GB wake command only once

### DIFF
--- a/apps/spotrem/ChangeLog
+++ b/apps/spotrem/ChangeLog
@@ -7,3 +7,5 @@
 0.07: Remove just the specific listeners to not interfere with Quick Launch
 when fastloading.
 0.08: Issue newline before GB commands (solves issue with console.log and ignored commands)
+0.09: Don't send the gadgetbridge wake command twice. Once should do since we
+	issue newline before GB commands.

--- a/apps/spotrem/app.js
+++ b/apps/spotrem/app.js
@@ -64,7 +64,6 @@ let touchHandler = function(_, xy) {
   } else if ((R.x-1<x && x<R.x+len) && (R.y2-len<y && y<R.y2+1)) {
     //Wake
     gadgetbridgeWake();
-    gadgetbridgeWake();
   } else if ((R.x2-len<x && x<R.x2+1) && (R.y-1<y && y<R.y+len)) {
     //Srch
     Bangle.removeListener("touch", touchHandler);

--- a/apps/spotrem/metadata.json
+++ b/apps/spotrem/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "spotrem",
   "name": "Remote for Spotify",
-  "version": "0.08",
+  "version": "0.09",
   "description": "Control spotify on your android device.",
   "readme": "README.md",
   "type": "app",


### PR DESCRIPTION
...instead of twice like we did before. It should not be needed now we issue a newline before GB commands.