### PR TITLE
[Slider] New library for input via sliders

### DIFF
--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -55,8 +55,8 @@ try { // For making it possiblie to run the test app in the following catch stat
       o.c.outerBorderSize--;
       o.c.innerBorderSize--;
     }
-    o.c.outerBorderSize = Math.max(0,o.c.outerBorderSize)
-    o.c.innerBorderSize = Math.max(0,o.c.innerBorderSize)
+    o.c.outerBorderSize = Math.max(0,o.c.outerBorderSize);
+    o.c.innerBorderSize = Math.max(0,o.c.innerBorderSize);
 
     let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
     o.c.rounded = o.c.rounded?o.c.width/2:0;
@@ -202,7 +202,7 @@ try { // For making it possiblie to run the test app in the following catch stat
     // Add logic for auto progressing the slider only if wanted.
     if (o.c.autoProgress) {
       o.f.autoUpdate = ()=>{
-        o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000)
+        o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000);
         if (o.v.level>o.c.steps) o.v.level=o.c.steps;
         cb("auto", o.v.level);
         o.f.draw&&o.f.draw(o.v.level);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -11,223 +11,223 @@
 
 */
 
-  exports.create = function(cb, conf) {
+exports.create = function(cb, conf) {
 
-    const R = Bangle.appRect;
+  const R = Bangle.appRect;
 
-    // Empty function added to cb if it's undefined.
-    if (!cb) cb = ()=>{};
+  // Empty function added to cb if it's undefined.
+  if (!cb) cb = ()=>{};
 
-    let o = {};
-    o.v = {}; // variables go here.
-    o.f = {}; // functions go here.
+  let o = {};
+  o.v = {}; // variables go here.
+  o.f = {}; // functions go here.
 
-    // Default configuration for the indicator, modified by parameter `conf`:
-    o.c = Object.assign({ // constants go here.
-      initLevel:0,
-      horizontal:false,
-      xStart:R.x2-R.w/4-4,
-      width:R.w/4,
-      yStart:R.y+4,
-      height:R.h-10,
-      steps:30,
+  // Default configuration for the indicator, modified by parameter `conf`:
+  o.c = Object.assign({ // constants go here.
+    initLevel:0,
+    horizontal:false,
+    xStart:R.x2-R.w/4-4,
+    width:R.w/4,
+    yStart:R.y+4,
+    height:R.h-10,
+    steps:30,
 
-      dragableSlider:true,
-      dragRect:R,
-      mode:"incr",
-      oversizeR:0,
-      oversizeL:0,
-      propagateDrag:false,
-      timeout:1,
+    dragableSlider:true,
+    dragRect:R,
+    mode:"incr",
+    oversizeR:0,
+    oversizeL:0,
+    propagateDrag:false,
+    timeout:1,
 
-      drawableSlider:true,
-      colorFG:g.theme.fg2,
-      colorBG:g.theme.bg2,
-      rounded:true,
-      outerBorderSize:Math.round(2*R.w/176), // 176 is the # of pixels in a row on the Bangle.js 2's screen and typically also its app rectangles, used here to rescale to whatever pixel count is on the current app rectangle.
-      innerBorderSize:Math.round(2*R.w/176),
+    drawableSlider:true,
+    colorFG:g.theme.fg2,
+    colorBG:g.theme.bg2,
+    rounded:true,
+    outerBorderSize:Math.round(2*R.w/176), // 176 is the # of pixels in a row on the Bangle.js 2's screen and typically also its app rectangles, used here to rescale to whatever pixel count is on the current app rectangle.
+    innerBorderSize:Math.round(2*R.w/176),
 
-      autoProgress:false,
-    },conf);
+    autoProgress:false,
+  },conf);
 
-    // If borders are bigger than the configured width, make them smaller to avoid glitches.
-    while (o.c.width <= 2*(o.c.outerBorderSize+o.c.innerBorderSize)) {
-      o.c.outerBorderSize--;
-      o.c.innerBorderSize--;
-    }
-    o.c.outerBorderSize = Math.max(0,o.c.outerBorderSize);
-    o.c.innerBorderSize = Math.max(0,o.c.innerBorderSize);
+  // If borders are bigger than the configured width, make them smaller to avoid glitches.
+  while (o.c.width <= 2*(o.c.outerBorderSize+o.c.innerBorderSize)) {
+    o.c.outerBorderSize--;
+    o.c.innerBorderSize--;
+  }
+  o.c.outerBorderSize = Math.max(0,o.c.outerBorderSize);
+  o.c.innerBorderSize = Math.max(0,o.c.innerBorderSize);
 
-    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
-    o.c.rounded = o.c.rounded?o.c.width/2:0;
-    if (o.c.rounded) o.c._rounded = (o.c.width-2*totalBorderSize)/2;
+  let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
+  o.c.rounded = o.c.rounded?o.c.width/2:0;
+  if (o.c.rounded) o.c._rounded = (o.c.width-2*totalBorderSize)/2;
 
-    o.c.STEP_SIZE = ((o.c.height-2*totalBorderSize)-(!o.c.rounded?0:(2*o.c._rounded)))/o.c.steps;
+  o.c.STEP_SIZE = ((o.c.height-2*totalBorderSize)-(!o.c.rounded?0:(2*o.c._rounded)))/o.c.steps;
 
-    // If horizontal, flip things around.
-    if (o.c.horizontal) {
-      let mediator = o.c.xStart;
-      o.c.xStart = o.c.yStart;
-      o.c.yStart = mediator;
-      mediator = o.c.width;
-      o.c.width = o.c.height;
-      o.c.height = mediator;
-      delete mediator;
-    }
+  // If horizontal, flip things around.
+  if (o.c.horizontal) {
+    let mediator = o.c.xStart;
+    o.c.xStart = o.c.yStart;
+    o.c.yStart = mediator;
+    mediator = o.c.width;
+    o.c.width = o.c.height;
+    o.c.height = mediator;
+    delete mediator;
+  }
 
-    // Make room for the border. Underscore indicates the area for the actual indicator bar without borders.
-    o.c._xStart = o.c.xStart + totalBorderSize;
-    o.c._width = o.c.width - 2*totalBorderSize;
-    o.c._yStart = o.c.yStart + totalBorderSize;
-    o.c._height = o.c.height - 2*totalBorderSize;
+  // Make room for the border. Underscore indicates the area for the actual indicator bar without borders.
+  o.c._xStart = o.c.xStart + totalBorderSize;
+  o.c._width = o.c.width - 2*totalBorderSize;
+  o.c._yStart = o.c.yStart + totalBorderSize;
+  o.c._height = o.c.height - 2*totalBorderSize;
 
-    // Add a rectangle object with x, y, x2, y2, w and h values.
-    o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
+  // Add a rectangle object with x, y, x2, y2, w and h values.
+  o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 
-    // Initialize the level
-    o.v.level = o.c.initLevel;
+  // Initialize the level
+  o.v.level = o.c.initLevel;
 
-    // Only add interactivity if wanted.
-    if (o.c.dragableSlider) {
+  // Only add interactivity if wanted.
+  if (o.c.dragableSlider) {
 
-      let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
-      let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
+    let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
+    let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
 
-      const Y_MAX = g.getHeight()-1; // TODO: Should this take users screen calibration into account?
+    const Y_MAX = g.getHeight()-1; // TODO: Should this take users screen calibration into account?
 
-      o.v.ebLast = 0;
-      o.v.dy = 0;
+    o.v.ebLast = 0;
+    o.v.dy = 0;
 
-      o.f.wasOnDragRect = (exFirst, eyFirst)=>{
-        "ram";
-        return exFirst>o.c.dragRect.x && exFirst<o.c.dragRect.x2 && eyFirst>o.c.dragRect.y && eyFirst<o.c.dragRect.y2;
-      };
+    o.f.wasOnDragRect = (exFirst, eyFirst)=>{
+      "ram";
+      return exFirst>o.c.dragRect.x && exFirst<o.c.dragRect.x2 && eyFirst>o.c.dragRect.y && eyFirst<o.c.dragRect.y2;
+    };
 
-      o.f.wasOnIndicator = (exFirst)=>{
-        "ram";
-        if (!o.c.horizontal) return exFirst>o.c._xStart-o.c.oversizeL*o.c._width && exFirst<o.c._xStart+o.c._width+o.c.oversizeR*o.c._width;
-        if (o.c.horizontal) return exFirst>o.c._yStart-o.c.oversizeL*o.c._height && exFirst<o.c._yStart+o.c._height+o.c.oversizeR*o.c._height;
-      };
+    o.f.wasOnIndicator = (exFirst)=>{
+      "ram";
+      if (!o.c.horizontal) return exFirst>o.c._xStart-o.c.oversizeL*o.c._width && exFirst<o.c._xStart+o.c._width+o.c.oversizeR*o.c._width;
+      if (o.c.horizontal) return exFirst>o.c._yStart-o.c.oversizeL*o.c._height && exFirst<o.c._yStart+o.c._height+o.c.oversizeR*o.c._height;
+    };
 
-      // Function to pass to `Bangle.on('drag', )`
-      o.f.dragSlider = e=>{
-        "ram";
-        if (o.v.ebLast==0) {
-          exFirst = o.c.horizontal?e.y:e.x;
-          eyFirst = o.c.horizontal?e.x:e.y;
-        }
+    // Function to pass to `Bangle.on('drag', )`
+    o.f.dragSlider = e=>{
+      "ram";
+      if (o.v.ebLast==0) {
+        exFirst = o.c.horizontal?e.y:e.x;
+        eyFirst = o.c.horizontal?e.x:e.y;
+      }
 
-        // Only react if on allowed area.
-        if (o.f.wasOnDragRect(exFirst, eyFirst)) {
-          o.v.dragActive = true;
-          if (!o.c.propagateDrag) E.stopEventPropagation&&E.stopEventPropagation();
+      // Only react if on allowed area.
+      if (o.f.wasOnDragRect(exFirst, eyFirst)) {
+        o.v.dragActive = true;
+        if (!o.c.propagateDrag) E.stopEventPropagation&&E.stopEventPropagation();
 
-          if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
-          if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
+        if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
+        if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
-          if (useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
+        if (useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
-            let input = !o.c.horizontal?
-              Math.min((Y_MAX-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
-              Math.min(e.x-o.c.xStart-3*o.c.rounded/4, o.c.width);
-            input = Math.round(input/o.c.STEP_SIZE);
+          let input = !o.c.horizontal?
+            Math.min((Y_MAX-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
+            Math.min(e.x-o.c.xStart-3*o.c.rounded/4, o.c.width);
+          input = Math.round(input/o.c.STEP_SIZE);
 
-            o.v.level = Math.min(Math.max(input,0),o.c.steps);
+          o.v.level = Math.min(Math.max(input,0),o.c.steps);
 
-            o.v.cbObj = {mode:"map", value:o.v.level};
+          o.v.cbObj = {mode:"map", value:o.v.level};
 
-          } else if (useIncr) { // Heavily inspired by "updown" mode of setUI.
+        } else if (useIncr) { // Heavily inspired by "updown" mode of setUI.
 
-            o.v.dy += o.c.horizontal?-e.dx:e.dy;
-            //if (!e.b) o.v.dy=0;
+          o.v.dy += o.c.horizontal?-e.dx:e.dy;
+          //if (!e.b) o.v.dy=0;
 
-            while (Math.abs(o.v.dy)>32) {
-              let incr;
-              if (o.v.dy>0) { o.v.dy-=32; incr = 1;}
-              else { o.v.dy+=32; incr = -1;}
-              Bangle.buzz(20);
+          while (Math.abs(o.v.dy)>32) {
+            let incr;
+            if (o.v.dy>0) { o.v.dy-=32; incr = 1;}
+            else { o.v.dy+=32; incr = -1;}
+            Bangle.buzz(20);
 
-              o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
+            o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
 
-              o.v.cbObj = {mode:"incr", value:incr};
-            }
+            o.v.cbObj = {mode:"incr", value:incr};
           }
-          if (o.v.cbObj && (o.v.level!==o.v.prevLevel||o.v.level===0||o.v.level===o.c.steps)) {
-            cb(o.v.cbObj.mode, o.v.cbObj.value);
-            o.f.draw&&o.f.draw(o.v.level);
-          }
-          o.v.cbObj = null;
-          o.v.prevLevel = o.v.level;
-          o.v.ebLast = e.b;
         }
-      };
-
-      // Cleanup.
-      o.f.remove = ()=> {
-        Bangle.removeListener('drag', o.f.dragSlider);
-        o.v.dragActive = false;
-        o.v.timeoutID = undefined;
-        cb("remove", o.v.level);
-      };
-    }
-
-    // Add standard slider graphics only if wanted.
-    if (o.c.drawableSlider) {
-
-      // Function for getting the indication bars size.
-      o.f.updateBar = (levelHeight)=>{
-        "ram";
-        if (!o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart+o.c._height-levelHeight,w:o.c._width,y2:o.c._yStart+o.c._height,r:o.c.rounded};
-        if (o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart,w:levelHeight,h:o.c._height,r:o.c.rounded};
-      };
-
-      o.c.borderRect = {x:o.c._xStart-totalBorderSize,y:o.c._yStart-totalBorderSize,w:o.c._width+2*totalBorderSize,h:o.c._height+2*totalBorderSize,r:o.c.rounded};
-
-      o.c.hollowRect = {x:o.c._xStart-o.c.innerBorderSize,y:o.c._yStart-o.c.innerBorderSize,w:o.c._width+2*o.c.innerBorderSize,h:o.c._height+2*o.c.innerBorderSize,r:o.c.rounded};
-
-      // Standard slider drawing method.
-      o.f.draw = (level)=>{
-        "ram";
-
-        g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
-          setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
-          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c._rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
-        if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded).
-            setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded-o.c.outerBorderSize);
+        if (o.v.cbObj && (o.v.level!==o.v.prevLevel||o.v.level===0||o.v.level===o.c.steps)) {
+          cb(o.v.cbObj.mode, o.v.cbObj.value);
+          o.f.draw&&o.f.draw(o.v.level);
         }
-      };
-    }
+        o.v.cbObj = null;
+        o.v.prevLevel = o.v.level;
+        o.v.ebLast = e.b;
+      }
+    };
 
-    // Add logic for auto progressing the slider only if wanted.
-    if (o.c.autoProgress) {
-      o.f.autoUpdate = ()=>{
-        o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000);
-        if (o.v.level>o.c.steps) o.v.level=o.c.steps;
-        cb("auto", o.v.level);
-        o.f.draw&&o.f.draw(o.v.level);
-        if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
-      };
-      o.f.initAutoValues = ()=>{
-        o.v.autoInitTime=Date.now();
-        o.v.autoInitLevel=o.v.level;
-      };
-      o.f.startAutoUpdate = (intervalSeconds)=>{
-        if (!intervalSeconds) intervalSeconds = 1;
-        o.f.stopAutoUpdate();
-        o.f.initAutoValues();
-        o.f.draw&&o.f.draw(o.v.level);
-        o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000*intervalSeconds);
-      };
-      o.f.stopAutoUpdate = ()=>{
-        if (o.v.autoIntervalID) {
-          clearInterval(o.v.autoIntervalID);
-          o.v.autoIntervalID = undefined;
-        }
-        o.v.autoInitLevel = undefined;
-        o.v.autoInitTime = undefined;
-      };
-    }
+    // Cleanup.
+    o.f.remove = ()=> {
+      Bangle.removeListener('drag', o.f.dragSlider);
+      o.v.dragActive = false;
+      o.v.timeoutID = undefined;
+      cb("remove", o.v.level);
+    };
+  }
 
-    return o;
-  };
+  // Add standard slider graphics only if wanted.
+  if (o.c.drawableSlider) {
+
+    // Function for getting the indication bars size.
+    o.f.updateBar = (levelHeight)=>{
+      "ram";
+      if (!o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart+o.c._height-levelHeight,w:o.c._width,y2:o.c._yStart+o.c._height,r:o.c.rounded};
+      if (o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart,w:levelHeight,h:o.c._height,r:o.c.rounded};
+    };
+
+    o.c.borderRect = {x:o.c._xStart-totalBorderSize,y:o.c._yStart-totalBorderSize,w:o.c._width+2*totalBorderSize,h:o.c._height+2*totalBorderSize,r:o.c.rounded};
+
+    o.c.hollowRect = {x:o.c._xStart-o.c.innerBorderSize,y:o.c._yStart-o.c.innerBorderSize,w:o.c._width+2*o.c.innerBorderSize,h:o.c._height+2*o.c.innerBorderSize,r:o.c.rounded};
+
+    // Standard slider drawing method.
+    o.f.draw = (level)=>{
+      "ram";
+
+      g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
+        setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
+        setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c._rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+      if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
+        g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded).
+          setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded-o.c.outerBorderSize);
+      }
+    };
+  }
+
+  // Add logic for auto progressing the slider only if wanted.
+  if (o.c.autoProgress) {
+    o.f.autoUpdate = ()=>{
+      o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000);
+      if (o.v.level>o.c.steps) o.v.level=o.c.steps;
+      cb("auto", o.v.level);
+      o.f.draw&&o.f.draw(o.v.level);
+      if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
+    };
+    o.f.initAutoValues = ()=>{
+      o.v.autoInitTime=Date.now();
+      o.v.autoInitLevel=o.v.level;
+    };
+    o.f.startAutoUpdate = (intervalSeconds)=>{
+      if (!intervalSeconds) intervalSeconds = 1;
+      o.f.stopAutoUpdate();
+      o.f.initAutoValues();
+      o.f.draw&&o.f.draw(o.v.level);
+      o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000*intervalSeconds);
+    };
+    o.f.stopAutoUpdate = ()=>{
+      if (o.v.autoIntervalID) {
+        clearInterval(o.v.autoIntervalID);
+        o.v.autoIntervalID = undefined;
+      }
+      o.v.autoInitLevel = undefined;
+      o.v.autoInitTime = undefined;
+    };
+  }
+
+  return o;
+};

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -44,8 +44,8 @@ try { // For making it possiblie to run the test app in the following catch stat
       colorFG:g.theme.fg2,
       colorBG:g.theme.bg2,
       rounded:true,
-      outerBorderSize:2,
-      innerBorderSize:2,
+      outerBorderSize:Math.round(2*R.w/176), // 176 is the # of pixels in a row on the Bangle.js 2's screen and typically also its app rectangles, used here to rescale to whatever pixel count is on the current app rectangle.
+      innerBorderSize:Math.round(2*R.w/176),
 
       autoProgress:false,
     },conf);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -110,8 +110,8 @@ try { // for making it possiblie to run the test app in the following catch stat
             o.v.dy += o.c.horizontal?-e.dx:e.dy;
             //if (!e.b) o.v.dy=0;
 
-            let incr;
             while (Math.abs(o.v.dy)>32) {
+              let incr;
               if (o.v.dy>0) { o.v.dy-=32; incr = 1;}
               else { o.v.dy+=32; incr = -1;}
               Bangle.buzz(20);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -130,8 +130,8 @@ try { // For making it possiblie to run the test app in the following catch stat
             }
           }
           if (o.v.level!==o.v.prevLevel || o.v.level===0 || o.v.level===o.c.steps) {
-            o.f.draw&&o.f.draw(o.v.level);
             cb(o.v.cbObj.mode, o.v.cbObj.value);
+            o.f.draw&&o.f.draw(o.v.level);
           }
           o.v.prevLevel = o.v.level;
           o.v.ebLast = e.b;
@@ -183,8 +183,8 @@ try { // For making it possiblie to run the test app in the following catch stat
       o.f.autoUpdate = ()=>{
         o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000)
         if (o.v.level>o.c.steps) o.v.level=o.c.steps;
-        o.f.draw&&o.f.draw(o.v.level);
         cb("auto");
+        o.f.draw&&o.f.draw(o.v.level);
         if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
       };
       o.f.initAutoValues = ()=>{

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -50,6 +50,10 @@ try { // For making it possiblie to run the test app in the following catch stat
       autoProgress:false,
     },conf);
 
+    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
+    o.c.rounded = o.c.rounded?o.c.width/2:0;
+    if (o.c.rounded) o.c._rounded = (o.c.width-2*totalBorderSize)/2;
+
     // If horizontal, flip things around.
     if (o.c.horizontal) {
       let mediator = o.c.xStart;
@@ -62,14 +66,12 @@ try { // For making it possiblie to run the test app in the following catch stat
     }
 
     // Make room for the border. Underscore indicates the area for the actual indicator bar without borders.
-    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
     o.c._xStart = o.c.xStart + totalBorderSize;
     o.c._width = o.c.width - 2*totalBorderSize;
     o.c._yStart = o.c.yStart + totalBorderSize;
     o.c._height = o.c.height - 2*totalBorderSize;
-    o.c.rounded = o.c.rounded?o.c._width/2:0;
 
-    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c.rounded)))/o.c.steps;
+    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c._rounded)))/o.c.steps;
 
     // Add a rectangle object with x, y, x2, y2, w and h values.
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
@@ -181,10 +183,10 @@ try { // For making it possiblie to run the test app in the following catch stat
 
         g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
           setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
-          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c._rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded).
-            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded-o.c.outerBorderSize);
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._rounded:o.c._rounded), o.c._yStart+o.c._height-o.c._rounded, o.c._rounded).
+            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._rounded:o.c._rounded), o.c._yStart+o.c._height-o.c._rounded, o.c._rounded-o.c.outerBorderSize);
         }
       };
     }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -69,6 +69,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 
