### PR TITLE
chargerot: handle missing settings (e.g. first install)

### DIFF
--- a/apps/chargerot/ChangeLog
+++ b/apps/chargerot/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Handle missing settings (e.g. first-install)

--- a/apps/chargerot/boot.js
+++ b/apps/chargerot/boot.js
@@ -1,5 +1,5 @@
 (() => {
-    const chargingRotation = 0 | require('Storage').readJSON("chargerot.settings.json").rotate;
+    const chargingRotation = 0 | (require('Storage').readJSON("chargerot.settings.json",1)||{}).rotate;
     const defaultRotation = 0 | require('Storage').readJSON("setting.json").rotate;
     if (Bangle.isCharging()) g.setRotation(chargingRotation&3,chargingRotation>>2).clear();
     Bangle.on('charging', (charging) => {

--- a/apps/chargerot/metadata.json
+++ b/apps/chargerot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "chargerot",
   "name": "Charge LCD rotation",
-  "version": "0.01",
+  "version": "0.02",
   "description": "When charging, this app can rotate your screen and revert it when unplugged. Made for all sort of cradles.",
   "icon": "icon.png",
   "tags": "battery",


### PR DESCRIPTION
A small tweak to `chargerot` to avoid exceptions on boot