### PR TITLE
bootgattbat & bthometemp: handle bleAdvert array

### DIFF
--- a/apps/bootgattbat/ChangeLog
+++ b/apps/bootgattbat/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial release.
+0.02: Handle the case where other apps have set bleAdvert to an array

--- a/apps/bootgattbat/boot.js
+++ b/apps/bootgattbat/boot.js
@@ -1,6 +1,22 @@
 (() => {
   function advertiseBattery() {
-    Bangle.bleAdvert[0x180F] = [E.getBattery()];
+    if(Array.isArray(Bangle.bleAdvert)){
+      // ensure we're in the cycle
+      var found = false;
+      for(var ad in Bangle.bleAdvert){
+        if(ad[0x180F]){
+          ad[0x180F] = [E.getBattery()];
+          found = true;
+          break;
+        }
+      }
+      if(!found)
+        Bangle.bleAdvert.push({ 0x180F: [E.getBattery()] });
+    }else{
+      // simple object
+      Bangle.bleAdvert[0x180F] = [E.getBattery()];
+    }
+
     NRF.setAdvertising(Bangle.bleAdvert);
   }
 

--- a/apps/bootgattbat/metadata.json
+++ b/apps/bootgattbat/metadata.json
@@ -2,7 +2,7 @@
   "id": "bootgattbat",
   "name": "BLE GATT Battery Service",
   "shortName": "BLE Battery Service",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Adds the GATT Battery Service to advertise the percentage of battery currently remaining over Bluetooth.\n",
   "icon": "bluetooth.png",
   "type": "bootloader",

--- a/apps/bthometemp/ChangeLog
+++ b/apps/bthometemp/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Handle the case where other apps have set bleAdvert to an array

--- a/apps/bthometemp/app.js
+++ b/apps/bthometemp/app.js
@@ -23,7 +23,7 @@ function onTemperature(p) {
   var temp100 = Math.round(avrTemp*100);
   var pressure100 = Math.round(avrPressure*100);
 
-  Bangle.bleAdvert[0xFCD2] = [ 0x40, /* BTHome Device Information
+  var advert = [ 0x40, /* BTHome Device Information
               bit 0: "Encryption flag"
               bit 1-4: "Reserved for future use"
               bit 5-7: "BTHome Version" */
@@ -37,6 +37,21 @@ function onTemperature(p) {
               0x04, // Pressure, 16 bit
               pressure100&255,(pressure100>>8)&255,pressure100>>16
   ];
+
+  if(Array.isArray(Bangle.bleAdvert)){
+    var found = false;
+    for(var ad in Bangle.bleAdvert){
+      if(ad[0xFCD2]){
+        ad[0xFCD2] = advert;
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+      Bangle.bleAdvert.push({ 0xFCD2: advert });
+  }else{
+    Bangle.bleAdvert[0xFCD2] = advert;
+  }
   NRF.setAdvertising(Bangle.bleAdvert);
 }
 

--- a/apps/bthometemp/metadata.json
+++ b/apps/bthometemp/metadata.json
@@ -1,7 +1,7 @@
 { "id": "bthometemp",
   "name": "BTHome Temperature and Pressure",
   "shortName":"BTHome T",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Displays temperature and pressure, and advertises them over bluetooth using BTHome.io standard",
   "icon": "app.png",
   "tags": "bthome,bluetooth,temperature",


### PR DESCRIPTION
Following on from #2912, this handles `Bangle.bleAdvert` being an array instead of an object