### PR TITLE
Add missing gx namespace for kml extensions

### DIFF
--- a/apps/recorder/interface.html
+++ b/apps/recorder/interface.html
@@ -30,7 +30,7 @@ function saveKML(track,title) {
   track = filterGPSCoordinates(track);
   // Now output KML
   var kml = `<?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
   <Document>
     <Schema id="schema">
 ${track[0].Heartrate!==undefined ? `<gx:SimpleArrayField name="heartrate" type="int">


### PR DESCRIPTION
According to https://developers.google.com/kml/documentation/kmlreference#kml-extension-namespace-and-the-gx-prefix

> This namespace URI must be added to the <kml> element in any KML file using gx-prefixed elements

As the exported kml tracks always contain such elements, add the namespace.