### PR TITLE
Alarm: Fix date not getting saved when tapping Confirm in event menu

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -44,3 +44,4 @@
 0.39: Dated event repeat option
 0.40: Use substring of message when it's longer than fits the designated menu entry.
 0.41: Fix a menu bug affecting alarms with empty messages.
+0.42: Fix date not getting saved in event edit menu when tapping Confirm

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -190,7 +190,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     },
     /*LANG*/"Cancel": () => showMainMenu(),
     /*LANG*/"Confirm": () => {
-      prepareAlarmForSave(alarm, alarmIndex, time);
+      prepareAlarmForSave(alarm, alarmIndex, time, date);
       saveAndReload();
       showMainMenu();
     }

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.41",
+  "version": "0.42",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
This fixes a bug I discovered in the Alarms app. When editing an event, any changes to the date do not get saved to the alarm if the user taps Confirm on the menu… only when pressing back. This is because the code for saving the alarm when tapping back did not match the code for the Confirm menu button; the latter only saved the time and not the date.

This patch adjusts the two pieces of code to match each other. Probably an even better idea would be to wrap this “save and quit” code into a small function and reference it by name in both the back and Confirm button entries rather than copy/paste the code. This would ensure that both actions in the UI cannot accidentally diverge and cause bugs like this.