### PR TITLE
multitimer: fastload

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Update for time_utils module
 0.03: Use default Bangle formatter for booleans
 0.04: Remove copied sched alarm.js & import newer features (oneshot alarms)
+0.05: Support fastloading

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -67,7 +67,7 @@ function setHM(alarm, on) {
 
 function drawTimers() {
   layer = 0;
-  var timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
+  const timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
 
   function updateTimers(idx) {
     if (!timerInt1[idx]) timerInt1[idx] = setTimeout(function() {
@@ -83,11 +83,10 @@ function drawTimers() {
     back : function() {load();},
     draw : (idx, r) => {
       function drawMenuItem(a) {
-        var msg;
+        let msg = "";
         g.setClipRect(R.x,R.y,R.x2,R.y2);
         if (idx > 0 && timers[idx-1].msg) msg = "\n"+(timers[idx-1].msg.length > 10 ?
           timers[idx-1].msg.substring(0, 10)+"..." : timers[idx-1].msg);
-        else msg = "";
         return g.setColor(g.theme.bg2).fillRect({x:r.x+4,y:r.y+2,w:r.w-8, h:r.h-4, r:5})
         .setColor(g.theme.fg2).setFont("6x8:2").setFontAlign(-1,0).drawString(a+msg,r.x+12,r.y+(r.h/2));
       }
@@ -118,15 +117,17 @@ function drawTimers() {
 
 function timerMenu(idx) {
   layer = -1;
-  var timers = require("sched").getAlarms();
-  var timerIdx = [];
+  const timers = require("sched").getAlarms();
+  const timerIdx = [];
+  let a;
+
   for (let i = 0; i < timers.length; i++) {
     if (timers[i].timer && timers[i].appid == "multitimer") {
       a = i;
       timerIdx.push(a);
     }
   }
-  var a = timers[timerIdx[idx]];
+  a = timers[timerIdx[idx]];
 
   function updateTimer() {
     if (timerInt1[0] == undefined) timerInt1[0] = setTimeout(function() {
@@ -152,7 +153,7 @@ function timerMenu(idx) {
       }
 
       if (i == 0) {
-        var msg = "";
+        let msg = "";
         if (a.msg) msg = "\n"+(a.msg.length > 10 ? a.msg.substring(0, 10)+"..." : a.msg);
         if (a.on == true) {
           drawMenuItem(formatTime(a.t-getCurrentTime())+msg);
@@ -220,9 +221,9 @@ function timerMenu(idx) {
 
 function editTimer(idx, a) {
   layer = -1;
-  var timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
-  var alarms = require("sched").getAlarms();
-  var timerIdx = [];
+  const timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
+  const alarms = require("sched").getAlarms();
+  const timerIdx = [];
   for (let i = 0; i < alarms.length; i++) {
     if (alarms[i].timer && alarms[i].appid == "multitimer") {
       timerIdx.push(i);
@@ -235,10 +236,10 @@ function editTimer(idx, a) {
   if (!a.data) {
     a.data = { hm: false };
   }
-  var t = decodeTime(a.timer);
+  const t = decodeTime(a.timer);
 
   function editMsg(idx, a) {
-    var msg;
+    let msg;
     g.clear();
     idx < 0 ? msg = "" : msg = a.msg;
     require("textinput").input({text:msg}).then(result => {
@@ -257,7 +258,7 @@ function editTimer(idx, a) {
     setUI();
   }
 
-  var menu = {
+  const menu = {
     "": { "title": "Timer" },
     "< Back": () => {
       a.t = getCurrentTime() + a.timer;
@@ -312,7 +313,7 @@ function editTimer(idx, a) {
       value: !a.msg ? "" : a.msg.length > 6 ? a.msg.substring(0, 6)+"..." : a.msg,
       //menu glitch? setTimeout required here
       onchange: () => {
-        var kbapp = require("Storage").read("textinput");
+        const kbapp = require("Storage").read("textinput");
         if (kbapp != undefined) setTimeout(editMsg, 0, idx, a);
         else setTimeout(kbAlert, 0);
       }
@@ -329,7 +330,7 @@ function editTimer(idx, a) {
 
 function drawSw() {
   layer = 1;
-  var sw = require("Storage").readJSON("multitimer.json", true) || [];
+  const sw = require("Storage").readJSON("multitimer.json", true) || [];
 
   function updateTimers(idx) {
     if (!timerInt1[idx]) timerInt1[idx] = setTimeout(function() {
@@ -346,7 +347,7 @@ function drawSw() {
     draw : (idx, r) => {
 
       function drawMenuItem(a) {
-        var msg;
+        let msg;
         g.setClipRect(R.x,R.y,R.x2,R.y2);
         if (idx > 0 && sw[idx-1].msg) msg = "\n"+(sw[idx-1].msg.length > 10 ?
           sw[idx-1].msg.substring(0, 10)+"..." : sw[idx-1].msg);
@@ -380,7 +381,7 @@ function drawSw() {
 
 function swMenu(idx, a) {
   layer = -1;
-  var sw = require("Storage").readJSON("multitimer.json", true) || [];
+  const sw = require("Storage").readJSON("multitimer.json", true) || [];
   if (sw[idx]) a = sw[idx];
   else {
     a = {"t" : 0, "on" : false, "msg" : ""};
@@ -399,7 +400,7 @@ function swMenu(idx, a) {
 
   function editMsg(idx, a) {
     g.clear();
-    var msg = a.msg;
+    const msg = a.msg;
     require("textinput").input({text:msg}).then(result => {
     if (result != "") {
       a.msg = result;
@@ -433,7 +434,7 @@ function swMenu(idx, a) {
       }
 
       if (i == 0) {
-        var msg;
+        let msg;
         if (a.msg) msg = "\n"+(a.msg.length > 10 ? a.msg.substring(0, 10)+"..." : a.msg);
         else msg = "";
         if (a.on == true) {
@@ -486,7 +487,7 @@ function swMenu(idx, a) {
       //edit message
       if (i == 3) {
         clearInt();
-        var kbapp = require("Storage").read("textinput");
+        const kbapp = require("Storage").read("textinput");
         if (kbapp != undefined) editMsg(idx, a);
         else kbAlert();
       }
@@ -503,7 +504,7 @@ function swMenu(idx, a) {
 
 function drawAlarms() {
   layer = 2;
-  var alarms = require("sched").getAlarms().filter(a => !a.timer);
+  const alarms = require("sched").getAlarms().filter(a => !a.timer);
 
   E.showScroller({
     h : 40, c : alarms.length+2,
@@ -512,8 +513,8 @@ function drawAlarms() {
 
       function drawMenuItem(a) {
         g.setClipRect(R.x,R.y,R.x2,R.y2);
-        var on = "";
-        var dow = "";
+        let on = "";
+        let dow = "";
         if (idx > 0 && alarms[idx-1].on == true) on = " - on";
         else if (idx > 0 && alarms[idx-1].on == false) on = " - off";
         if (idx > 0 && idx < alarms.length+1) dow = "\n"+"SMTWTFS".split("").map((d,n)=>alarms[idx-1].dow&(1<<n)?d:".").join("");
@@ -529,7 +530,7 @@ function drawAlarms() {
         .setColor(g.theme.fg).setFont("6x8:2").setFontAlign(0,0).drawString("<   Swipe   >",r.x+(r.w/2),r.y+(r.h/2));
       }
       else if (idx > 0 && idx < alarms.length+1){
-        var str = formatTime(alarms[idx-1].t);
+        const str = formatTime(alarms[idx-1].t);
         drawMenuItem(str.slice(0, -3));
       }
     },
@@ -546,8 +547,8 @@ function editDOW(dow, onchange) {
     '': { 'title': 'Days of Week' },
     '< Back' : () => onchange(dow)
   };
-  for (var i = 0; i < 7; i++) (i => {
-    var dayOfWeek = require("locale").dow({ getDay: () => i });
+  for (let i = 0; i < 7; i++) (i => {
+    const dayOfWeek = require("locale").dow({ getDay: () => i });
     menu[dayOfWeek] = {
       value: !!(dow&(1<<i)),
       onchange: v => v ? dow |= 1<<i : dow &= ~(1<<i),
@@ -559,8 +560,8 @@ function editDOW(dow, onchange) {
 
 function editAlarm(idx, a) {
   layer = -1;
-  var alarms = require("sched").getAlarms();
-  var alarmIdx = [];
+  const alarms = require("sched").getAlarms();
+  const alarmIdx = [];
   for (let i = 0; i < alarms.length; i++) {
     if (!alarms[i].timer) {
       alarmIdx.push(i);
@@ -573,10 +574,10 @@ function editAlarm(idx, a) {
   if (!a.data) {
     a.data = { hm: false };
   }
-  var t = decodeTime(a.t);
+  const t = decodeTime(a.t);
 
   function editMsg(idx, a) {
-    var msg;
+    let msg;
     g.clear();
     idx < 0 ? msg = "" : msg = a.msg;
     require("textinput").input({text:msg}).then(result => {
@@ -595,7 +596,7 @@ function editAlarm(idx, a) {
     setUI();
   }
 
-  var menu = {
+  const menu = {
     "": { "title": "Alarm" },
     "< Back": () => {
       if (idx >= 0) alarms[alarmIdx[idx]] = a;
@@ -650,7 +651,7 @@ function editAlarm(idx, a) {
       value: !a.msg ? "" : a.msg.length > 6 ? a.msg.substring(0, 6)+"..." : a.msg,
       //menu glitch? setTimeout required here
       onchange: () => {
-        var kbapp = require("Storage").read("textinput");
+        const kbapp = require("Storage").read("textinput");
         if (kbapp != undefined) setTimeout(editMsg, 0, idx, a);
         else setTimeout(kbAlert, 0);
       }

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -2,11 +2,11 @@
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
-var R = Bangle.appRect;
-var layer;
-var drag;
-var timerInt1 = [];
-var timerInt2 = [];
+const R = Bangle.appRect;
+let layer;
+let drag;
+let timerInt1 = [];
+let timerInt2 = [];
 
 function getCurrentTime() {
   let time = new Date();

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -68,7 +68,6 @@ function setHM(alarm, on) {
 function drawTimers() {
   layer = 0;
   var timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
-  var alarms = require("sched").getAlarms();
 
   function updateTimers(idx) {
     if (!timerInt1[idx]) timerInt1[idx] = setTimeout(function() {
@@ -79,7 +78,7 @@ function drawTimers() {
     }, 1000 - (timers[idx].t % 1000));
   }
 
-  var s = E.showScroller({
+  E.showScroller({
     h : 40, c : timers.length+2,
     back : function() {load();},
     draw : (idx, r) => {
@@ -120,12 +119,10 @@ function timerMenu(idx) {
   layer = -1;
   var timers = require("sched").getAlarms();
   var timerIdx = [];
-  var j = 0;
   for (let i = 0; i < timers.length; i++) {
     if (timers[i].timer && timers[i].appid == "multitimer") {
       a = i;
       timerIdx.push(a);
-      j++;
     }
   }
   var a = timers[timerIdx[idx]];
@@ -140,7 +137,7 @@ function timerMenu(idx) {
     }, 1000 - (a.t % 1000));
   }
 
-  var s = E.showScroller({
+  E.showScroller({
     h : 40, c : 5,
     back : function() {
       clearInt();
@@ -225,12 +222,9 @@ function editTimer(idx, a) {
   var timers = require("sched").getAlarms().filter(a => a.timer && a.appid == "multitimer");
   var alarms = require("sched").getAlarms();
   var timerIdx = [];
-  var j = 0;
   for (let i = 0; i < alarms.length; i++) {
     if (alarms[i].timer && alarms[i].appid == "multitimer") {
-      b = i;
-      timerIdx.push(b);
-      j++;
+      timerIdx.push(i);
     }
   }
   if (!a) {
@@ -344,7 +338,7 @@ function drawSw() {
     }, 1000 - (sw[idx].t % 1000));
   }
 
-  var s = E.showScroller({
+  E.showScroller({
     h : 40, c : sw.length+2,
     back : function() {load();},
     draw : (idx, r) => {
@@ -421,7 +415,7 @@ function swMenu(idx, a) {
     setUI();
   }
 
-  var s = E.showScroller({
+  E.showScroller({
     h : 40, c : 5,
     back : function() {
       clearInt();
@@ -507,7 +501,7 @@ function drawAlarms() {
   layer = 2;
   var alarms = require("sched").getAlarms().filter(a => !a.timer);
 
-  var s = E.showScroller({
+  E.showScroller({
     h : 40, c : alarms.length+2,
     back : function() {load();},
     draw : (idx, r) => {
@@ -563,12 +557,9 @@ function editAlarm(idx, a) {
   layer = -1;
   var alarms = require("sched").getAlarms();
   var alarmIdx = [];
-  var j = 0;
   for (let i = 0; i < alarms.length; i++) {
     if (!alarms[i].timer) {
-      b = i;
-      alarmIdx.push(b);
-      j++;
+      alarmIdx.push(i);
     }
   }
   if (!a) {

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -1,3 +1,4 @@
+{
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
@@ -112,6 +113,7 @@ function drawTimers() {
       else if (idx > 0 && idx < timers.length+1) timerMenu(idx-1);
     }
   });
+  setUI();
 }
 
 function timerMenu(idx) {
@@ -256,6 +258,7 @@ function editTimer(idx, a) {
     E.showAlert("Must install keyboard app").then(function() {
       editTimer(idx, a);
     });
+    setUI();
   }
 
   var menu = {
@@ -325,6 +328,7 @@ function editTimer(idx, a) {
   };
 
   E.showMenu(menu);
+  setUI();
 }
 
 function drawSw() {
@@ -414,6 +418,7 @@ function swMenu(idx, a) {
     E.showAlert("Must install keyboard app").then(function() {
       swMenu(idx, a);
     });
+    setUI();
   }
 
   var s = E.showScroller({
@@ -551,6 +556,7 @@ function editDOW(dow, onchange) {
     };
   })(i);
   E.showMenu(menu);
+  setUI();
 }
 
 function editAlarm(idx, a) {
@@ -590,6 +596,7 @@ function editAlarm(idx, a) {
     E.showAlert("Must install keyboard app").then(function() {
       editAlarm(idx, a);
     });
+    setUI();
   }
 
   var menu = {
@@ -663,11 +670,20 @@ function editAlarm(idx, a) {
   };
 
   E.showMenu(menu);
+  setUI();
 }
 
-drawTimers();
+function setUI() {
+  // E.showMenu/E.showScroller/E.showAlert call setUI, so we register onDrag() separately
+  // and tack on uiRemove after the fact to avoid interfering
+  Bangle.uiRemove = () => {
+    Bangle.removeListener("drag", onDrag);
+    Object.values(timerInt1).forEach(clearTimeout);
+    Object.values(timerInt2).forEach(clearTimeout);
+  };
+}
 
-Bangle.on("drag", e=>{
+function onDrag(e) {
   if (layer < 0) return;
   if (!drag) { // start dragging
     drag = {x: e.x, y: e.y};
@@ -688,4 +704,9 @@ Bangle.on("drag", e=>{
       else if (layer == 2) drawAlarms();
     }
   }
-});
+}
+
+drawTimers();
+
+Bangle.on("drag", onDrag);
+}

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -83,6 +83,7 @@ function drawTimers() {
     back : function() {load();},
     draw : (idx, r) => {
       function drawMenuItem(a) {
+        var msg;
         g.setClipRect(R.x,R.y,R.x2,R.y2);
         if (idx > 0 && timers[idx-1].msg) msg = "\n"+(timers[idx-1].msg.length > 10 ?
           timers[idx-1].msg.substring(0, 10)+"..." : timers[idx-1].msg);
@@ -126,7 +127,6 @@ function timerMenu(idx) {
     }
   }
   var a = timers[timerIdx[idx]];
-  var msg = "";
 
   function updateTimer() {
     if (timerInt1[0] == undefined) timerInt1[0] = setTimeout(function() {
@@ -152,6 +152,7 @@ function timerMenu(idx) {
       }
 
       if (i == 0) {
+        var msg = "";
         if (a.msg) msg = "\n"+(a.msg.length > 10 ? a.msg.substring(0, 10)+"..." : a.msg);
         if (a.on == true) {
           drawMenuItem(formatTime(a.t-getCurrentTime())+msg);
@@ -237,6 +238,7 @@ function editTimer(idx, a) {
   var t = decodeTime(a.timer);
 
   function editMsg(idx, a) {
+    var msg;
     g.clear();
     idx < 0 ? msg = "" : msg = a.msg;
     require("textinput").input({text:msg}).then(result => {
@@ -344,6 +346,7 @@ function drawSw() {
     draw : (idx, r) => {
 
       function drawMenuItem(a) {
+        var msg;
         g.setClipRect(R.x,R.y,R.x2,R.y2);
         if (idx > 0 && sw[idx-1].msg) msg = "\n"+(sw[idx-1].msg.length > 10 ?
           sw[idx-1].msg.substring(0, 10)+"..." : sw[idx-1].msg);
@@ -396,7 +399,7 @@ function swMenu(idx, a) {
 
   function editMsg(idx, a) {
     g.clear();
-    msg = a.msg;
+    var msg = a.msg;
     require("textinput").input({text:msg}).then(result => {
     if (result != "") {
       a.msg = result;
@@ -430,6 +433,7 @@ function swMenu(idx, a) {
       }
 
       if (i == 0) {
+        var msg;
         if (a.msg) msg = "\n"+(a.msg.length > 10 ? a.msg.substring(0, 10)+"..." : a.msg);
         else msg = "";
         if (a.on == true) {
@@ -572,6 +576,7 @@ function editAlarm(idx, a) {
   var t = decodeTime(a.t);
 
   function editMsg(idx, a) {
+    var msg;
     g.clear();
     idx < 0 ? msg = "" : msg = a.msg;
     require("textinput").input({text:msg}).then(result => {

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
I find I regularly want to set timers/alarms, and this speeds up that interaction.

There is a 1-byte memory leak however - have we seen this kind of pattern before?

```javascript
>Bangle.loadWidgets()
=undefined
>Bangle.drawWidgets()
=undefined
>process.memory().usage
=3540                       // base

>eval(require("Storage").read("multitimer.app.js"))
=undefined
>process.memory().usage
=4023                       // initial app load

>Bangle.setUI()
=undefined
>process.memory().usage
=3800                       // app loads modules, memory remains bumped

>eval(require("Storage").read("multitimer.app.js"))
=undefined
>process.memory().usage
=4024                       // second app load - 1 byte more in use
>Bangle.setUI()
=undefined
>process.memory().usage
=3801                       // app removal - memory leak of 1 byte
```