### PR TITLE
multitimer: ensure onDrag is registered after all E.showXYZ calls

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -4,3 +4,5 @@
 0.04: Remove copied sched alarm.js & import newer features (oneshot alarms)
 0.05: Fix creating new alarms/timers in hardmode
 0.06: Support fastloading
+0.07: Fix fastloading support - ensure drag handler's restored after
+      menu display/fastload removes it

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -217,6 +217,7 @@ function timerMenu(idx) {
       }
     }
   });
+  setUI();
 }
 
 function editTimer(idx, a) {
@@ -376,6 +377,7 @@ function drawSw() {
       else if (idx > 0 && idx < sw.length+1) swMenu(idx-1);
     }
   });
+  setUI();
 }
 
 function swMenu(idx, a) {
@@ -499,6 +501,7 @@ function swMenu(idx, a) {
       }
     }
   });
+  setUI();
 }
 
 function drawAlarms() {
@@ -539,6 +542,7 @@ function drawAlarms() {
       else if (idx > 0 && idx < alarms.length+1) editAlarm(idx-1);
     }
   });
+  setUI();
 }
 
 function editDOW(dow, onchange) {
@@ -672,6 +676,7 @@ function editAlarm(idx, a) {
 function setUI() {
   // E.showMenu/E.showScroller/E.showAlert call setUI, so we register onDrag() separately
   // and tack on uiRemove after the fact to avoid interfering
+  Bangle.on("drag", onDrag);
   Bangle.uiRemove = () => {
     Bangle.removeListener("drag", onDrag);
     Object.values(timerInt1).forEach(clearTimeout);
@@ -703,6 +708,4 @@ function onDrag(e) {
 }
 
 drawTimers();
-
-Bangle.on("drag", onDrag);
 }

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
This fixes multitimer's fastload support, from #2879 