### PR TITLE
openstmap: Enable Compass if needed

### DIFF
--- a/apps/openstmap/ChangeLog
+++ b/apps/openstmap/ChangeLog
@@ -27,3 +27,4 @@
 0.21: Draw a current position marker (Bangle.js 2 only)
       Enable/Disable previous position marker in new setting "Draw cont. position"
 0.22: Replace position marker with direction arrow
+0.23: Bugfix: Enable Compass if needed

--- a/apps/openstmap/app.js
+++ b/apps/openstmap/app.js
@@ -133,6 +133,7 @@ Bangle.on('GPS',function(f) {
   }
 });
 Bangle.setGPSPower(1, "app");
+Bangle.setCompassPower(settings.dirSrc === 2, "openstmap");
 
 if (HASWIDGETS) {
   Bangle.loadWidgets();
@@ -196,6 +197,7 @@ function showMenu() {
       format: v => [/*LANG*/"None", /*LANG*/"GPS", /*LANG*/"Compass"][v],
       onchange: v => {
         settings.dirSrc = v;
+        Bangle.setCompassPower(settings.dirSrc === 2, "openstmap");
         writeSettings();
       }
     };

--- a/apps/openstmap/metadata.json
+++ b/apps/openstmap/metadata.json
@@ -2,7 +2,7 @@
   "id": "openstmap",
   "name": "OpenStreetMap",
   "shortName": "OpenStMap",
-  "version": "0.22",
+  "version": "0.23",
   "description": "Loads map tiles from OpenStreetMap onto your Bangle.js and displays a map of where you are. Once installed this also adds map functionality to `GPS Recorder` and `Recorder` apps",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
Bugfix: In the last PR I forgot to power the compass. I have a script that powers on the compass in the background which is why I had no issue when testing. Just remembered that.

Sorry for the noise.