### PR TITLE
Messagesoverlay - Fix low memory handling when overlay already visible

### DIFF
--- a/apps/messagesoverlay/ChangeLog
+++ b/apps/messagesoverlay/ChangeLog
@@ -3,3 +3,5 @@
 0.03: Scroll six lines per swipe, leaving the previous top/bottom row visible.
 0.04: Use the event mechanism for getting messages
 0.05: Fix the overlay keeping the LCD on
+0.06: Better low memory handling
+      Fix first message beeing displayed again on unlock

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -30,6 +30,7 @@ let callInProgress = false;
 
 let show = function(ovr){
   let img = ovr;
+  LOG("show", img.getBPP());
   if (ovr.getBPP() == 1) {
     img = ovr.asImage();
     img.palette = new Uint16Array([_g.theme.fg,_g.theme.bg]);
@@ -164,8 +165,9 @@ let showMessage = function(ovr, msg) {
   drawMessage(ovr, msg);
 };
 
-let drawBorder = function(ovr) {
+let drawBorder = function(img) {
   LOG("drawBorder", isQuiet());
+  if (img) ovr=img;
   if (Bangle.isLocked())
     ovr.setColor(ovr.theme.fgH);
   else
@@ -402,7 +404,7 @@ let main = function(ovr, event) {
 
   if (!lockListener) {
     lockListener = function (){
-      drawBorder(ovr);
+      drawBorder();
     };
     Bangle.on('lock', lockListener);
   }

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -436,14 +436,15 @@ exports.message = function(type, event) {
   if(event.handled) return;
 
   bpp = 4;
-  if (process.memory().free < LOW_MEM) bpp = 1;
+  if (process.memory().free < LOW_MEM)
+    bpp = 1;
 
   while (process.memory().free < MIN_FREE_MEM && eventQueue.length > 0){
     let dropped = eventQueue.pop();
     print("Dropped message because of memory constraints", dropped);
   }
 
-  if (!ovr || bpp==1) {
+  if (!ovr || ovr.getBPP() != bpp) {
     ovr = Graphics.createArrayBuffer(ovrw, ovrh, bpp, {
       msb: true
     });

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -1,3 +1,5 @@
+const MIN_FREE_MEM = 1000;
+const LOW_MEM = 2000;
 const ovrx = 10;
 const ovry = 10;
 const ovrw = g.getWidth()-2*ovrx;
@@ -432,9 +434,14 @@ exports.message = function(type, event) {
   if(event.handled) return;
 
   bpp = 4;
-  if (process.memory().free < 2000) bpp = 1;
+  if (process.memory().free < LOW_MEM) bpp = 1;
 
-  if (!ovr) {
+  while (process.memory().free < MIN_FREE_MEM && eventQueue.length > 0){
+    let dropped = eventQueue.pop();
+    print("Dropped message because of memory constraints", dropped);
+  }
+
+  if (!ovr || bpp==1) {
     ovr = Graphics.createArrayBuffer(ovrw, ovrh, bpp, {
       msb: true
     });

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -232,13 +232,6 @@ let next = function(ovr) {
   showMessage(ovr, eventQueue[0]);
 };
 
-let showMapMessage = function(ovr, msg) {
-  ovr.clearRect(2,2,ovr.getWidth()-3,ovr.getHeight()-3);
-  drawMessage(ovr, {
-    body: "Not implemented!"
-  });
-};
-
 let callBuzzTimer = null;
 let stopCallBuzz = function() {
   if (callBuzzTimer) {

--- a/apps/messagesoverlay/metadata.json
+++ b/apps/messagesoverlay/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagesoverlay",
   "name": "Messages Overlay",
-  "version": "0.05",
+  "version": "0.06",
   "description": "An overlay based implementation of a messages UI (display notifications from iOS and Gadgetbridge/Android)",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
The lock handler had kept a reference to the first created overlay buffer, which caused the first message to be shown again on unlock (and used memory). Additionally the switch from normal to low memory mode did not work correctly because the buffer was not recreated with 1 bit depth.