### PR TITLE
chimer: sleep between buzzes, instead of during

### DIFF
--- a/apps/chimer/ChangeLog
+++ b/apps/chimer/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial Creation
 0.02: Fixed some sleep bugs. Added a sleep mode toggle
 0.03: Reduce busy-loop and code
+0.04: Separate buzz-time and sleep-time

--- a/apps/chimer/metadata.json
+++ b/apps/chimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "chimer",
   "name": "Chimer",
-  "version": "0.03",
+  "version": "0.04",
   "description": "A fork of Hour Chime that adds extra features such as: \n - Buzz or beep on every 60, 30 or 15 minutes. \n - Repeat Chime up to 3 times \n - Set hours to disable chime",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/chimer/widget.js
+++ b/apps/chimer/widget.js
@@ -20,15 +20,16 @@
     let count = settings.repeat;
 
     const chime1 = () => {
+      let p;
       if (settings.type === 1) {
-        Bangle.buzz(100);
+        p = Bangle.buzz(100);
       } else if (settings.type === 2) {
-        Bangle.beep();
+        p = Bangle.beep();
       } else {
         return;
       }
       if (--count > 0)
-        setTimeout(chime1, 150);
+        p.then(() => setTimeout(chime1, 150));
     };
 
     chime1();


### PR DESCRIPTION
A small fix to #2799, we now sleep between buzzes instead of kicking off a buzz and instantly sleeping