### PR TITLE
bikespeedo: fix locale units setting

### DIFF
--- a/apps/bikespeedo/ChangeLog
+++ b/apps/bikespeedo/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Use default Bangle formatter for booleans
 0.04: Add options for units in locale and recording GPS
 0.05: Allow toggling of "max" values (screen tap) and recording (button press)
+0.06: Fix local unit setting

--- a/apps/bikespeedo/app.js
+++ b/apps/bikespeedo/app.js
@@ -420,7 +420,7 @@ function updateClock() {
 // Read settings.
 let cfg = require('Storage').readJSON('bikespeedo.json',1)||{};
 
-cfg.spd = !cfg.localeUnits;  // Multiplier for speed unit conversions. 0 = use the locale values for speed
+cfg.spd = cfg.localeUnits ? 0 : 1;  // Multiplier for speed unit conversions. 0 = use the locale values for speed
 cfg.spd_unit = 'km/h';  // Displayed speed unit
 cfg.alt = 1; // Multiplier for altitude unit conversions. (feet:'0.3048')
 cfg.alt_unit = 'm';  // Displayed altitude units ('feet')

--- a/apps/bikespeedo/metadata.json
+++ b/apps/bikespeedo/metadata.json
@@ -2,7 +2,7 @@
   "id": "bikespeedo",
   "name": "Bike Speedometer (beta)",
   "shortName": "Bike Speedometer",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Shows GPS speed, GPS heading, Compass heading, GPS altitude and Barometer altitude from internal sources",
   "icon": "app.png",
   "screenshots": [{"url":"Screenshot.png"}],


### PR DESCRIPTION
Fixes #2961 - the original code needed exactly a number, not a boolean