### PR TITLE
multitimer: fix hardmode in new alarms/timers

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Update for time_utils module
 0.03: Use default Bangle formatter for booleans
 0.04: Remove copied sched alarm.js & import newer features (oneshot alarms)
+0.05: Fix creating new alarms/timers in hardmode

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -265,7 +265,6 @@ function editTimer(idx, a) {
       a.last = 0;
       a.data.ot = a.timer;
       a.appid = "multitimer";
-      a.js = "(require('Storage').read('multitimer.alarm.js') !== undefined) ? load('multitimer.alarm.js') : load('sched.js')";
       if (idx < 0) alarms.push(a);
       else alarms[timerIdx[idx]] = a;
       require("sched").setAlarms(alarms);

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
A small bugfix leftover from #2781 - the previous PR changed how hardmode worked, but didn't update how new alarms/timers were created.