### PR TITLE
layout.d.ts: render() takes a RenderedHierarchy (x/y/w/h)

### DIFF
--- a/typescript/types/layout.d.ts
+++ b/typescript/types/layout.d.ts
@@ -120,6 +120,6 @@ declare module Layout_ {
       src: Image | (() => Image),
     } | {
       type: "custom",
-      render: (h: Hierarchy) => void,
+      render: (h: RenderedHierarchy) => void,
     };
 }


### PR DESCRIPTION
A minor tweak to `layout.d.ts` from some local development to permit "real" usage