### PR TITLE
[fastload] Improve code readability + new option

### DIFF
--- a/apps/fastload/ChangeLog
+++ b/apps/fastload/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Allow redirection of loads to the launcher
 0.03: Allow hiding the fastloading info screen
 0.04: (WIP) Allow use of app history when going back (`load()` or `Bangle.load()` calls without specified app).
+0.05: New option 'FastLoad into Widget-less' keep widgets in RAM but hide them.

--- a/apps/fastload/ChangeLog
+++ b/apps/fastload/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Allow hiding the fastloading info screen
 0.04: (WIP) Allow use of app history when going back (`load()` or `Bangle.load()` calls without specified app).
 0.05: New option 'FastLoad into Widget-less' keep widgets in RAM but hide them.
+0.06: Code overhaul increase readability.

--- a/apps/fastload/README.md
+++ b/apps/fastload/README.md
@@ -12,6 +12,7 @@ This allows fast loading of all apps with two conditions:
 * If Quick Launch is installed it can be excluded from app history
 * Allows to redirect all loads usually loading the clock to the launcher instead
 * The "Fastloading..." screen can be switched off
+* FastLoad into Widget-less uses widget_utils to hide widgets but remain in RAM.
 
 ## App history
 
@@ -29,3 +30,4 @@ It checks the app to be loaded for widget use and stores the result of that and 
 
 # Contributors
 [thyttan](https://github.com/thyttan)
+[d3nd3](https://github.com/d3nd3)

--- a/apps/fastload/boot.js
+++ b/apps/fastload/boot.js
@@ -39,12 +39,21 @@ let slowload = function(n){
 };
 
 let fastload = function(n){
-  if (!n || checkApp(n)){
+  let force = SETTINGS.force;
+  let checked = n ? checkApp(n) : true;
+  if (force || !n || checkApp(n)){
     // Bangle.load can call load, to prevent recursion this must be the system load
     global.load = slowload;
+    if (force && n === ".bootcde") n = ""; // hide that we direct call clock.
     Bangle.load(n);
+    //its loaded because above line would had reset mem otherwise.
+    global.__FILE__ = n; // restore
     // if fastloading worked, we need to set load back to this method
     global.load = fastload;
+    if (force) { 
+      if (checked) require("widget_utils").show();
+      else require("widget_utils").hide();
+    }
   }
   else
     slowload(n);

--- a/apps/fastload/metadata.json
+++ b/apps/fastload/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastload",
   "name": "Fastload Utils",
   "shortName" : "Fastload Utils",
-  "version": "0.04",
+  "version": "0.05",
   "icon": "icon.png",
   "description": "Enable experimental fastloading for more apps",
   "type":"bootloader",

--- a/apps/fastload/metadata.json
+++ b/apps/fastload/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastload",
   "name": "Fastload Utils",
   "shortName" : "Fastload Utils",
-  "version": "0.05",
+  "version": "0.06",
   "icon": "icon.png",
   "description": "Enable experimental fastloading for more apps",
   "type":"bootloader",

--- a/apps/fastload/settings.js
+++ b/apps/fastload/settings.js
@@ -61,9 +61,9 @@
     };
     
     mainmenu['FastLoad into Widget-less'] = {
-        value: !!settings.force,
+        value: !!settings.hiddenWidgets,
         onchange: v => {
-          writeSettings("force",v);
+          writeSettings("hiddenWidgets",v);
         }
     };
     return mainmenu;

--- a/apps/fastload/settings.js
+++ b/apps/fastload/settings.js
@@ -30,7 +30,7 @@
             setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
           }
         }
-      };
+    };
 
     if (isQuicklaunchPresent) {
       mainmenu['Exclude Quick Launch from history'] = {
@@ -50,15 +50,22 @@
             setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
           } // Don't use app history and load to launcher together.
         }
-      };
+    };
 
     mainmenu['Hide "Fastloading..."'] = {
         value: !!settings.hideLoading,
         onchange: v => {
           writeSettings("hideLoading",v);
         }
-      };
-
+        
+    };
+    
+    mainmenu['FastLoad into Widget-less'] = {
+        value: !!settings.force,
+        onchange: v => {
+          writeSettings("force",v);
+        }
+    };
     return mainmenu;
   }
 


### PR DESCRIPTION
keep widgets in RAM but hide or show using widget_utils. In case user doesn't care about extra memory used or interference.