### PR TITLE
widanclk: add todays date behind clock hands.

### DIFF
--- a/apps/widanclk/ChangeLog
+++ b/apps/widanclk/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app
 0.02: Clear between redraws
+0.03: Add todays date behind the clock hands.

--- a/apps/widanclk/metadata.json
+++ b/apps/widanclk/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "widanclk",
   "name": "Analog clock widget",
-  "version": "0.02",
-  "description": "A simple analog clock widget that appears when not showing a fullscreen clock",
+  "version": "0.03",
+  "description": "A simple analog clock widget that appears when not showing a fullscreen clock. Todays date sits behind the clock hands.",
   "icon": "widget.png",
   "type": "widget",
   "tags": "widget,clock",

--- a/apps/widanclk/widget.js
+++ b/apps/widanclk/widget.js
@@ -9,10 +9,15 @@ WIDGETS["wdanclk"]={area:"tl",width:Bangle.CLOCK?0:24,draw:function() {
   if (!this.width) return; // if size not right, return
   g.reset();
   let d = new Date();
+  let dd = d.getDate();
   let x=this.x+12, y=this.y+12,
       ah = (d.getHours()+d.getMinutes()/60)*Math.PI/6,
       am = d.getMinutes()*Math.PI/30;
   g.clearRect(this.x, this.y, this.x+this.width-1, this.y+23).
+    setFont("Vector:16").
+    setColor(g.theme.bgH).
+    drawString(dd,this.x+4+10*(dd<10),this.y+5,true).
+    setColor(g.theme.fg).
     drawCircle(x, y, 11).
     drawLine(x,y, x+Math.sin(ah)*7, y-Math.cos(ah)*7).
     drawLine(x,y, x+Math.sin(am)*9, y-Math.cos(am)*9);


### PR DESCRIPTION
Currently adds the days date behind the clock hands in the `g.theme.bgH` color.

Should this:
- just be added like this, always on?
- be configurable via settings?
- be a new separate widget?