### PR TITLE
timerclk: Improve swipe responsiveness on main clock screen

### DIFF
--- a/apps/timerclk/ChangeLog
+++ b/apps/timerclk/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Add sunrise/sunset. Fix timer bugs.
 0.03: Use default Bangle formatter for booleans
 0.04: Use 'modules/suncalc.js' to avoid it being copied 8 times for different apps
+0.05: Improve responsiveness and detection of swipes on main clock screen

--- a/apps/timerclk/app.js
+++ b/apps/timerclk/app.js
@@ -148,23 +148,23 @@ if (process.env.HWVERSION==1) {
   setWatch(()=>load("timerclk.alarm.js"), BTN3);
   setWatch(()=>load("timerclk.alarm.js"), BTN1);
 } else {
-  var absY, lastX, lastY;
+  var absY, lastX=0, lastY=0;
   Bangle.on('drag', e=>{
     if (!e.b) {
-      if (lastX > 50) { // right
+      if (lastX > 5) { // right
         if (absY < dragBorder) { // drag over time
           load("timerclk.timer.js");
         }else { // drag over date/dow
           load("timerclk.alarm.js");
         }
-      } else if (lastX < -50) { // left
+      } else if (lastX < -5) { // left
         if (absY < dragBorder) { // drag over time
           load("timerclk.stopwatch.js");
         }else { // drag over date/dow
           load("timerclk.alarm.js");
         }
-      } else if (lastY > 50) { // down
-      } else if (lastY < -50) { // up
+      } else if (lastY > 5) { // down
+      } else if (lastY < -5) { // up
       }
       lastX = 0;
       lastY = 0;

--- a/apps/timerclk/lib.js
+++ b/apps/timerclk/lib.js
@@ -87,7 +87,7 @@ exports.registerControls = function(o) {
         }
       }
     });
-    var absX, lastX, lastY;
+    var absX, lastX=0, lastY=0;
     Bangle.on('drag', e=>{
       if (!e.b) {
         if (lastX > 40) { // right

--- a/apps/timerclk/metadata.json
+++ b/apps/timerclk/metadata.json
@@ -2,7 +2,7 @@
 	"id": "timerclk",
 	"name": "Timer Clock",
 	"shortName":"Timer Clock",
-	"version":"0.04",
+	"version":"0.05",
 	"description": "A clock with stopwatches, timers and alarms build in.",
 	"icon": "app-icon.png",
 	"type": "clock",


### PR DESCRIPTION
On my Bangle 2 I noticed that the existing Timer Clock app seems to be unusually fickle with registering swipes to switch to the various screens compared to other apps, sometimes requiring me several attempted swipes to get to the desired mode. So I took a look at the code and managed to make a couple of small changes that make it a lot more reliable.

The first change significantly increases the sensitivity (that is, decreases the minimum swipe length) required to activate the switch to timer, stopwatch, or alarm modes. Since the main screen only cares about left vs. right swipes, decreasing the length to just 5 from 50 works well, as the Bangle 2 touchscreen already seems to have a fair bit of hysteresis in movement before registering a drag to begin with.

The other change fixes a coding error where the variables involved in summing up the swipe length were not initialized at the start, resulting in a sum of NaN. As a result, the first swipe upon waking the screen was pretty much guaranteed not to be recognized no matter what. With this change, the first swipe works reliably.

I fixed the similar variable initialization issue for the stopwatch/timer/alarm screens, but I did not tweak the sensitivity for those here because those do both vertical and horizontal swipe detection and I found that allowing too-short swipes makes it more prone to misreading the axis of the intended swipe. Ideally, I think this could improved by reworking the touch code in a different way, but I'm a bit new to this still so I'll leave it at that for now. :)