### PR TITLE
fastload: fix caching

### DIFF
--- a/apps/fastload/ChangeLog
+++ b/apps/fastload/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Allow hiding the fastloading info screen
 0.04: (WIP) Allow use of app history when going back (`load()` or `Bangle.load()` calls without specified app).
 0.05: Check for changes in setting.js and force real reload if needed
+0.06: Fix caching whether an app is fastloadable

--- a/apps/fastload/boot.js
+++ b/apps/fastload/boot.js
@@ -30,12 +30,13 @@ let appFastloadPossible = function(n){
 
   // no widgets, no problem
   if (!global.WIDGETS) return true;
-  let app = s.read(n);
-  if (cache[n] && s.hash(app) == cache[n].hash)
+  let hash = s.hash(n);
+  if (cache[n] && hash == cache[n].hash)
     return cache[n].fast;
+  let app = s.read(n);
   cache[n] = {};
   cache[n].fast = app.includes("Bangle.loadWidgets");
-  cache[n].hash = s.hash(app);
+  cache[n].hash = hash;
   s.writeJSON("fastload.cache", cache);
   return cache[n].fast;
 };

--- a/apps/fastload/metadata.json
+++ b/apps/fastload/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastload",
   "name": "Fastload Utils",
   "shortName" : "Fastload Utils",
-  "version": "0.05",
+  "version": "0.06",
   "icon": "icon.png",
   "description": "Enable experimental fastloading for more apps",
   "type":"bootloader",


### PR DESCRIPTION
broken since e2ba3ca64 (fastload - Replace E.CRC32 with Storage.hash, 2023-07-24)

Storage.hash() expects a regex (or apparently the name as a string) to match files that should be hashed, but was called with the contents of the file