### PR TITLE
swiperclocklaunch: check `mode` after pulling from `options`

### DIFF
--- a/apps/swiperclocklaunch/ChangeLog
+++ b/apps/swiperclocklaunch/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Update setUI to work with new Bangle.js 2v13 menu style
 0.04: Update to work with new 'fast switch' clock->launcher functionality
 0.05: Keep track of event listeners we "overwrite", and remove them at the start of setUI
+0.06: Handle apps that call setUI({}) to reset

--- a/apps/swiperclocklaunch/boot.js
+++ b/apps/swiperclocklaunch/boot.js
@@ -8,8 +8,9 @@
     sui(mode,cb);
     oldSwipe = Bangle.swipeHandler;
 
-    if(!mode) return;
     if ("object"==typeof mode) mode = mode.mode;
+    if (!mode) return;
+
     if (mode.startsWith("clock")) {
       // clock -> launcher
       Bangle.swipeHandler = dir => { if (dir<0) Bangle.showLauncher(); };

--- a/apps/swiperclocklaunch/metadata.json
+++ b/apps/swiperclocklaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "swiperclocklaunch",
   "name": "Swiper Clock Launch",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Navigate between clock and launcher with Swipe action",
   "icon": "swiperclocklaunch.png",
   "type": "bootloader",


### PR DESCRIPTION
Fixes #2869 