### PR TITLE
messagesoverlay - Use event based mechanism

### DIFF
--- a/apps/messagesoverlay/ChangeLog
+++ b/apps/messagesoverlay/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial fork from messages_light
 0.02: Fix touch/drag/swipe handlers not being restored correctly if a message is removed
 0.03: Scroll six lines per swipe, leaving the previous top/bottom row visible.
+0.04: Use the event mechanism for getting messages

--- a/apps/messagesoverlay/boot.js
+++ b/apps/messagesoverlay/boot.js
@@ -1,7 +1,1 @@
-//override require to filter require("message")
-global.require_real=global.require;
-global.require = (_require => file => {
-    if (file==="messages") file = "messagesoverlay";
-    return _require(file);
-})(require);
-  
+Bangle.on("message", (type, msg) => require("messagesoverlay").message(type, msg));

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -434,6 +434,7 @@ let ovr;
 exports.message = function(type, event) {
   // only handle some event types
   if(!(type=="text" || type == "call")) return;
+  if(type=="text" && event.id == "nav") return;
   if(event.handled) return;
 
   bpp = 4;

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -1,15 +1,3 @@
-/* MESSAGES is a list of:
-  {id:int,
-    src,
-    title,
-    subject,
-    body,
-    sender,
-    tel:string,
-    new:true // not read yet
-  }
-*/
-
 const ovrx = 10;
 const ovry = 10;
 const ovrw = g.getWidth()-2*ovrx;
@@ -84,18 +72,8 @@ let manageEvent = function(ovr, event) {
 
       if (!callInProgress && eventQueue[0] !== undefined && eventQueue[0].id == event.id)
         next(ovr);
-
-      else {
-        eventQueue.length = 0; // empty existing queue
-        eventQueue.forEach(element => {
-          if (element.id != event.id)
-            neweventQueue.push(element);
-        });
-      }
-
-      break;
-    case "musicstate":
-    case "musicinfo":
+      else 
+        eventQueue = [];
 
       break;
   }
@@ -453,8 +431,10 @@ let main = function(ovr, event) {
 
 let ovr;
 
-exports.pushMessage = function(event) {
-  if( event.id=="music") return require_real("messages").pushMessage(event);
+exports.message = function(type, event) {
+  // only handle some event types
+  if(!(type=="text" || type == "call")) return;
+  if(event.handled) return;
 
   bpp = 4;
   if (process.memory().free < 2000) bpp = 1;
@@ -475,14 +455,6 @@ exports.pushMessage = function(event) {
     ovr.theme = { fg:0, bg:1, fg2:1, bg2:0, fgH:1, bgH:0 };
 
   main(ovr, event);
-
+  event.handled = true;
   g = _g;
 };
-
-
-//Call original message library
-exports.clearAll = function() { return require_real("messages").clearAll();};
-exports.getMessages = function() { return require_real("messages").getMessages();};
-exports.status = function() { return require_real("messages").status();};
-exports.buzz = function() { return require_real("messages").buzz(msgSrc);};
-exports.stopBuzz = function() { return require_real("messages").stopBuzz();};

--- a/apps/messagesoverlay/metadata.json
+++ b/apps/messagesoverlay/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagesoverlay",
   "name": "Messages Overlay",
-  "version": "0.03",
+  "version": "0.04",
   "description": "An overlay based implementation of a messages UI (display notifications from iOS and Gadgetbridge/Android)",
   "icon": "app.png",
   "type": "bootloader",
@@ -11,7 +11,7 @@
   "readme": "README.md",
   "storage": [
     {"name":"messagesoverlay","url":"lib.js"},
-    {"name":"messagesoverlay.boot.js","url":"boot.js"}
+    {"name":"messagesoverlay.0.boot.js","url":"boot.js"}
   ],
   "screenshots": [{"url":"screen_call.png"} ,{"url":"screen_message.png"} ]
 }


### PR DESCRIPTION
This uses the `messages` events instead of overloading the require function to get the messages.