### PR TITLE
agenda: Fixed "Today" and "Yesterday" wrongly displayed for allDay events on some time zones

### DIFF
--- a/apps/agenda/ChangeLog
+++ b/apps/agenda/ChangeLog
@@ -13,3 +13,4 @@
       Added dynamic, short and range fields to clkinfo
 0.12: Added color field and updating clkinfo periodically (running events)
 0.13: Show day of the week in date
+0.14: Fixed "Today" and "Yesterday" wrongly displayed for allDay events on some time zones

--- a/apps/agenda/agenda.js
+++ b/apps/agenda/agenda.js
@@ -38,13 +38,12 @@ function formatDay(date) {
   if (!settings.useToday) {
     return formattedDate;
   }
-  const dateformatted = date.toISOString().split('T')[0]; // yyyy-mm-dd
-  const today = new Date(Date.now()).toISOString().split('T')[0]; // yyyy-mm-dd
-  if (dateformatted == today) {
+  const today = new Date(Date.now());
+  if (date.getDay() == today.getDay() && date.getMonth() == today.getMonth())
      return /*LANG*/"Today ";
-  } else {
-    const tomorrow = new Date(Date.now() + 86400 * 1000).toISOString().split('T')[0]; // yyyy-mm-dd
-    if (dateformatted == tomorrow) {
+  else {
+    const tomorrow = new Date(Date.now() + 86400 * 1000);
+    if (date.getDay() == tomorrow.getDay() && date.getMonth() == tomorrow.getMonth()) {
        return /*LANG*/"Tomorrow ";
     }
     return formattedDate;

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "agenda",
   "name": "Agenda",
-  "version": "0.13",
+  "version": "0.14",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],


### PR DESCRIPTION
The way we were comparing the date for Today and Yesterday was to compute the ISOstring, extract the date and compare that with today's. Such date is however in UTC and allDay events start at midnight, which makes them belong to the previous day on half of the time zones (the same problem could appear on other events earlier than the time zone's offset).
With this PR we compare day and month, which is safer as it should take into consideration also  time zones.

Fixes: https://github.com/espruino/BangleApps/issues/2856