### PR TITLE
fastload - Monitor *.boot.js and setting.json and force real load on …

### DIFF
--- a/apps/fastload/ChangeLog
+++ b/apps/fastload/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Allow redirection of loads to the launcher
 0.03: Allow hiding the fastloading info screen
 0.04: (WIP) Allow use of app history when going back (`load()` or `Bangle.load()` calls without specified app).
+0.05: Allow forcing full reload on changes of setting.json or *.boot.js files

--- a/apps/fastload/README.md
+++ b/apps/fastload/README.md
@@ -12,6 +12,7 @@ This allows fast loading of all apps with two conditions:
 * If Quick Launch is installed it can be excluded from app history
 * Allows to redirect all loads usually loading the clock to the launcher instead
 * The "Fastloading..." screen can be switched off
+* Enable monitoring for writes to `*.boot.js` and `setting.json` and force a complete load on writes to these files
 
 ## App history
 

--- a/apps/fastload/metadata.json
+++ b/apps/fastload/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastload",
   "name": "Fastload Utils",
   "shortName" : "Fastload Utils",
-  "version": "0.04",
+  "version": "0.05",
   "icon": "icon.png",
   "description": "Enable experimental fastloading for more apps",
   "type":"bootloader",

--- a/apps/fastload/settings.js
+++ b/apps/fastload/settings.js
@@ -52,12 +52,19 @@
         }
       };
 
-    mainmenu['Hide "Fastloading..."'] = {
-        value: !!settings.hideLoading,
-        onchange: v => {
-          writeSettings("hideLoading",v);
-        }
-      };
+      mainmenu['Hide "Fastloading..."'] = {
+          value: !!settings.hideLoading,
+          onchange: v => {
+            writeSettings("hideLoading",v);
+          }
+        };
+
+        mainmenu['Detect settings changes'] = {
+            value: !!settings.detectSettingsChange,
+            onchange: v => {
+              writeSettings("detectSettingsChange",v);
+            }
+          };
 
     return mainmenu;
   }

--- a/apps/fastload/settings.js
+++ b/apps/fastload/settings.js
@@ -42,29 +42,29 @@
     }
 
     mainmenu['Force load to launcher'] = {
-        value: !!settings.autoloadLauncher,
-        onchange: v => {
-          writeSettings("autoloadLauncher",v);
-          if (v && settings.useAppHistory) {
-            writeSettings("useAppHistory",!v);
-            setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
-          } // Don't use app history and load to launcher together.
-        }
-      };
+      value: !!settings.autoloadLauncher,
+      onchange: v => {
+        writeSettings("autoloadLauncher",v);
+        if (v && settings.useAppHistory) {
+          writeSettings("useAppHistory",!v);
+          setTimeout(()=>E.showMenu(buildMainMenu()), 0); // Update the menu so it can be seen if a value was automatically set to false (app history vs load launcher).
+        } // Don't use app history and load to launcher together.
+      }
+    };
 
-      mainmenu['Hide "Fastloading..."'] = {
-          value: !!settings.hideLoading,
-          onchange: v => {
-            writeSettings("hideLoading",v);
-          }
-        };
+    mainmenu['Hide "Fastloading..."'] = {
+      value: !!settings.hideLoading,
+      onchange: v => {
+        writeSettings("hideLoading",v);
+      }
+    };
 
-        mainmenu['Detect settings changes'] = {
-            value: !!settings.detectSettingsChange,
-            onchange: v => {
-              writeSettings("detectSettingsChange",v);
-            }
-          };
+    mainmenu['Detect settings changes'] = {
+      value: !!settings.detectSettingsChange,
+      onchange: v => {
+        writeSettings("detectSettingsChange",v);
+      }
+    };
 
     return mainmenu;
   }


### PR DESCRIPTION
…change

This allows things like `qmsched` to work correctly. When setting.json or one of the boot files is changed in the background and the app does a reload to apply the change, fastload will usually prevent this until another app was launched and that has triggered a real reload when leaving it. In the case of `qmsched` this means the theme could be applied maybe hours later than planned if the watch only changes between clock and launcher or overlay messages.

The method of monitoring writes is a bit hacky (and dangerous in case of errors, recovery requires deleting `fastboot.5.boot.js`), but I could not find better way to implement this without actually changing the `Storage` implementation.