### PR TITLE
Ensure progress toast is visible above modal dialogs

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -54,7 +54,7 @@ a.btn.btn-link.dropdown-toggle {
 #toastcontainer {
   position:fixed;
   bottom:8px;left:0px;right:0px;
-  z-index: 100;
+  z-index: 500;
 }
 .hero {
   padding-bottom: 1rem;


### PR DESCRIPTION
The modal dialog has a z-index of 400, so the toasts would not be visible (eg. while downloading data from the health app).

Setting a z-index of 500 fixes this.