### PR TITLE
android: Allow alarm enable/disable

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -28,3 +28,4 @@
 0.27: Issue newline before GB commands (solves issue with console.log and ignored commands)
 0.28: Navigation messages no longer launch the Maps view unless they're new
 0.29: Support for http request xpath return format
+0.30: Allow alarm enable/disable

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -86,7 +86,7 @@
           var a = require("sched").newDefaultAlarm();
           a.id = "gb"+j;
           a.appid = "gbalarms";
-          a.on = true;
+          a.on = event.d[j].on !== undefined ? event.d[j].on : true;
           a.t = event.d[j].h * 3600000 + event.d[j].m * 60000;
           a.dow = ((dow&63)<<1) | (dow>>6); // Gadgetbridge sends DOW in a different format
           a.last = last;

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.29",
+  "version": "0.30",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",


### PR DESCRIPTION
Allow alarms to be enabled or disabled from Gadgetbridge, without deleting them from the watch.

Needs https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3240, but stays backwards compatible.