### PR TITLE
Implement API for activity fetching

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -30,3 +30,4 @@
 0.29: Support for http request xpath return format
 0.30: Send firmware and hardware versions on connection
       Allow alarm enable/disable
+0.31: Implement API for activity fetching

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.30",
+  "version": "0.31",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",

--- a/apps/gbridge/PROTOCOL.md
+++ b/apps/gbridge/PROTOCOL.md
@@ -59,6 +59,26 @@ Send a response to a notification from phone
 * n can be one of "dismiss", "dismiss all", "open", "mute", "reply"
 * id, tel and message are optional
 
+## activity data
+
+```json
+{
+  "t": "act",
+  "ts": 1692226800000,
+  "stp": 26,
+  "hrm": 70,
+  "mov": 10,
+  "rt": 1
+}
+```
+
+* `ts` is the sample timestamp, in milliseconds since the unix epoch
+* `stp` is the number of steps
+* `hrm` is heart rate, in bpm
+* `mov` is the movement intensity (todo: range?)
+* `rt` whether it is a real-time sample
+
+
 # Phone -> Watch
 
 ## show notification
@@ -177,3 +197,14 @@ n is the intensity
 * hum is the humidity
 * txt is the weather condition
 * loc is the location
+
+## fetch activity data
+
+```json
+{
+  "t": "actfetch",
+  "ts": 1692226800000
+}
+```
+
+* `ts` is the start timestamp, in milliseconds since the unix epoch

--- a/apps/gbridge/widget.js
+++ b/apps/gbridge/widget.js
@@ -263,7 +263,7 @@
   function sendActivity(hrm) {
     var steps = currentSteps - lastSentSteps;
     lastSentSteps = currentSteps;
-    gbSend({ t: "act", stp: steps, hrm:hrm });
+    gbSend({ t: "act", stp: steps, hrm:hrm, rt:1 });
   }
 
   // Battery monitor

--- a/apps/health/ChangeLog
+++ b/apps/health/ChangeLog
@@ -26,3 +26,4 @@
 0.25: lib.read* methods now return correctly scaled movement
       movement graph in app is now an average, not sum
       fix 11pm slot for daily HRM
+0.26: Implement API for activity fetching

--- a/apps/health/metadata.json
+++ b/apps/health/metadata.json
@@ -2,7 +2,7 @@
   "id": "health",
   "name": "Health Tracking",
   "shortName": "Health",
-  "version": "0.25",
+  "version": "0.26",
   "description": "Logs health data and provides an app to view it",
   "icon": "app.png",
   "tags": "tool,system,health",


### PR DESCRIPTION
Add a simple API for ativify fetching from Gadgetbridge. The API receives the start timestamp, and returns activity up until the current timestamp.

PR on Gadgetbridge: https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3212

Not incredibly happy with the code, but I am trying to avoid iterating through entire months needlessly, since sync might happen periodically.

Still very much a WIP.

Fixes #718