### PR TITLE
lcdclock: load clockinfo before widgets

### DIFF
--- a/apps/lcdclock/ChangeLog
+++ b/apps/lcdclock/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Use clock_info module as an app
 0.03: clock_info now uses app name to maintain settings specifically for this clock face
+0.04: clock_info is loaded before widgets to match other clocks

--- a/apps/lcdclock/app.js
+++ b/apps/lcdclock/app.js
@@ -30,24 +30,6 @@ let draw = function() {
   }, 60000 - (Date.now() % 60000));
 };
 
-// Show launcher when middle button pressed
-Bangle.setUI({
-  mode : "clock",
-  remove : function() {
-    // Called to unload all of the clock app
-    if (drawTimeout) clearTimeout(drawTimeout);
-    drawTimeout = undefined;
-    delete Graphics.prototype.setFont7Seg;
-    // remove info menu
-    clockInfoMenu.remove();
-    delete clockInfoMenu;
-    clockInfoMenu2.remove();
-    delete clockInfoMenu2;
-    // reset theme
-    g.setTheme(oldTheme);
-  }});
-// Load widgets
-Bangle.loadWidgets();
 var R = Bangle.appRect;
 R.x+=1;
 R.y+=1;
@@ -57,12 +39,6 @@ R.w-=2;
 R.h-=2;
 var midX = R.x+R.w/2;
 var barY = 80;
-// Clear the screen once, at startup
-let oldTheme = g.theme;
-g.setTheme({bg:"#000",fg:"#fff",dark:true}).clear(1);
-g.fillRect({x:R.x, y:R.y, w:R.w, h:R.h, r:8}).clearRect(R.x,barY,R.w,barY+1).clearRect(midX,R.y,midX+1,barY);
-draw();
-setTimeout(Bangle.drawWidgets,0);
 
 let clockInfoDraw = (itm, info, options) => {
   let texty = options.y+41;
@@ -81,4 +57,29 @@ let clockInfoDraw = (itm, info, options) => {
 let clockInfoItems = require("clock_info").load();
 let clockInfoMenu = require("clock_info").addInteractive(clockInfoItems, { app:"lcdclock", x:R.x, y:R.y, w:midX-2, h:barY-R.y-2, draw : clockInfoDraw});
 let clockInfoMenu2 = require("clock_info").addInteractive(clockInfoItems, {  app:"lcdclock", x:midX+2, y:R.y, w:midX-3, h:barY-R.y-2, draw : clockInfoDraw});
+
+// Show launcher when middle button pressed
+Bangle.setUI({
+  mode : "clock",
+  remove : function() {
+    // Called to unload all of the clock app
+    if (drawTimeout) clearTimeout(drawTimeout);
+    drawTimeout = undefined;
+    delete Graphics.prototype.setFont7Seg;
+    // remove info menu
+    clockInfoMenu.remove();
+    delete clockInfoMenu;
+    clockInfoMenu2.remove();
+    delete clockInfoMenu2;
+    // reset theme
+    g.setTheme(oldTheme);
+  }});
+// Load widgets
+Bangle.loadWidgets();
+// Clear the screen once, at startup
+let oldTheme = g.theme;
+g.setTheme({bg:"#000",fg:"#fff",dark:true}).clear(1);
+g.fillRect({x:R.x, y:R.y, w:R.w, h:R.h, r:8}).clearRect(R.x,barY,R.w,barY+1).clearRect(midX,R.y,midX+1,barY);
+draw();
+setTimeout(Bangle.drawWidgets,0);
 }

--- a/apps/lcdclock/metadata.json
+++ b/apps/lcdclock/metadata.json
@@ -1,6 +1,6 @@
 { "id": "lcdclock",
   "name": "LCD Clock",
-  "version":"0.03",
+  "version":"0.04",
   "description": "A Casio-style clock, with ClockInfo areas at the top and bottom. Tap them and swipe up/down to toggle between different information",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
This just rearranges code to match the behaviour of other clocks, meaning any dependencies between widgets and clock info is consistent

See also #2900 / [this comment](https://github.com/espruino/BangleApps/pull/2900#issuecomment-1663510899)