### PR TITLE
apploader - Additional option to allow updates regardless of version

### DIFF
--- a/android.html
+++ b/android.html
@@ -172,6 +172,10 @@
               <input type="checkbox" id="settings-minify">
               <i class="form-icon"></i> Minify apps before upload (⚠️DANGER⚠️: Not recommended. Uploads smaller, faster apps but this <b>will</b> break many apps)
             </label>
+            <label class="form-switch">
+              <input type="checkbox" id="settings-alwaysAllowUpdate">
+              <i class="form-icon"></i> Always allow to reinstall apps in place regardless of the version
+            </label>
             <button class="btn" id="defaultsettings">Reset to default App Loader settings</button>
           </details>
         </div>

--- a/index.html
+++ b/index.html
@@ -175,6 +175,10 @@
               <input type="checkbox" id="settings-minify">
               <i class="form-icon"></i> Minify apps before upload (⚠️DANGER⚠️: Not recommended. Uploads smaller, faster apps but this <b>will</b> break many apps)
             </label>
+            <label class="form-switch">
+              <input type="checkbox" id="settings-alwaysAllowUpdate">
+              <i class="form-icon"></i> Always allow to reinstall apps in place regardless of the version
+            </label>
             <button class="btn" id="defaultsettings">Reset to default App Loader settings</button>
           </details>
         </div>


### PR DESCRIPTION
Make apps installable even with the same version number as an advanced option. This is helpful during development where the version is not always updated for every change. Needs https://github.com/espruino/EspruinoAppLoaderCore/pull/51 ;