### PR TITLE
draguboard: remove arguments from `catchSwipe`

### DIFF
--- a/apps/draguboard/lib.js
+++ b/apps/draguboard/lib.js
@@ -134,7 +134,7 @@ exports.input = function(options) {
     }
   };
 
-  let catchSwipe = (_,__)=>{
+  let catchSwipe = ()=>{
     E.stopEventPropagation&&E.stopEventPropagation();
   };
 


### PR DESCRIPTION
Reference https://github.com/espruino/BangleApps/pull/2934 and https://github.com/espruino/BangleApps/pull/2936.

I don't think it warrants a version bump.