+      const Y_MAX = g.getHeight()-1; // Should this take users screen calibration into account?
 
       o.v.ebLast = 0;
       o.v.dy = 0;
@@ -104,7 +105,7 @@ try { // For making it possiblie to run the test app in the following catch stat
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
             let input = !o.c.horizontal?
-              Math.min((175-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
+              Math.min((Y_MAX-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
               Math.min(e.x-o.c.xStart-3*o.c.rounded/4, o.c.width);
             input = Math.round(input/o.c.STEP_SIZE);
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -125,8 +125,8 @@ try { // for making it possiblie to run the test app in the following catch stat
             }
           }
           o.v.ebLast = e.b;
-        };
-      }
+        }
+      };
 
       o.f.remove = ()=> {
         Bangle.removeListener('drag', o.f.dragSlider);
@@ -187,7 +187,7 @@ try { // for making it possiblie to run the test app in the following catch stat
     //o.f.printThis = ()=>(print(this));
 
     return o;
-  }
+  };
 
 } catch (e) {
   print(e);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -163,8 +163,8 @@ try { // for making it possiblie to run the test app in the following catch stat
           setColor(0==level?o.c.colorBG:o.c.colorFG).
           fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) {
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
-          g.setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
+          g.setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
         }
 
         //print(level);
@@ -196,6 +196,6 @@ try { // for making it possiblie to run the test app in the following catch stat
 
 } catch (e) {
   print(e);
-  let appName = "slidertest";
+  let appName = "spotrem";
   eval(require("Storage").read(appName+".app.js"));
 }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -163,17 +163,21 @@ try { // for making it possiblie to run the test app in the following catch stat
     }
 
     if (o.c.autoProgress) {
-      o.v.shouldAutoDraw = true;
       o.f.autoUpdate = ()=>{
         //if (o.v.level===undefined) o.v.level = -1;
-        o.v.level = o.v.level+1;
-        if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
+        o.v.level = o.c.currLevel + Math.round((Date.now()-o.v.initTime)/1000)
+        if (o.v.level>o.c.steps) o.v.level=o.c.steps;
+        o.f.draw&&o.f.draw(o.v.level);
         cb("auto");
         if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
       };
+      o.f.updateInitTime = ()=>{
+        o.v.initTime=Date.now();
+      }
       o.f.startAutoUpdate = ()=>{
         o.f.stopAutoUpdate();
-        if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
+        !o.v.initTime&&o.f.updateInitTime();
+        o.f.draw&&o.f.draw(o.v.level);
         o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
       };
       o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -147,10 +147,11 @@ o.f.remove = ()=> {
 };
 
 if (o.c.autoProgress) {
+  o.v.shouldAutoDraw = true;
   o.f.autoUpdate = ()=>{
     //if (o.v.level===undefined) o.v.level = -1;
     o.v.level = o.v.level+1;
-    o.f.draw(o.v.level);
+    if (o.v.shouldAutoDraw) o.f.draw(o.v.level);
     cb("auto");
     if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
   };

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -23,8 +23,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
       dragableSlider:true,
       dragRect:R,
-      useIncr:true,
-      useMap:false,
+      mode:"incr",
       oversizeR:0,
       oversizeL:0,
       propagateDrag:false,
@@ -93,6 +92,9 @@ try { // For making it possiblie to run the test app in the following catch stat
           eyFirst = o.c.horizontal?e.x:e.y;
         }
 
+        let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
+        let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
+
         // Only react if on allowed area.
         if (o.f.wasOnDragRect(exFirst, eyFirst)) {
           o.v.dragActive = true;
@@ -101,7 +103,7 @@ try { // For making it possiblie to run the test app in the following catch stat
           if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
           if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
-          if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
+          if (useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
             let input = !o.c.horizontal?
               Math.min((Y_MAX-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
@@ -112,7 +114,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
             o.v.cbObj = {mode:"map", value:o.v.level};
 
-          } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
+          } else if (useIncr) { // Heavily inspired by "updown" mode of setUI.
 
             o.v.dy += o.c.horizontal?-e.dx:e.dy;
             //if (!e.b) o.v.dy=0;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -184,7 +184,7 @@ try { // For making it possiblie to run the test app in the following catch stat
       o.f.autoUpdate = ()=>{
         o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000)
         if (o.v.level>o.c.steps) o.v.level=o.c.steps;
-        cb("auto");
+        cb("auto", o.v.level);
         o.f.draw&&o.f.draw(o.v.level);
         if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
       };

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -155,7 +155,11 @@ if (o.c.autoProgress) {
     cb("auto");
     if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
   };
-  o.f.startAutoUpdate = ()=>{o.f.stopAutoUpdate(); o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);};
+  o.f.startAutoUpdate = ()=>{
+      o.f.stopAutoUpdate();
+      if (o.v.shouldAutoDraw) o.f.draw(o.v.level);
+      o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
+  };
   o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};
 }
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -1,4 +1,15 @@
-try { // For making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined when uploading from Web IDE and not run otherwise.
+/* Copyright (c) 2023 Bangle.js contributors. See the file LICENSE for copying permission. */
+
+// See Slider.md for documentation
+
+/* Minify to 'Slider.min.js' by: // FIXME: Should we do this for Slider module?
+
+   * checking out: https://github.com/espruino/EspruinoDocs
+   * run: ../EspruinoDocs/bin/minify.js modules/Slider.js modules/Slider.min.js
+
+*/
+
+try { // For making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined when uploading from Web IDE and not run otherwise. // FIXME: This try-catch logic should be removed once development on this module slows down.
 
   exports.create = function(cb, conf) {
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -100,10 +100,12 @@ try { // for making it possiblie to run the test app in the following catch stat
 
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
-            let input = Math.max(0,Math.min((o.c.horizontal?175-e.x:e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height));
+            let input = !o.c.horizontal?
+              Math.min((175-e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height):
+              Math.min(e.x-o.c.xStart-3*o.c.rounded/4, o.c.width);
             input = Math.round(input/o.c.STEP_SIZE);
 
-            o.v.level = Math.min(Math.max(o.c.steps-input,0),o.c.steps);
+            o.v.level = Math.min(Math.max(input,0),o.c.steps);
 
             if (o.v.level != o.v.prevLevel) cb("map",o.v.level);
             o.f.draw&&o.f.draw(o.v.level);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -212,11 +212,12 @@ try { // For making it possiblie to run the test app in the following catch stat
         o.v.autoInitTime=Date.now();
         o.v.autoInitLevel=o.v.level;
       };
-      o.f.startAutoUpdate = ()=>{
+      o.f.startAutoUpdate = (intervalSeconds)=>{
+        if (!intervalSeconds) intervalSeconds = 1;
         o.f.stopAutoUpdate();
         o.f.initAutoValues();
         o.f.draw&&o.f.draw(o.v.level);
-        o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
+        o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000*intervalSeconds);
       };
       o.f.stopAutoUpdate = ()=>{
         if (o.v.autoIntervalID) {

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -131,6 +131,7 @@ try { // for making it possiblie to run the test app in the following catch stat
       o.f.remove = ()=> {
         Bangle.removeListener('drag', o.f.dragSlider);
         o.v.dragActive = false;
+        o.v.timeoutID = undefined;
         cb("remove", o.v.prevLevel);
       };
     }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -42,9 +42,9 @@ try { // for making it possiblie to run the test app in the following catch stat
     o.c._width = o.c.width - 2*totalBorderSize;
     o.c._yStart = o.c.yStart + totalBorderSize;
     o.c._height = o.c.height - 2*totalBorderSize;
-    if (o.c.rounded) o.c.rounded = 40;
+    o.c.rounded = o.c.rounded?20:0;
 
-    o.c.STEP_SIZE = o.c._height/o.c.steps;
+    o.c.STEP_SIZE = (o.c._height-(2*o.c.rounded-7))/o.c.steps;
 
     if (o.c.horizontal) {
       let mediator = o.c._xStart;
@@ -161,7 +161,11 @@ try { // for making it possiblie to run the test app in the following catch stat
         g.setColor(o.c.colorBG).
           fillRect(o.c.hollowRect). // ... and here it's made hollow.
           setColor(0==level?o.c.colorBG:o.c.colorFG).
-          fillRect(o.f.updateBar(level*o.c.STEP_SIZE)); // Here the bar is drawn.
+          fillRect(o.f.updateBar(2*o.c.rounded-7+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+        if (o.c.rounded && level===0) {
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
+          g.setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
+        }
 
         //print(level);
         //print(process.memory().usage);
@@ -192,6 +196,6 @@ try { // for making it possiblie to run the test app in the following catch stat
 
 } catch (e) {
   print(e);
-  let appName = "spotrem";
+  let appName = "slidertest";
   eval(require("Storage").read(appName+".app.js"));
 }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -69,6 +69,7 @@ o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
 
 o.v.firstRun = true;
 o.v.ebLast = 0;
+o.v.dy = 0;
 
 if (o.c.dragableSlider) { 
   o.f.wasOnIndicator = (exFirst)=>{

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -11,8 +11,6 @@
 
 */
 
-try { // For making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined when uploading from Web IDE and not run otherwise. // FIXME: This try-catch logic should be removed once development on this module slows down.
-
   exports.create = function(cb, conf) {
 
     const R = Bangle.appRect;
@@ -233,9 +231,3 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     return o;
   };
-
-} catch (e) {
-  print(e);
-  let appName = "slidertest";
-  eval(require("Storage").read(appName+".app.js"));
-}

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -98,10 +98,10 @@ try { // for making it possiblie to run the test app in the following catch stat
           if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
           if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
-          let input = Math.min(o.c.horizontal?175-e.x:e.y, 170);
-          input = Math.round(input/o.c.STEP_SIZE);
-
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
+
+            let input = Math.max(0,Math.min((o.c.horizontal?175-e.x:e.y)-o.c.yStart-3*o.c.rounded/4, o.c.height));
+            input = Math.round(input/o.c.STEP_SIZE);
 
             o.v.level = Math.min(Math.max(o.c.steps-input,0),o.c.steps);
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -68,6 +68,10 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 
+
+      let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
+      let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
+
       const Y_MAX = g.getHeight()-1; // Should this take users screen calibration into account?
 
       o.v.ebLast = 0;
@@ -91,9 +95,6 @@ try { // For making it possiblie to run the test app in the following catch stat
           exFirst = o.c.horizontal?e.y:e.x;
           eyFirst = o.c.horizontal?e.x:e.y;
         }
-
-        let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
-        let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
 
         // Only react if on allowed area.
         if (o.f.wasOnDragRect(exFirst, eyFirst)) {

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -131,7 +131,7 @@ try { // For making it possiblie to run the test app in the following catch stat
             }
           }
           if (o.v.level!==o.v.prevLevel || o.v.level===0 || o.v.level===o.c.steps) {
-            cb(o.v.cbObj.mode, o.v.cbObj.value);
+            cb(o.v.cbObj.mode, o.v.cbObj.value); // FIXME: Can cause error when using "incr" since it's not sure that o.v.cbObj has been initialized thanks to how the while-logic above works. (Can also do callback with faulty feedback since it didn't update)
             o.f.draw&&o.f.draw(o.v.level);
           }
           o.v.prevLevel = o.v.level;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -166,5 +166,6 @@ return o;
 
 } catch (e) {
 print(e);
-eval(require("Storage").read("slidertest.app.js"));
+let appName = "spotrem";
+eval(require("Storage").read(appName+".app.js"));
 }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -13,28 +13,31 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     // Default configuration for the indicator, modified by parameter `conf`:
     o.c = Object.assign({ // constants go here.
-      useMap:false,
-      useIncr:true,
+      currLevel:undefined,
       horizontal:false,
       xStart:R.x2-R.w/4-4,
       width:R.w/4,
       yStart:R.y+4,
       height:R.h-10,
-      steps:30, // Default corresponds to my phones volume range, [0,30]. Maybe it should be 31. Math is hard sometimes...
+      steps:30,
+
+      dragableSlider:true,
+      dragRect:R,
+      useIncr:true,
+      useMap:false,
       oversizeR:0,
       oversizeL:0,
+      propagateDrag:false,
       timeout:1,
+
+      drawableSlider:true,
       colorFG:g.theme.fg2,
       colorBG:g.theme.bg2,
       rounded:true,
-      propagateDrag:false,
-      autoProgress:false,
       outerBorderSize:2,
       innerBorderSize:2,
-      drawableSlider:true,
-      dragableSlider:true,
-      currLevel:undefined,
-      dragRect:R,
+
+      autoProgress:false,
     },conf);
 
     // If horizontal, flip things around.

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -37,24 +37,8 @@ try { // for making it possiblie to run the test app in the following catch stat
       dragRect:R,
     },conf);
 
-    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
-    o.c._xStart = o.c.xStart + totalBorderSize;
-    o.c._width = o.c.width - 2*totalBorderSize;
-    o.c._yStart = o.c.yStart + totalBorderSize;
-    o.c._height = o.c.height - 2*totalBorderSize;
-    o.c.rounded = o.c.rounded?20:0;
-
-    o.c.STEP_SIZE = (o.c._height-(!o.c.rounded?0:(2*o.c.rounded-7)))/o.c.steps;
-
     if (o.c.horizontal) {
-      let mediator = o.c._xStart;
-      o.c._xStart = o.c._yStart;
-      o.c._yStart = mediator;
-      mediator = o.c._width;
-      o.c._width = o.c._height;
-      o.c._height = mediator;
-
-      mediator = o.c.xStart;
+      let mediator = o.c.xStart;
       o.c.xStart = o.c.yStart;
       o.c.yStart = mediator;
       mediator = o.c.width;
@@ -62,6 +46,15 @@ try { // for making it possiblie to run the test app in the following catch stat
       o.c.height = mediator;
       delete mediator;
     }
+
+    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
+    o.c._xStart = o.c.xStart + totalBorderSize;
+    o.c._width = o.c.width - 2*totalBorderSize;
+    o.c._yStart = o.c.yStart + totalBorderSize;
+    o.c._height = o.c.height - 2*totalBorderSize;
+    o.c.rounded = o.c.rounded?20:0;
+
+    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c.rounded-7)))/o.c.steps;
 
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -107,9 +107,11 @@ try { // for making it possiblie to run the test app in the following catch stat
 
             o.v.level = Math.min(Math.max(input,0),o.c.steps);
 
-            if (o.v.level != o.v.prevLevel) cb("map",o.v.level);
-            o.f.draw&&o.f.draw(o.v.level);
-
+            if (o.v.level != o.v.prevLevel) {
+              cb("map",o.v.level);
+              o.f.draw&&o.f.draw(o.v.level);
+            }
+            o.v.prevLevel = o.v.level;
           } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
 
             o.v.dy += o.c.horizontal?-e.dx:e.dy;
@@ -124,6 +126,7 @@ try { // for making it possiblie to run the test app in the following catch stat
               o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
               cb("incr",incr);
               o.f.draw&&o.f.draw(o.v.level);
+              o.v.prevLevel = o.v.level;
             }
           }
           o.v.ebLast = e.b;
@@ -134,7 +137,7 @@ try { // for making it possiblie to run the test app in the following catch stat
         Bangle.removeListener('drag', o.f.dragSlider);
         o.v.dragActive = false;
         o.v.timeoutID = undefined;
-        cb("remove", o.v.prevLevel);
+        cb("remove", o.v.level);
       };
     }
 
@@ -153,17 +156,9 @@ try { // for making it possiblie to run the test app in the following catch stat
       o.f.draw = (level)=>{
         "ram";
 
-        if (true || o.v.firstRun || !o.c.lazy) {
-          g.setColor(o.c.colorFG).fillRect(o.c.borderRect); // To get outer border...
-        }
-        if (false && level == o.v.prevLevel) {if (!o.v.firstRun) return; if (o.v.firstRun) o.v.firstRun = false;}
-
-        o.v.prevLevel = level;
-
-        g.setColor(o.c.colorBG).
-          fillRect(o.c.hollowRect). // ... and here it's made hollow.
-          setColor(0==level?o.c.colorBG:o.c.colorFG).
-          fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+        g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
+          setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
+          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) {
           g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
           g.setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -159,9 +159,9 @@ try { // for making it possiblie to run the test app in the following catch stat
         g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
           setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
           setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
-        if (o.c.rounded && level===0) {
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
-          g.setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
+        if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize).
+            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
         }
 
         //print(level);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -2,7 +2,7 @@
 
 // See Slider.md for documentation
 
-/* Minify to 'Slider.min.js' by: // FIXME: Should we do this for Slider module?
+/* Minify to 'Slider.min.js' by: // TODO: Should we do this for Slider module?
 
    * checking out: https://github.com/espruino/EspruinoDocs
    * run: ../EspruinoDocs/bin/minify.js modules/Slider.js modules/Slider.min.js
@@ -83,7 +83,7 @@ try { // For making it possiblie to run the test app in the following catch stat
       let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
       let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
 
-      const Y_MAX = g.getHeight()-1; // Should this take users screen calibration into account?
+      const Y_MAX = g.getHeight()-1; // TODO: Should this take users screen calibration into account?
 
       o.v.ebLast = 0;
       o.v.dy = 0;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -44,7 +44,7 @@ try { // for making it possiblie to run the test app in the following catch stat
     o.c._height = o.c.height - 2*totalBorderSize;
     o.c.rounded = o.c.rounded?20:0;
 
-    o.c.STEP_SIZE = (o.c._height-(2*o.c.rounded-7))/o.c.steps;
+    o.c.STEP_SIZE = (o.c._height-(!o.c.rounded?0:(2*o.c.rounded-7)))/o.c.steps;
 
     if (o.c.horizontal) {
       let mediator = o.c._xStart;
@@ -161,7 +161,7 @@ try { // for making it possiblie to run the test app in the following catch stat
         g.setColor(o.c.colorBG).
           fillRect(o.c.hollowRect). // ... and here it's made hollow.
           setColor(0==level?o.c.colorBG:o.c.colorFG).
-          fillRect(o.f.updateBar(2*o.c.rounded-7+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+          fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) {
           g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize);
           g.setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._width/2,o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -50,6 +50,14 @@ try { // For making it possiblie to run the test app in the following catch stat
       autoProgress:false,
     },conf);
 
+    // If borders are bigger than the configured width, make them smaller to avoid glitches.
+    while (o.c.width <= 2*(o.c.outerBorderSize+o.c.innerBorderSize)) {
+      o.c.outerBorderSize--;
+      o.c.innerBorderSize--;
+    }
+    o.c.outerBorderSize = Math.max(0,o.c.outerBorderSize)
+    o.c.innerBorderSize = Math.max(0,o.c.innerBorderSize)
+
     let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
     o.c.rounded = o.c.rounded?o.c.width/2:0;
     if (o.c.rounded) o.c._rounded = (o.c.width-2*totalBorderSize)/2;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -186,9 +186,6 @@ try { // For making it possiblie to run the test app in the following catch stat
           g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded).
             setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded-o.c.outerBorderSize);
         }
-
-        //print(level);
-        //print(process.memory().usage);
       };
     }
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -33,6 +33,7 @@ o.c = Object.assign({ // constants go here.
   innerBorderSize:2,
   drawableSlider:true,
   dragableSlider:true,
+  currLevel:undefined,
 },conf);
 
 let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -26,10 +26,8 @@ try { // for making it possiblie to run the test app in the following catch stat
       timeout:1,
       colorFG:g.theme.fg2,
       colorBG:g.theme.bg2,
-      lazy:true,
-      rounded:0,
+      rounded:true,
       propagateDrag:false,
-      immediatedraw:false,
       autoProgress:false,
       outerBorderSize:2,
       innerBorderSize:2,
@@ -63,7 +61,6 @@ try { // for making it possiblie to run the test app in the following catch stat
     // Initialize the level
     o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
 
-    o.v.firstRun = true;
     o.v.ebLast = 0;
     o.v.dy = 0;
 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -1,5 +1,7 @@
 /* Copyright (c) 2023 Bangle.js contributors. See the file LICENSE for copying permission. */
 
+// At time of writing in October 2023 this module is new and things are more likely to change during the coming weeks than in a month or two.
+
 // See Slider.md for documentation
 
 /* Minify to 'Slider.min.js' by: // TODO: Should we do this for Slider module?

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -100,6 +100,7 @@ try { // For making it possiblie to run the test app in the following catch stat
           if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
           if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
+          let cbObj;
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
             let input = !o.c.horizontal?
@@ -109,11 +110,8 @@ try { // For making it possiblie to run the test app in the following catch stat
 
             o.v.level = Math.min(Math.max(input,0),o.c.steps);
 
-            if (o.v.level != o.v.prevLevel) {
-              cb("map",o.v.level);
-              o.f.draw&&o.f.draw(o.v.level);
-            }
-            o.v.prevLevel = o.v.level;
+            cbObj = {mode:"map", value:o.v.level};
+
           } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
 
             o.v.dy += o.c.horizontal?-e.dx:e.dy;
@@ -126,11 +124,15 @@ try { // For making it possiblie to run the test app in the following catch stat
               Bangle.buzz(20);
 
               o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
-              cb("incr",incr);
-              o.f.draw&&o.f.draw(o.v.level);
-              o.v.prevLevel = o.v.level;
+
+              cbObj = {mode:"incr", value:incr};
             }
           }
+          if (o.v.level != o.v.prevLevel) {
+            o.f.draw&&o.f.draw(o.v.level);
+            cb(cbObj.mode, cbObj.value);
+          }
+          o.v.prevLevel = o.v.level;
           o.v.ebLast = e.b;
         }
       };

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -1,17 +1,17 @@
-try { // for making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined.
+try { // For making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined when uploading from Web IDE and not run otherwise.
 
   exports.create = function(cb, conf) {
 
     const R = Bangle.appRect;
 
+    // Empty function added to cb if it's undefined.
     if (!cb) cb = ()=>{};
 
     let o = {};
     o.v = {}; // variables go here.
     o.f = {}; // functions go here.
 
-    // configuration for the indicator:
-
+    // Default configuration for the indicator, modified by parameter `conf`:
     o.c = Object.assign({ // constants go here.
       useMap:false,
       useIncr:true,
@@ -37,6 +37,7 @@ try { // for making it possiblie to run the test app in the following catch stat
       dragRect:R,
     },conf);
 
+    // If horizontal, flip things around.
     if (o.c.horizontal) {
       let mediator = o.c.xStart;
       o.c.xStart = o.c.yStart;
@@ -47,6 +48,7 @@ try { // for making it possiblie to run the test app in the following catch stat
       delete mediator;
     }
 
+    // Make room for the border. Underscore indicates the area for the actual indicator bar without borders.
     let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
     o.c._xStart = o.c.xStart + totalBorderSize;
     o.c._width = o.c.width - 2*totalBorderSize;
@@ -56,6 +58,7 @@ try { // for making it possiblie to run the test app in the following catch stat
 
     o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c.rounded-7)))/o.c.steps;
 
+    // Add a rectangle object with x, y, x2, y2, w and h values.
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 
     // Initialize the level
@@ -64,7 +67,9 @@ try { // for making it possiblie to run the test app in the following catch stat
     o.v.ebLast = 0;
     o.v.dy = 0;
 
+    // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 
+
       o.f.wasOnDragRect = (exFirst, eyFirst)=>{
         "ram";
         return exFirst>o.c.dragRect.x && exFirst<o.c.dragRect.x2 && eyFirst>o.c.dragRect.y && eyFirst<o.c.dragRect.y2;
@@ -76,6 +81,7 @@ try { // for making it possiblie to run the test app in the following catch stat
         if (o.c.horizontal) return exFirst>o.c._yStart-o.c.oversizeL*o.c._height && exFirst<o.c._yStart+o.c._height+o.c.oversizeR*o.c._height;
       };
 
+      // Function to pass to `Bangle.on('drag', )`
       o.f.dragSlider = e=>{
         "ram";
         if (o.v.ebLast==0) {
@@ -83,6 +89,7 @@ try { // for making it possiblie to run the test app in the following catch stat
           eyFirst = o.c.horizontal?e.x:e.y;
         }
 
+        // Only react if on allowed area.
         if (o.f.wasOnDragRect(exFirst, eyFirst)) {
           o.v.dragActive = true;
           if (!o.c.propagateDrag) E.stopEventPropagation&&E.stopEventPropagation();
@@ -125,6 +132,7 @@ try { // for making it possiblie to run the test app in the following catch stat
         }
       };
 
+      // Cleanup.
       o.f.remove = ()=> {
         Bangle.removeListener('drag', o.f.dragSlider);
         o.v.dragActive = false;
@@ -133,8 +141,10 @@ try { // for making it possiblie to run the test app in the following catch stat
       };
     }
 
+    // Add standard slider graphics only if wanted.
     if (o.c.drawableSlider) { 
 
+      // Function for getting the indication bars size.
       o.f.updateBar = (levelHeight)=>{
         "ram";
         if (!o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart+o.c._height-levelHeight,w:o.c._width,y2:o.c._yStart+o.c._height,r:o.c.rounded};
@@ -145,6 +155,7 @@ try { // for making it possiblie to run the test app in the following catch stat
 
       o.c.hollowRect = {x:o.c._xStart-o.c.innerBorderSize,y:o.c._yStart-o.c.innerBorderSize,w:o.c._width+2*o.c.innerBorderSize,h:o.c._height+2*o.c.innerBorderSize,r:o.c.rounded};
 
+      // Standard slider drawing method.
       o.f.draw = (level)=>{
         "ram";
 
@@ -161,9 +172,9 @@ try { // for making it possiblie to run the test app in the following catch stat
       };
     }
 
+    // Add logic for auto progressing the slider only if wanted.
     if (o.c.autoProgress) {
       o.f.autoUpdate = ()=>{
-        //if (o.v.level===undefined) o.v.level = -1;
         o.v.level = o.c.currLevel + Math.round((Date.now()-o.v.initTime)/1000)
         if (o.v.level>o.c.steps) o.v.level=o.c.steps;
         o.f.draw&&o.f.draw(o.v.level);
@@ -181,8 +192,6 @@ try { // for making it possiblie to run the test app in the following catch stat
       };
       o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};
     }
-
-    //o.f.printThis = ()=>(print(this));
 
     return o;
   };

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -175,22 +175,30 @@ try { // For making it possiblie to run the test app in the following catch stat
     // Add logic for auto progressing the slider only if wanted.
     if (o.c.autoProgress) {
       o.f.autoUpdate = ()=>{
-        o.v.level = o.c.currLevel + Math.round((Date.now()-o.v.initTime)/1000)
+        o.v.level = o.v.autoInitLevel + Math.round((Date.now()-o.v.autoInitTime)/1000)
         if (o.v.level>o.c.steps) o.v.level=o.c.steps;
         o.f.draw&&o.f.draw(o.v.level);
         cb("auto");
         if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
       };
-      o.f.updateInitTime = ()=>{
-        o.v.initTime=Date.now();
-      }
+      o.f.initAutoValues = ()=>{
+        o.v.autoInitTime=Date.now();
+        o.v.autoInitLevel=o.v.level;
+      };
       o.f.startAutoUpdate = ()=>{
         o.f.stopAutoUpdate();
-        !o.v.initTime&&o.f.updateInitTime();
+        o.f.initAutoValues();
         o.f.draw&&o.f.draw(o.v.level);
         o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
       };
-      o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};
+      o.f.stopAutoUpdate = ()=>{
+        if (o.v.autoIntervalID) {
+          clearInterval(o.v.autoIntervalID);
+          o.v.autoIntervalID = undefined;
+        }
+        o.v.autoInitLevel = undefined;
+        o.v.autoInitTime = undefined;
+      };
     }
 
     return o;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -88,7 +88,7 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.v.level = o.c.initLevel;
 
     // Only add interactivity if wanted.
-    if (o.c.dragableSlider) { 
+    if (o.c.dragableSlider) {
 
       let useMap = (o.c.mode==="map"||o.c.mode==="mapincr")?true:false;
       let useIncr = (o.c.mode==="incr"||o.c.mode==="mapincr")?true:false;
@@ -172,7 +172,7 @@ try { // For making it possiblie to run the test app in the following catch stat
     }
 
     // Add standard slider graphics only if wanted.
-    if (o.c.drawableSlider) { 
+    if (o.c.drawableSlider) {
 
       // Function for getting the indication bars size.
       o.f.updateBar = (levelHeight)=>{

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -130,10 +130,11 @@ try { // For making it possiblie to run the test app in the following catch stat
               o.v.cbObj = {mode:"incr", value:incr};
             }
           }
-          if (o.v.level!==o.v.prevLevel || o.v.level===0 || o.v.level===o.c.steps) {
-            cb(o.v.cbObj.mode, o.v.cbObj.value); // FIXME: Can cause error when using "incr" since it's not sure that o.v.cbObj has been initialized thanks to how the while-logic above works. (Can also do callback with faulty feedback since it didn't update)
+          if (o.v.cbObj && (o.v.level!==o.v.prevLevel||o.v.level===0||o.v.level===o.c.steps)) {
+            cb(o.v.cbObj.mode, o.v.cbObj.value);
             o.f.draw&&o.f.draw(o.v.level);
           }
+          o.v.cbObj = null;
           o.v.prevLevel = o.v.level;
           o.v.ebLast = e.b;
         }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -129,7 +129,7 @@ try { // For making it possiblie to run the test app in the following catch stat
               cbObj = {mode:"incr", value:incr};
             }
           }
-          if (o.v.level != o.v.prevLevel) {
+          if (o.v.level!==o.v.prevLevel || o.v.level===0 || o.v.level===o.c.steps) {
             o.f.draw&&o.f.draw(o.v.level);
             cb(cbObj.mode, cbObj.value);
           }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -4,6 +4,8 @@ try { // for making it possiblie to run the test app in the following catch stat
 
     const R = Bangle.appRect;
 
+    if (!cb) cb = ()=>{};
+
     let o = {};
     o.v = {}; // variables go here.
     o.f = {}; // functions go here.

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -101,7 +101,6 @@ try { // For making it possiblie to run the test app in the following catch stat
           if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
           if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
-          o.v.cbObj;
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
             let input = !o.c.horizontal?

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -1,196 +1,196 @@
 try { // for making it possiblie to run the test app in the following catch statement. It would complain on `exports` not being defined.
 
-exports.create = function(cb, conf) {
+  exports.create = function(cb, conf) {
 
-const R = Bangle.appRect;
+    const R = Bangle.appRect;
 
-let o = {};
-o.v = {}; // variables go here.
-o.f = {}; // functions go here.
+    let o = {};
+    o.v = {}; // variables go here.
+    o.f = {}; // functions go here.
 
-// configuration for the indicator:
+    // configuration for the indicator:
 
-o.c = Object.assign({ // constants go here.
-  useMap:false,
-  useIncr:true,
-  horizontal:false,
-  xStart:R.x2-R.w/4-4,
-  width:R.w/4,
-  yStart:R.y+4,
-  height:R.h-10,
-  steps:30, // Default corresponds to my phones volume range, [0,30]. Maybe it should be 31. Math is hard sometimes...
-  oversizeR:0,
-  oversizeL:0,
-  timeout:1,
-  colorFG:g.theme.fg2,
-  colorBG:g.theme.bg2,
-  lazy:true,
-  rounded:0,
-  propagateDrag:false,
-  immediatedraw:false,
-  autoProgress:false,
-  outerBorderSize:2,
-  innerBorderSize:2,
-  drawableSlider:true,
-  dragableSlider:true,
-  currLevel:undefined,
-  dragRect:R,
-},conf);
+    o.c = Object.assign({ // constants go here.
+      useMap:false,
+      useIncr:true,
+      horizontal:false,
+      xStart:R.x2-R.w/4-4,
+      width:R.w/4,
+      yStart:R.y+4,
+      height:R.h-10,
+      steps:30, // Default corresponds to my phones volume range, [0,30]. Maybe it should be 31. Math is hard sometimes...
+      oversizeR:0,
+      oversizeL:0,
+      timeout:1,
+      colorFG:g.theme.fg2,
+      colorBG:g.theme.bg2,
+      lazy:true,
+      rounded:0,
+      propagateDrag:false,
+      immediatedraw:false,
+      autoProgress:false,
+      outerBorderSize:2,
+      innerBorderSize:2,
+      drawableSlider:true,
+      dragableSlider:true,
+      currLevel:undefined,
+      dragRect:R,
+    },conf);
 
-let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
-o.c._xStart = o.c.xStart + totalBorderSize;
-o.c._width = o.c.width - 2*totalBorderSize;
-o.c._yStart = o.c.yStart + totalBorderSize;
-o.c._height = o.c.height - 2*totalBorderSize;
-if (o.c.rounded) o.c.rounded = 40;
+    let totalBorderSize = o.c.outerBorderSize + o.c.innerBorderSize;
+    o.c._xStart = o.c.xStart + totalBorderSize;
+    o.c._width = o.c.width - 2*totalBorderSize;
+    o.c._yStart = o.c.yStart + totalBorderSize;
+    o.c._height = o.c.height - 2*totalBorderSize;
+    if (o.c.rounded) o.c.rounded = 40;
 
-o.c.STEP_SIZE = o.c._height/o.c.steps;
+    o.c.STEP_SIZE = o.c._height/o.c.steps;
 
-if (o.c.horizontal) {
-  let mediator = o.c._xStart;
-  o.c._xStart = o.c._yStart;
-  o.c._yStart = mediator;
-  mediator = o.c._width;
-  o.c._width = o.c._height;
-  o.c._height = mediator;
+    if (o.c.horizontal) {
+      let mediator = o.c._xStart;
+      o.c._xStart = o.c._yStart;
+      o.c._yStart = mediator;
+      mediator = o.c._width;
+      o.c._width = o.c._height;
+      o.c._height = mediator;
 
-  mediator = o.c.xStart;
-  o.c.xStart = o.c.yStart;
-  o.c.yStart = mediator;
-  mediator = o.c.width;
-  o.c.width = o.c.height;
-  o.c.height = mediator;
-  delete mediator;
-}
-
-o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
-
-// Initialize the level
-o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
-
-o.v.firstRun = true;
-o.v.ebLast = 0;
-o.v.dy = 0;
-
-if (o.c.dragableSlider) { 
-  o.f.wasOnDragRect = (exFirst, eyFirst)=>{
-    "ram";
-    return exFirst>o.c.dragRect.x && exFirst<o.c.dragRect.x2 && eyFirst>o.c.dragRect.y && eyFirst<o.c.dragRect.y2;
-  };
-
-  o.f.wasOnIndicator = (exFirst)=>{
-    "ram";
-    if (!o.c.horizontal) return exFirst>o.c._xStart-o.c.oversizeL*o.c._width && exFirst<o.c._xStart+o.c._width+o.c.oversizeR*o.c._width;
-    if (o.c.horizontal) return exFirst>o.c._yStart-o.c.oversizeL*o.c._height && exFirst<o.c._yStart+o.c._height+o.c.oversizeR*o.c._height;
-  };
-
-  o.f.dragSlider = e=>{
-    "ram";
-    if (o.v.ebLast==0) {
-      exFirst = o.c.horizontal?e.y:e.x;
-      eyFirst = o.c.horizontal?e.x:e.y;
+      mediator = o.c.xStart;
+      o.c.xStart = o.c.yStart;
+      o.c.yStart = mediator;
+      mediator = o.c.width;
+      o.c.width = o.c.height;
+      o.c.height = mediator;
+      delete mediator;
     }
 
-    if (o.f.wasOnDragRect(exFirst, eyFirst)) {
-      o.v.dragActive = true;
-      if (!o.c.propagateDrag) E.stopEventPropagation&&E.stopEventPropagation();
+    o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 
-      if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
-      if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
+    // Initialize the level
+    o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
 
-      let input = Math.min(o.c.horizontal?175-e.x:e.y, 170);
-      input = Math.round(input/o.c.STEP_SIZE);
+    o.v.firstRun = true;
+    o.v.ebLast = 0;
+    o.v.dy = 0;
 
-      if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
+    if (o.c.dragableSlider) { 
+      o.f.wasOnDragRect = (exFirst, eyFirst)=>{
+        "ram";
+        return exFirst>o.c.dragRect.x && exFirst<o.c.dragRect.x2 && eyFirst>o.c.dragRect.y && eyFirst<o.c.dragRect.y2;
+      };
 
-        o.v.level = Math.min(Math.max(o.c.steps-input,0),o.c.steps);
+      o.f.wasOnIndicator = (exFirst)=>{
+        "ram";
+        if (!o.c.horizontal) return exFirst>o.c._xStart-o.c.oversizeL*o.c._width && exFirst<o.c._xStart+o.c._width+o.c.oversizeR*o.c._width;
+        if (o.c.horizontal) return exFirst>o.c._yStart-o.c.oversizeL*o.c._height && exFirst<o.c._yStart+o.c._height+o.c.oversizeR*o.c._height;
+      };
 
-        if (o.v.level != o.v.prevLevel) cb("map",o.v.level);
-        o.f.draw&&o.f.draw(o.v.level);
-
-      } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
-
-        o.v.dy += o.c.horizontal?-e.dx:e.dy;
-        //if (!e.b) o.v.dy=0;
-
-        let incr;
-        while (Math.abs(o.v.dy)>32) {
-          if (o.v.dy>0) { o.v.dy-=32; incr = 1;}
-          else { o.v.dy+=32; incr = -1;}
-          Bangle.buzz(20);
-
-          o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
-          cb("incr",incr);
-          o.f.draw&&o.f.draw(o.v.level);
+      o.f.dragSlider = e=>{
+        "ram";
+        if (o.v.ebLast==0) {
+          exFirst = o.c.horizontal?e.y:e.x;
+          eyFirst = o.c.horizontal?e.x:e.y;
         }
+
+        if (o.f.wasOnDragRect(exFirst, eyFirst)) {
+          o.v.dragActive = true;
+          if (!o.c.propagateDrag) E.stopEventPropagation&&E.stopEventPropagation();
+
+          if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
+          if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
+
+          let input = Math.min(o.c.horizontal?175-e.x:e.y, 170);
+          input = Math.round(input/o.c.STEP_SIZE);
+
+          if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
+
+            o.v.level = Math.min(Math.max(o.c.steps-input,0),o.c.steps);
+
+            if (o.v.level != o.v.prevLevel) cb("map",o.v.level);
+            o.f.draw&&o.f.draw(o.v.level);
+
+          } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
+
+            o.v.dy += o.c.horizontal?-e.dx:e.dy;
+            //if (!e.b) o.v.dy=0;
+
+            let incr;
+            while (Math.abs(o.v.dy)>32) {
+              if (o.v.dy>0) { o.v.dy-=32; incr = 1;}
+              else { o.v.dy+=32; incr = -1;}
+              Bangle.buzz(20);
+
+              o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
+              cb("incr",incr);
+              o.f.draw&&o.f.draw(o.v.level);
+            }
+          }
+          o.v.ebLast = e.b;
+        };
       }
-      o.v.ebLast = e.b;
-    };
+
+      o.f.remove = ()=> {
+        Bangle.removeListener('drag', o.f.dragSlider);
+        o.v.dragActive = false;
+        cb("remove", o.v.prevLevel);
+      };
+    }
+
+    if (o.c.drawableSlider) { 
+
+      o.f.updateBar = (levelHeight)=>{
+        "ram";
+        if (!o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart+o.c._height-levelHeight,w:o.c._width,y2:o.c._yStart+o.c._height,r:o.c.rounded};
+        if (o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart,w:levelHeight,h:o.c._height,r:o.c.rounded};
+      };
+
+      o.c.borderRect = {x:o.c._xStart-totalBorderSize,y:o.c._yStart-totalBorderSize,w:o.c._width+2*totalBorderSize,h:o.c._height+2*totalBorderSize,r:o.c.rounded};
+
+      o.c.hollowRect = {x:o.c._xStart-o.c.innerBorderSize,y:o.c._yStart-o.c.innerBorderSize,w:o.c._width+2*o.c.innerBorderSize,h:o.c._height+2*o.c.innerBorderSize,r:o.c.rounded};
+
+      o.f.draw = (level)=>{
+        "ram";
+
+        if (true || o.v.firstRun || !o.c.lazy) {
+          g.setColor(o.c.colorFG).fillRect(o.c.borderRect); // To get outer border...
+        }
+        if (false && level == o.v.prevLevel) {if (!o.v.firstRun) return; if (o.v.firstRun) o.v.firstRun = false;}
+
+        o.v.prevLevel = level;
+
+        g.setColor(o.c.colorBG).
+          fillRect(o.c.hollowRect). // ... and here it's made hollow.
+          setColor(0==level?o.c.colorBG:o.c.colorFG).
+          fillRect(o.f.updateBar(level*o.c.STEP_SIZE)); // Here the bar is drawn.
+
+        //print(level);
+        //print(process.memory().usage);
+      };
+    }
+
+    if (o.c.autoProgress) {
+      o.v.shouldAutoDraw = true;
+      o.f.autoUpdate = ()=>{
+        //if (o.v.level===undefined) o.v.level = -1;
+        o.v.level = o.v.level+1;
+        if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
+        cb("auto");
+        if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
+      };
+      o.f.startAutoUpdate = ()=>{
+        o.f.stopAutoUpdate();
+        if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
+        o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
+      };
+      o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};
+    }
+
+    //o.f.printThis = ()=>(print(this));
+
+    return o;
   }
 
-  o.f.remove = ()=> {
-    Bangle.removeListener('drag', o.f.dragSlider);
-    o.v.dragActive = false;
-    cb("remove", o.v.prevLevel);
-  };
-}
-
-if (o.c.drawableSlider) { 
-
-  o.f.updateBar = (levelHeight)=>{
-    "ram";
-    if (!o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart+o.c._height-levelHeight,w:o.c._width,y2:o.c._yStart+o.c._height,r:o.c.rounded};
-    if (o.c.horizontal) return {x:o.c._xStart,y:o.c._yStart,w:levelHeight,h:o.c._height,r:o.c.rounded};
-  };
-
-  o.c.borderRect = {x:o.c._xStart-totalBorderSize,y:o.c._yStart-totalBorderSize,w:o.c._width+2*totalBorderSize,h:o.c._height+2*totalBorderSize,r:o.c.rounded};
-
-  o.c.hollowRect = {x:o.c._xStart-o.c.innerBorderSize,y:o.c._yStart-o.c.innerBorderSize,w:o.c._width+2*o.c.innerBorderSize,h:o.c._height+2*o.c.innerBorderSize,r:o.c.rounded};
-
-  o.f.draw = (level)=>{
-    "ram";
-
-    if (true || o.v.firstRun || !o.c.lazy) {
-      g.setColor(o.c.colorFG).fillRect(o.c.borderRect); // To get outer border...
-    }
-    if (false && level == o.v.prevLevel) {if (!o.v.firstRun) return; if (o.v.firstRun) o.v.firstRun = false;}
-
-    o.v.prevLevel = level;
-
-    g.setColor(o.c.colorBG).
-      fillRect(o.c.hollowRect). // ... and here it's made hollow.
-      setColor(0==level?o.c.colorBG:o.c.colorFG).
-      fillRect(o.f.updateBar(level*o.c.STEP_SIZE)); // Here the bar is drawn.
-
-    //print(level);
-    //print(process.memory().usage);
-  };
-}
-
-if (o.c.autoProgress) {
-  o.v.shouldAutoDraw = true;
-  o.f.autoUpdate = ()=>{
-    //if (o.v.level===undefined) o.v.level = -1;
-    o.v.level = o.v.level+1;
-    if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
-    cb("auto");
-    if (o.v.level==o.c.steps) {o.f.stopAutoUpdate();}
-  };
-  o.f.startAutoUpdate = ()=>{
-      o.f.stopAutoUpdate();
-      if (o.v.shouldAutoDraw) o.f.draw&&o.f.draw(o.v.level);
-      o.v.autoIntervalID = setInterval(o.f.autoUpdate,1000);
-  };
-  o.f.stopAutoUpdate = ()=>{if (o.v.autoIntervalID) {clearInterval(o.v.autoIntervalID); o.v.autoIntervalID = undefined;}};
-}
-
-//o.f.printThis = ()=>(print(this));
-
-return o;
-}
-
 } catch (e) {
-print(e);
-let appName = "spotrem";
-eval(require("Storage").read(appName+".app.js"));
+  print(e);
+  let appName = "spotrem";
+  eval(require("Storage").read(appName+".app.js"));
 }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -54,6 +54,8 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.c.rounded = o.c.rounded?o.c.width/2:0;
     if (o.c.rounded) o.c._rounded = (o.c.width-2*totalBorderSize)/2;
 
+    o.c.STEP_SIZE = ((o.c.height-2*totalBorderSize)-(!o.c.rounded?0:(2*o.c._rounded)))/o.c.steps;
+
     // If horizontal, flip things around.
     if (o.c.horizontal) {
       let mediator = o.c.xStart;
@@ -70,8 +72,6 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.c._width = o.c.width - 2*totalBorderSize;
     o.c._yStart = o.c.yStart + totalBorderSize;
     o.c._height = o.c.height - 2*totalBorderSize;
-
-    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c._rounded)))/o.c.steps;
 
     // Add a rectangle object with x, y, x2, y2, w and h values.
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -56,9 +56,9 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.c._width = o.c.width - 2*totalBorderSize;
     o.c._yStart = o.c.yStart + totalBorderSize;
     o.c._height = o.c.height - 2*totalBorderSize;
-    o.c.rounded = o.c.rounded?20:0;
+    o.c.rounded = o.c.rounded?o.c._width/2:0;
 
-    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c.rounded-7)))/o.c.steps;
+    o.c.STEP_SIZE = ((!o.c.horizontal?o.c._height:o.c._width)-(!o.c.rounded?0:(2*o.c.rounded)))/o.c.steps;
 
     // Add a rectangle object with x, y, x2, y2, w and h values.
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
@@ -170,10 +170,10 @@ try { // For making it possiblie to run the test app in the following catch stat
 
         g.setColor(o.c.colorFG).fillRect(o.c.borderRect). // To get outer border...
           setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
-          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded-7))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
+          setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c.rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize).
-            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded+2, o.c.rounded-o.c.innerBorderSize-2);
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded).
+            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._width/2:o.c.rounded-2), o.c._yStart+o.c._height-o.c.rounded, o.c.rounded-o.c.outerBorderSize);
         }
 
         //print(level);
@@ -215,6 +215,6 @@ try { // For making it possiblie to run the test app in the following catch stat
 
 } catch (e) {
   print(e);
-  let appName = "spotrem";
+  let appName = "slidertest";
   eval(require("Storage").read(appName+".app.js"));
 }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -13,7 +13,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     // Default configuration for the indicator, modified by parameter `conf`:
     o.c = Object.assign({ // constants go here.
-      currLevel:undefined,
+      currLevel:null,
       horizontal:false,
       xStart:R.x2-R.w/4-4,
       width:R.w/4,
@@ -65,7 +65,7 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 
     // Initialize the level
-    o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
+    o.v.level = o.c.currLevel!==null?o.c.currLevel:o.c.steps/2;
 
     // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -64,11 +64,11 @@ try { // For making it possiblie to run the test app in the following catch stat
     // Initialize the level
     o.v.level = (o.c.currLevel||o.c.currLevel===0)?o.c.currLevel:o.c.steps/2;
 
-    o.v.ebLast = 0;
-    o.v.dy = 0;
-
     // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 
+
+      o.v.ebLast = 0;
+      o.v.dy = 0;
 
       o.f.wasOnDragRect = (exFirst, eyFirst)=>{
         "ram";

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -185,8 +185,8 @@ try { // For making it possiblie to run the test app in the following catch stat
           setColor(o.c.colorBG).fillRect(o.c.hollowRect). // ... and here it's made hollow.
           setColor(0==level?o.c.colorBG:o.c.colorFG).fillRect(o.f.updateBar((!o.c.rounded?0:(2*o.c._rounded))+level*o.c.STEP_SIZE)); // Here the bar is drawn.
         if (o.c.rounded && level===0) { // Hollow circle indicates level zero when slider is rounded.
-          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._rounded:o.c._rounded), o.c._yStart+o.c._height-o.c._rounded, o.c._rounded).
-            setColor(o.c.colorBG).fillCircle(o.c._xStart+(!o.c.horizontal?o.c._rounded:o.c._rounded), o.c._yStart+o.c._height-o.c._rounded, o.c._rounded-o.c.outerBorderSize);
+          g.setColor(o.c.colorFG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded).
+            setColor(o.c.colorBG).fillCircle(o.c._xStart+o.c._rounded, o.c._yStart+o.c._height-o.c._rounded, o.c._rounded-o.c.outerBorderSize);
         }
       };
     }

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -101,7 +101,7 @@ try { // For making it possiblie to run the test app in the following catch stat
           if (o.v.timeoutID) {clearTimeout(o.v.timeoutID); o.v.timeoutID = undefined;}
           if (e.b==0 && !o.v.timeoutID && (o.c.timeout || o.c.timeout===0)) o.v.timeoutID = setTimeout(o.f.remove, 1000*o.c.timeout);
 
-          let cbObj;
+          o.v.cbObj;
           if (o.c.useMap && o.f.wasOnIndicator(exFirst)) { // If draging starts on the indicator, adjust one-to-one.
 
             let input = !o.c.horizontal?
@@ -111,7 +111,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
             o.v.level = Math.min(Math.max(input,0),o.c.steps);
 
-            cbObj = {mode:"map", value:o.v.level};
+            o.v.cbObj = {mode:"map", value:o.v.level};
 
           } else if (o.c.useIncr) { // Heavily inspired by "updown" mode of setUI.
 
@@ -126,12 +126,12 @@ try { // For making it possiblie to run the test app in the following catch stat
 
               o.v.level = Math.min(Math.max(o.v.level-incr,0),o.c.steps);
 
-              cbObj = {mode:"incr", value:incr};
+              o.v.cbObj = {mode:"incr", value:incr};
             }
           }
           if (o.v.level!==o.v.prevLevel || o.v.level===0 || o.v.level===o.c.steps) {
             o.f.draw&&o.f.draw(o.v.level);
-            cb(cbObj.mode, cbObj.value);
+            cb(o.v.cbObj.mode, o.v.cbObj.value);
           }
           o.v.prevLevel = o.v.level;
           o.v.ebLast = e.b;

--- a/modules/Slider.js
+++ b/modules/Slider.js
@@ -13,7 +13,7 @@ try { // For making it possiblie to run the test app in the following catch stat
 
     // Default configuration for the indicator, modified by parameter `conf`:
     o.c = Object.assign({ // constants go here.
-      currLevel:null,
+      initLevel:0,
       horizontal:false,
       xStart:R.x2-R.w/4-4,
       width:R.w/4,
@@ -64,7 +64,7 @@ try { // For making it possiblie to run the test app in the following catch stat
     o.c.r = {x:o.c.xStart, y:o.c.yStart, x2:o.c.xStart+o.c.width, y2:o.c.yStart+o.c.height, w:o.c.width, h:o.c.height};
 
     // Initialize the level
-    o.v.level = o.c.currLevel!==null?o.c.currLevel:o.c.steps/2;
+    o.v.level = o.c.initLevel;
 
     // Only add interactivity if wanted.
     if (o.c.dragableSlider) { 

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -8,7 +8,7 @@ Slider Library
 Usage
 -----
 
-```JS
+```js
 var Slider = require("Slider");
 var slider =  Slider(callbackFunction, configObject);
 
@@ -63,16 +63,16 @@ slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
   v: { level: 0, ebLast: 0, dy: 0 },
   f: {
-    wasOnDragRect: function (exFirst,eyFirst) { ... },
-    wasOnIndicator: function (exFirst) { ... },
-    dragSlider: function (e) { ... },
-    remove: function () { ... },
-    updateBar: function (levelHeight) { ... },
-    draw: function (level) { ... },
-    autoUpdate: function () { ... },
-    initAutoValues: function () { ... },
-    startAutoUpdate: function (intervalSeconds) { ... },
-    stopAutoUpdate: function () { ... }
+    wasOnDragRect: function (exFirst,eyFirst) { ... }, // Used internally.
+    wasOnIndicator: function (exFirst) { ... }, // Used internally.
+    dragSlider: function (e) { ... }, // The drag handler.
+    remove: function () { ... }, // Used to remove the drag handler and run the callback function.
+    updateBar: function (levelHeight) { ... }, // Used internally to get the variable height rectangle for the indicator.
+    draw: function (level) { ... }, // Draw the slider with the supplied level.
+    autoUpdate: function () { ... }, // Used to update the slider when auto progressing.
+    initAutoValues: function () { ... }, // Used internally.
+    startAutoUpdate: function (intervalSeconds) { ... }, // `intervalSeconds` defaults to 1 second if it's not supplied when `startAutoUpdate` is called.
+    stopAutoUpdate: function () { ... } // Stop auto progressing and clear some related values.
    },
   c: { initLevel: 0, horizontal: false, xStart: 127, width: 44,
     yStart: 4, height: 166, steps: 30, dragableSlider: true,

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -1,6 +1,8 @@
 Slider Library
 ==============
 
+*At time of writing in October 2023 this module is new and things are more likely to change during the coming weeks than in a month or two.*
+
 > Take a look at README.md for hints on developing with this library.
 
 Usage
@@ -57,7 +59,7 @@ autoProgress:    false,                 // The slider should be able to progress
 
 A slider initiated in the Web IDE terminal window reveals its internals to a degree:
 ```js
->slider = require("Slider").create(()=>{}, {autoProgress:true})
+slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
   v: { level: 0, ebLast: 0, dy: 0 },
   f: {
@@ -69,7 +71,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     draw: function (level) { ... },
     autoUpdate: function () { ... },
     initAutoValues: function () { ... },
-    startAutoUpdate: function () { ... },
+    startAutoUpdate: function (intervalSeconds) { ... },
     stopAutoUpdate: function () { ... }
    },
   c: { initLevel: 0, horizontal: false, xStart: 127, width: 44,
@@ -79,8 +81,8 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     mode: "incr",
     oversizeR: 0, oversizeL: 0, propagateDrag: false, timeout: 1, drawableSlider: true,
     colorFG: 63488, colorBG: 8, rounded: 22, outerBorderSize: 2, innerBorderSize: 2,
-    autoProgress: true, _rounded: 18, _xStart: 131, _width: 36, _yStart: 8,
-    _height: 158, STEP_SIZE: 4.06666666666,
+    autoProgress: true, _rounded: 18, STEP_SIZE: 4.06666666666, _xStart: 131, _width: 36,
+    _yStart: 8, _height: 158,
     r: { x: 127, y: 4, x2: 171, y2: 170,
       w: 44, h: 166 },
     borderRect: { x: 127, y: 4, w: 44, h: 166,
@@ -89,7 +91,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
       r: 22 }
    }
  }
->
+> 
 ```
 Tips
 ----

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -24,7 +24,7 @@ Bangle.on("drag", slider.f.dragSlider);
 
 `configObject` (second argument, optional) has the following defaults:
 
-```JSON
+```js
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
@@ -57,7 +57,7 @@ autoProgress:    false,        // The slider should be able to progress automati
 ```
 
 A slider initiated in the Web IDE terminal window reveals its internals to a degree:
-```
+```js
 >slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
   v: { level: 15, ebLast: 0, dy: 0 },

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -20,7 +20,7 @@ Bangle.on("drag", slider.f.dragSlider);
 - `"map", o.v.level` | current level when interacting by mapping interface.
 - `"incr", incr` | where `incr` == +/-1, when interacting by incrementing interface.
 - `"remove", o.v.level` | last level when the slider times out.
-- `"auto"` | on its own, when auto progressing.
+- `"auto", o.v.level` | when auto progressing.
 
 `configObject` (`conf`) (second argument, optional) has the following defaults:
 

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -16,7 +16,7 @@ Bangle.on("drag", slider.f.dragSlider);
 // Bangle.prependListener("drag", slider.f.dragSlider);
 ```
 
-`callbackFunction` (first argument) determines what `slider` is used for. `slider` will pass two arguments, `mode` and `feedback` into `callbackFunction` (if `slider` is interactive). The different `mode`/`feedback` combinations to expect are:
+`callbackFunction` (first argument) determines what `slider` is used for. `slider` will pass two arguments, `mode` and `feedback`, into `callbackFunction` (if `slider` is interactive or auto progressing). The different `mode`/`feedback` combinations to expect are:
 - `"map", o.v.level` | current level when interacting by mapping interface.
 - `"incr", incr` | where incr = +-1, when interacting by incrementing interface.
 - `"remove", o.v.level` | last level when the slider times out.
@@ -28,28 +28,31 @@ Bangle.on("drag", slider.f.dragSlider);
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
-useMap:          false,        // Use the mapping feature?
-useIncr:         true,         // Use the incementing feature?
+currLevel:       undefined,    // The level to initate the slider with.
 horizontal:      false,        // Slider should be horizontal?
 xStart:          R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
 width:           R.w/4,        // Width of the slider. (Height if horizontal)
 yStart:          R.y+4,        // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
 height:          R.h-10,       // Height of the slider. (Width if horizontal)
 steps:           30,           // Number of discrete steps of the slider.
+
+dragableSlider:  true,         // Should supply the sliders standard interaction mechanisms?
+dragRect:        R,            // Accept input within this rectangle.
+useIncr:         true,         // Use the incrementing feature?
+useMap:          false,        // Use the mapping feature?
 oversizeR:       0,            // Determines if the mapping area should be extend outside the indicator (Right/Up).
 oversizeL:       0,            // Determines if the mapping area should be extend outside the indicator (Left/Down).
+propagateDrag:   false,        // Pass the drag event on down the handler chain?
 timeout:         1,            // Seconds untill the slider times out.
+
+drawableSlider:  true,         // Should supply the sliders standard drawing mechanism?
 colorFG:         g.theme.fg2,  // Foreground color.
 colorBG:         g.theme.bg2,  // Background color.
 rounded:         true,         // Slider should have rounded corners?
-propagateDrag:   false,        // Pass the drag event on down the handler chain?
-autoProgress:    false,        // The slider should be able to progress automatically?
 outerBorderSize: 2,            // The size of the visual border.
 innerBorderSize: 2,            // The distance between visual border and the slider.
-drawableSlider:  true,         // Should supply the sliders standard drawing mechanism?
-dragableSlider:  true,         // Should supply the sliders standard interaction mechanisms?
-currLevel:       undefined,    // The level to initate the slider with.
-dragRect:        R,            // Accept input within this rectangle.
+
+autoProgress:    false,        // The slider should be able to progress automatically?
 }
 ```
 
@@ -66,7 +69,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     updateBar: function (levelHeight) { ... },
     draw: function (level) { ... },
     autoUpdate: function () { ... },
-    updateInitTime: function () { ... },
+    initAutoValues: function () { ... },
     startAutoUpdate: function () { ... },
     stopAutoUpdate: function () { ... }
    },

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -63,16 +63,16 @@ slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
   v: { level: 0, ebLast: 0, dy: 0 },
   f: {
-    wasOnDragRect: function (exFirst,eyFirst) { ... }, // Used internally.
-    wasOnIndicator: function (exFirst) { ... }, // Used internally.
-    dragSlider: function (e) { ... }, // The drag handler.
-    remove: function () { ... }, // Used to remove the drag handler and run the callback function.
-    updateBar: function (levelHeight) { ... }, // Used internally to get the variable height rectangle for the indicator.
-    draw: function (level) { ... }, // Draw the slider with the supplied level.
-    autoUpdate: function () { ... }, // Used to update the slider when auto progressing.
-    initAutoValues: function () { ... }, // Used internally.
+    wasOnDragRect: function (exFirst,eyFirst) { ... },   // Used internally.
+    wasOnIndicator: function (exFirst) { ... },          // Used internally.
+    dragSlider: function (e) { ... },                    // The drag handler.
+    remove: function () { ... },                         // Used to remove the drag handler and run the callback function.
+    updateBar: function (levelHeight) { ... },           // Used internally to get the variable height rectangle for the indicator.
+    draw: function (level) { ... },                      // Draw the slider with the supplied level.
+    autoUpdate: function () { ... },                     // Used to update the slider when auto progressing.
+    initAutoValues: function () { ... },                 // Used internally.
     startAutoUpdate: function (intervalSeconds) { ... }, // `intervalSeconds` defaults to 1 second if it's not supplied when `startAutoUpdate` is called.
-    stopAutoUpdate: function () { ... } // Stop auto progressing and clear some related values.
+    stopAutoUpdate: function () { ... }                  // Stop auto progressing and clear some related values.
    },
   c: { initLevel: 0, horizontal: false, xStart: 127, width: 44,
     yStart: 4, height: 166, steps: 30, dragableSlider: true,

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -1,5 +1,5 @@
 Slider Library
-========================
+==============
 
 > Take a look at README.md for hints on developing with this library.
 
@@ -28,7 +28,7 @@ Bangle.on("drag", slider.f.dragSlider);
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
-currLevel:       undefined,    // The level to initialize the slider with.
+initLevel:       0,            // The level to initialize the slider with.
 horizontal:      false,        // Slider should be horizontal?
 xStart:          R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
 width:           R.w/4,        // Width of the slider. (Height if horizontal)
@@ -76,7 +76,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     width: 44, yStart: 28, height: 142, steps: 30, oversizeR: 0,
     oversizeL: 0, timeout: 1, colorFG: 65535, colorBG: 8, rounded: 20,
     propagateDrag: false, autoProgress: true, outerBorderSize: 2, innerBorderSize: 2,
-    drawableSlider: true, dragableSlider: true, currLevel: undefined,
+    drawableSlider: true, dragableSlider: true, initLevel: undefined,
     dragRect: { x: 0, y: 24, w: 176, h: 152,
       x2: 175, y2: 175 },
     _xStart: 131, _width: 36, _yStart: 32, _height: 134, STEP_SIZE: 3.36666666666,

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -28,7 +28,7 @@ Bangle.on("drag", slider.f.dragSlider);
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
-currLevel:       undefined,    // The level to initate the slider with.
+currLevel:       undefined,    // The level to initialize the slider with.
 horizontal:      false,        // Slider should be horizontal?
 xStart:          R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
 width:           R.w/4,        // Width of the slider. (Height if horizontal)
@@ -38,12 +38,11 @@ steps:           30,           // Number of discrete steps of the slider.
 
 dragableSlider:  true,         // Should supply the sliders standard interaction mechanisms?
 dragRect:        R,            // Accept input within this rectangle.
-useIncr:         true,         // Use the incrementing feature?
-useMap:          false,        // Use the mapping feature?
+mode:            "incr",       // What mode of draging to use: "map", "incr" or "mapincr".
 oversizeR:       0,            // Determines if the mapping area should be extend outside the indicator (Right/Up).
 oversizeL:       0,            // Determines if the mapping area should be extend outside the indicator (Left/Down).
 propagateDrag:   false,        // Pass the drag event on down the handler chain?
-timeout:         1,            // Seconds untill the slider times out.
+timeout:         1,            // Seconds until the slider times out.
 
 drawableSlider:  true,         // Should supply the sliders standard drawing mechanism?
 colorFG:         g.theme.fg2,  // Foreground color.
@@ -73,7 +72,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     startAutoUpdate: function () { ... },
     stopAutoUpdate: function () { ... }
    },
-  c: { useMap: false, useIncr: true, horizontal: false, xStart: 127,
+  c: { mode: "incr", horizontal: false, xStart: 127,
     width: 44, yStart: 28, height: 142, steps: 30, oversizeR: 0,
     oversizeL: 0, timeout: 1, colorFG: 65535, colorBG: 8, rounded: 20,
     propagateDrag: false, autoProgress: true, outerBorderSize: 2, innerBorderSize: 2,

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -16,13 +16,13 @@ Bangle.on("drag", slider.f.dragSlider);
 // Bangle.prependListener("drag", slider.f.dragSlider);
 ```
 
-`callbackFunction` (first argument) determines what `slider` is used for. `slider` will pass two arguments, `mode` and `feedback`, into `callbackFunction` (if `slider` is interactive or auto progressing). The different `mode`/`feedback` combinations to expect are:
+`callbackFunction` (`cb`) (first argument) determines what `slider` is used for. `slider` will pass two arguments, `mode` and `feedback` (`fb`), into `callbackFunction` (if `slider` is interactive or auto progressing). The different `mode`/`feedback` combinations to expect are:
 - `"map", o.v.level` | current level when interacting by mapping interface.
-- `"incr", incr` | where incr = +-1, when interacting by incrementing interface.
+- `"incr", incr` | where `incr` == +/-1, when interacting by incrementing interface.
 - `"remove", o.v.level` | last level when the slider times out.
 - `"auto"` | on its own, when auto progressing.
 
-`configObject` (second argument, optional) has the following defaults:
+`configObject` (`conf`) (second argument, optional) has the following defaults:
 
 ```js
 R = Bangle.appRect; // For use when determining defaults below.
@@ -90,6 +90,10 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
  }
 >
 ```
+Tips
+----
+
+You can implement custom graphics for a slider in the `callbackFunction`. The slider test app mentioned in the links below do this. To draw on top of the included slider graphics you need to wrap the drawing code in a timeout somewhat like so: `setTimeout(drawingFunction,0,fb)` (see [`setTimeout` documentation](https://www.espruino.com/Reference#l__global_setTimeout)).
 
 Links
 -----

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -28,30 +28,30 @@ Bangle.on("drag", slider.f.dragSlider);
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
-initLevel:       0,            // The level to initialize the slider with.
-horizontal:      false,        // Slider should be horizontal?
-xStart:          R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
-width:           R.w/4,        // Width of the slider. (Height if horizontal)
-yStart:          R.y+4,        // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
-height:          R.h-10,       // Height of the slider. (Width if horizontal)
-steps:           30,           // Number of discrete steps of the slider.
+initLevel:       0,                     // The level to initialize the slider with.
+horizontal:      false,                 // Slider should be horizontal?
+xStart:          R.x2-R.w/4-4,          // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
+width:           R.w/4,                 // Width of the slider. (Height if horizontal)
+yStart:          R.y+4,                 // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
+height:          R.h-10,                // Height of the slider. (Width if horizontal)
+steps:           30,                    // Number of discrete steps of the slider.
 
-dragableSlider:  true,         // Should supply the sliders standard interaction mechanisms?
-dragRect:        R,            // Accept input within this rectangle.
-mode:            "incr",       // What mode of draging to use: "map", "incr" or "mapincr".
-oversizeR:       0,            // Determines if the mapping area should be extend outside the indicator (Right/Up).
-oversizeL:       0,            // Determines if the mapping area should be extend outside the indicator (Left/Down).
-propagateDrag:   false,        // Pass the drag event on down the handler chain?
-timeout:         1,            // Seconds until the slider times out.
+dragableSlider:  true,                  // Should supply the sliders standard interaction mechanisms?
+dragRect:        R,                     // Accept input within this rectangle.
+mode:            "incr",                // What mode of draging to use: "map", "incr" or "mapincr".
+oversizeR:       0,                     // Determines if the mapping area should be extend outside the indicator (Right/Up).
+oversizeL:       0,                     // Determines if the mapping area should be extend outside the indicator (Left/Down).
+propagateDrag:   false,                 // Pass the drag event on down the handler chain?
+timeout:         1,                     // Seconds until the slider times out.
 
-drawableSlider:  true,         // Should supply the sliders standard drawing mechanism?
-colorFG:         g.theme.fg2,  // Foreground color.
-colorBG:         g.theme.bg2,  // Background color.
-rounded:         true,         // Slider should have rounded corners?
-outerBorderSize: 2,            // The size of the visual border.
-innerBorderSize: 2,            // The distance between visual border and the slider.
+drawableSlider:  true,                  // Should supply the sliders standard drawing mechanism?
+colorFG:         g.theme.fg2,           // Foreground color.
+colorBG:         g.theme.bg2,           // Background color.
+rounded:         true,                  // Slider should have rounded corners?
+outerBorderSize: Math.round(2*R.w/176), // The size of the visual border. Scaled in relation to Bangle.js 2 screen width/typical app rectangle widths.
+innerBorderSize: Math.round(2*R.w/176), // The distance between visual border and the slider.
 
-autoProgress:    false,        // The slider should be able to progress automatically?
+autoProgress:    false,                 // The slider should be able to progress automatically?
 }
 ```
 
@@ -59,7 +59,7 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
 ```js
 >slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
-  v: { level: 15, ebLast: 0, dy: 0 },
+  v: { level: 0, ebLast: 0, dy: 0 },
   f: {
     wasOnDragRect: function (exFirst,eyFirst) { ... },
     wasOnIndicator: function (exFirst) { ... },
@@ -72,20 +72,21 @@ A slider initiated in the Web IDE terminal window reveals its internals to a deg
     startAutoUpdate: function () { ... },
     stopAutoUpdate: function () { ... }
    },
-  c: { mode: "incr", horizontal: false, xStart: 127,
-    width: 44, yStart: 28, height: 142, steps: 30, oversizeR: 0,
-    oversizeL: 0, timeout: 1, colorFG: 65535, colorBG: 8, rounded: 20,
-    propagateDrag: false, autoProgress: true, outerBorderSize: 2, innerBorderSize: 2,
-    drawableSlider: true, dragableSlider: true, initLevel: undefined,
-    dragRect: { x: 0, y: 24, w: 176, h: 152,
+  c: { initLevel: 0, horizontal: false, xStart: 127, width: 44,
+    yStart: 4, height: 166, steps: 30, dragableSlider: true,
+    dragRect: { x: 0, y: 0, w: 176, h: 176,
       x2: 175, y2: 175 },
-    _xStart: 131, _width: 36, _yStart: 32, _height: 134, STEP_SIZE: 3.36666666666,
-    r: { x: 127, y: 28, x2: 171, y2: 170,
-      w: 44, h: 142 },
-    borderRect: { x: 127, y: 28, w: 44, h: 142,
-      r: 20 },
-    hollowRect: { x: 129, y: 30, w: 40, h: 138,
-      r: 20 }
+    mode: "incr",
+    oversizeR: 0, oversizeL: 0, propagateDrag: false, timeout: 1, drawableSlider: true,
+    colorFG: 63488, colorBG: 8, rounded: 22, outerBorderSize: 2, innerBorderSize: 2,
+    autoProgress: true, _rounded: 18, _xStart: 131, _width: 36, _yStart: 8,
+    _height: 158, STEP_SIZE: 4.06666666666,
+    r: { x: 127, y: 4, x2: 171, y2: 170,
+      w: 44, h: 166 },
+    borderRect: { x: 127, y: 4, w: 44, h: 166,
+      r: 22 },
+    hollowRect: { x: 129, y: 6, w: 40, h: 162,
+      r: 22 }
    }
  }
 >

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -16,11 +16,11 @@ Bangle.on("drag", slider.f.dragSlider);
 // Bangle.prependListener("drag", slider.f.dragSlider);
 ```
 
-`callbackFunction` (first argument) determines what `slider` is used for. Should take two arguments, `mode` and `feedback`. The different modes/feedback combinations to expect are:
-- "map", o.v.level | current level when interacting by mapping interface.
-- "incr", incr | where incr = +-1, when interacting by incrementing interface.
-- "remove", o.v.level | last level when the slider times out.
-- "auto" | on its own, when auto progressing.
+`callbackFunction` (first argument) determines what `slider` is used for. `slider` will pass two arguments, `mode` and `feedback` into `callbackFunction` (if `slider` is interactive). The different `mode`/`feedback` combinations to expect are:
+- `"map", o.v.level` | current level when interacting by mapping interface.
+- `"incr", incr` | where incr = +-1, when interacting by incrementing interface.
+- `"remove", o.v.level` | last level when the slider times out.
+- `"auto"` | on its own, when auto progressing.
 
 `configObject` (second argument, optional) has the following defaults:
 
@@ -28,34 +28,34 @@ Bangle.on("drag", slider.f.dragSlider);
 R = Bangle.appRect; // For use when determining defaults below.
 
 {
-useMap:false, // Use the mapping feature?
-useIncr:true, // Use the incementing feature?
-horizontal:false, // Slider should be horizontal?
-xStart:R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordingat if horizontal)
-width:R.w/4, // Width of the slider. (Height if horizontal)
-yStart:R.y+4, // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
-height:R.h-10, // Height of the slider. (Width if horizontal)
-steps:30, // Number of discrete steps of the slider.
-oversizeR:0, // Determines if the mapping area should be extend outside the indicator (Right/Up).
-oversizeL:0, // Determines if the mapping area should be extend outside the indicator (Left/Down).
-timeout:1, // Second untill the slider times out.
-colorFG:g.theme.fg2, // Forground color.
-colorBG:g.theme.bg2, // Background color.
-rounded:true, // Slider should have rounded corners?
-propagateDrag:false, // Pass the drag event on down the handler chain?
-autoProgress:false, // The slider should be able to progress automatically?
-outerBorderSize:2, // The size of the visual border.
-innerBorderSize:2, // The distance between visual border and the slider.
-drawableSlider:true, // Should supply the sliders standard drawing mechanism?
-dragableSlider:true, // Should supply the sliders standard interaction mechanisms?
-currLevel:undefined, // The level to initate the slider with.
-dragRect:R, // Accept input withing this rectangle.
+useMap:          false,        // Use the mapping feature?
+useIncr:         true,         // Use the incementing feature?
+horizontal:      false,        // Slider should be horizontal?
+xStart:          R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordinate if horizontal)
+width:           R.w/4,        // Width of the slider. (Height if horizontal)
+yStart:          R.y+4,        // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
+height:          R.h-10,       // Height of the slider. (Width if horizontal)
+steps:           30,           // Number of discrete steps of the slider.
+oversizeR:       0,            // Determines if the mapping area should be extend outside the indicator (Right/Up).
+oversizeL:       0,            // Determines if the mapping area should be extend outside the indicator (Left/Down).
+timeout:         1,            // Seconds untill the slider times out.
+colorFG:         g.theme.fg2,  // Foreground color.
+colorBG:         g.theme.bg2,  // Background color.
+rounded:         true,         // Slider should have rounded corners?
+propagateDrag:   false,        // Pass the drag event on down the handler chain?
+autoProgress:    false,        // The slider should be able to progress automatically?
+outerBorderSize: 2,            // The size of the visual border.
+innerBorderSize: 2,            // The distance between visual border and the slider.
+drawableSlider:  true,         // Should supply the sliders standard drawing mechanism?
+dragableSlider:  true,         // Should supply the sliders standard interaction mechanisms?
+currLevel:       undefined,    // The level to initate the slider with.
+dragRect:        R,            // Accept input within this rectangle.
 }
 ```
 
-A slider initiated in the Web IDE terminal reveals its internals to a degree:
+A slider initiated in the Web IDE terminal window reveals its internals to a degree:
 ```
->slider = require("Slider").create(()=>{},{autoProgress:true})
+>slider = require("Slider").create(()=>{}, {autoProgress:true})
 ={
   v: { level: 15, ebLast: 0, dy: 0 },
   f: {

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -1,0 +1,97 @@
+Slider Library
+========================
+
+> Take a look at README.md for hints on developing with this library.
+
+Usage
+-----
+
+```JS
+var Slider = require("Slider");
+var slider =  Slider(callbackFunction, configObject);
+
+Bangle.on("drag", slider.f.dragSlider);
+
+// If the slider should take precedent over other drag handlers use (fw2v18 and up):
+// Bangle.prependListener("drag", slider.f.dragSlider);
+```
+
+`callbackFunction` (first argument) determines what `slider` is used for. Should take two arguments, `mode` and `feedback`. The different modes/feedback combinations to expect are:
+- "map", o.v.level | current level when interacting by mapping interface.
+- "incr", incr | where incr = +-1, when interacting by incrementing interface.
+- "remove", o.v.level | last level when the slider times out.
+- "auto" | on its own, when auto progressing.
+
+`configObject` (second argument, optional) has the following defaults:
+
+```JSON
+R = Bangle.appRect; // For use when determining defaults below.
+
+{
+useMap:false, // Use the mapping feature?
+useIncr:true, // Use the incementing feature?
+horizontal:false, // Slider should be horizontal?
+xStart:R.x2-R.w/4-4, // Leftmost x-coordinate. (Uppermost y-coordingat if horizontal)
+width:R.w/4, // Width of the slider. (Height if horizontal)
+yStart:R.y+4, // Uppermost y-coordinate. (Rightmost x-coordinate if horizontal)
+height:R.h-10, // Height of the slider. (Width if horizontal)
+steps:30, // Number of discrete steps of the slider.
+oversizeR:0, // Determines if the mapping area should be extend outside the indicator (Right/Up).
+oversizeL:0, // Determines if the mapping area should be extend outside the indicator (Left/Down).
+timeout:1, // Second untill the slider times out.
+colorFG:g.theme.fg2, // Forground color.
+colorBG:g.theme.bg2, // Background color.
+rounded:true, // Slider should have rounded corners?
+propagateDrag:false, // Pass the drag event on down the handler chain?
+autoProgress:false, // The slider should be able to progress automatically?
+outerBorderSize:2, // The size of the visual border.
+innerBorderSize:2, // The distance between visual border and the slider.
+drawableSlider:true, // Should supply the sliders standard drawing mechanism?
+dragableSlider:true, // Should supply the sliders standard interaction mechanisms?
+currLevel:undefined, // The level to initate the slider with.
+dragRect:R, // Accept input withing this rectangle.
+}
+```
+
+A slider initiated in the Web IDE terminal reveals its internals to a degree:
+```
+>slider = require("Slider").create(()=>{},{autoProgress:true})
+={
+  v: { level: 15, ebLast: 0, dy: 0 },
+  f: {
+    wasOnDragRect: function (exFirst,eyFirst) { ... },
+    wasOnIndicator: function (exFirst) { ... },
+    dragSlider: function (e) { ... },
+    remove: function () { ... },
+    updateBar: function (levelHeight) { ... },
+    draw: function (level) { ... },
+    autoUpdate: function () { ... },
+    updateInitTime: function () { ... },
+    startAutoUpdate: function () { ... },
+    stopAutoUpdate: function () { ... }
+   },
+  c: { useMap: false, useIncr: true, horizontal: false, xStart: 127,
+    width: 44, yStart: 28, height: 142, steps: 30, oversizeR: 0,
+    oversizeL: 0, timeout: 1, colorFG: 65535, colorBG: 8, rounded: 20,
+    propagateDrag: false, autoProgress: true, outerBorderSize: 2, innerBorderSize: 2,
+    drawableSlider: true, dragableSlider: true, currLevel: undefined,
+    dragRect: { x: 0, y: 24, w: 176, h: 152,
+      x2: 175, y2: 175 },
+    _xStart: 131, _width: 36, _yStart: 32, _height: 134, STEP_SIZE: 3.36666666666,
+    r: { x: 127, y: 28, x2: 171, y2: 170,
+      w: 44, h: 142 },
+    borderRect: { x: 127, y: 28, w: 44, h: 142,
+      r: 20 },
+    hollowRect: { x: 129, y: 30, w: 40, h: 138,
+      r: 20 }
+   }
+ }
+>
+```
+
+Links
+-----
+
+There is a [slider test app on thyttan's personal app loader](https://thyttan.github.io/BangleApps/?q=slidertest) (at time of writing). Looking at [its code](https://github.com/thyttan/BangleApps/blob/ui-slider-lib/apps/slidertest/app.js) is a good way to see how the slider is used in app development.
+
+The version of [Remote for Spotify on thyttan's personal app loader](https://thyttan.github.io/BangleApps/?q=spotrem) (at time of writing) also utilizes the `Slider` module. Here is [the code](https://github.com/thyttan/BangleApps/blob/ui-slider-lib/apps/spotrem/app.js).

--- a/modules/Slider.md
+++ b/modules/Slider.md
@@ -44,7 +44,7 @@ mode:            "incr",                // What mode of draging to use: "map", "
 oversizeR:       0,                     // Determines if the mapping area should be extend outside the indicator (Right/Up).
 oversizeL:       0,                     // Determines if the mapping area should be extend outside the indicator (Left/Down).
 propagateDrag:   false,                 // Pass the drag event on down the handler chain?
-timeout:         1,                     // Seconds until the slider times out.
+timeout:         1,                     // Seconds until the slider times out. If set to `false` the slider stays active. The callback function is responsible for repainting over the slider graphics.
 
 drawableSlider:  true,                  // Should supply the sliders standard drawing mechanism?
 colorFG:         g.theme.fg2,           // Foreground color.


### PR DESCRIPTION
WIP

[Companion PR to Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3241).

This is meant to become a flexible and as lightweight/performant implementation of ui with input sliders as I can manage.

https://thyttan.github.io/BangleApps/apps/slidertest/screenshot-1.png

To try it out:

1. Install [updated Android Integration](https://thyttan.github.io/BangleApps/?q=android) to be able to send new `vg` command (vg = Volume Get level).
2. Install [the test app](https://thyttan.github.io/BangleApps/?q=slidertest)
3. Start the app named "Slider test" from your watch's launcher.
4. Optionally install and try [this modified "Remote for Spotify"](https://thyttan.github.io/BangleApps/?q=spotrem) to see the library used in a proper app.
5. Build Gadgetbridge from source with changes in [Companion PR to Gadgetbridge](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3241) included to see it handle the and `vg` command.

Still much to do:

- [x] - Many hardcoded values should depend on parameters.
- [x] - Refactor to split up logic and graphics better.
- [x] - initiate the border on first launch - don't draw it on every `drag` event?
- [x] - add ability to disable timeout.
- [x] - Ideally make the graphics nicer on low levels, but I don't want to introduce too much code.
- [x] - possibility to display multiple sliders simultaneously?
- [X] - optional auto incrementing level for persistent sliders (such as for a seek bar tracking a song)
- [x]  - fix behavior when moving an auto progressing slider. Especially after it had reached the end. GOOD ENOUGH FOR NOW
- [x] -  when using one persistent slider and one temporary, stop the persistent one not being redrawn when the temporary one goes away.
- [x] - Optimize data sent to Gadgetbridge for speed?
- [x] - Try to ensure backwards compatibility with older `Android Integration` versions - make sure nothing breaks at least. SEEMS TO NOT BREAK.
- [x] - Should it be compatible with Bangle.js 1? NOT FOR NOW AT LEAST
- [x]  - maybe refine behavior so input to one slider stops input to the other one when drag is being propagated. ACHIEVABLE BY CHECKING FOR ACTIVE SLIDER DRAG HANDLERS.
- [x]  - find out why I don't get position info for media tracks playing on my android phone.
- [x] - fix or remove lazy drawing? I DID BOTH.
- [x] - is using setClipRect a good or bad idea? FEELS PRETTY GOOD.
- [x] - make as many parts of the slider object as possible optional.
- [x] - redo/add logic for auto progressing sliders to use Date/getTime or similar? So it's not dependent on a timeout to keep track of correct current position. Would be good for battery maybe.
- [x] - Add documentation to Slider.md in modules folder. ADDED SOME. MORE CAN BE ADDED LATER.
- [x] - remove debug code/commits.
- [x] - check for ram leaks. I THINK IT LOOKS GOOD SO FAR. WILL LOOK AGAIN LATER.
- [x] - split the PR up in parts, one app per PR. 
- [x] - relate configurations defaults to g.getwidth/height (e.g. outerBorderSize).
- [ ] - make final decisions on names for vars, consts and functions.
- [ ] - take cues from `Layout` module? E.g. adapt to using `this`?
- [ ] - Try breaking the slider with configurations:
  - [x] - fix width below 44 starts to give bad graphics on rounded sliders (e.g. the zero-level circle should be able to be smaller)
  - [x] - when width is just a few pixels (depending on config) the bar can suddenly become very wide.
- [ ] - follow the espruino coding style guide.
- [ ] - look through the espruino performance notes and apply relevant tweaks?
- [ ] - how do I make it easy to not mess up memory usage/ making it straight forward to not end up with ram leaks?
- [ ]  - think about the scoping/flow of vars/funcs etc.
- [ ] - be more selective with sprinkling `"ram"` in functions? (Test app will use blocks of memory ca 3230 with vs 2930 without "ram", out of 12000 blocks. With "ram" a slider using map feels snappier, but it's not a super big difference.)

other considerations:
- ~~After I remove my drag handlers there will be an entry `undefined` in the first position of drag handlers. Should this entry be completely removed instead? (yes I think) how?~~ See: https://github.com/espruino/BangleApps/pull/2953#issuecomment-1754854824 and https://github.com/espruino/BangleApps/pull/2953#issuecomment-1757080143.
