### PR TITLE
Fix hwid_a_battery_widget background color

### DIFF
--- a/apps/hwid_a_battery_widget/ChangeLog
+++ b/apps/hwid_a_battery_widget/ChangeLog
@@ -7,3 +7,4 @@
 0.07: Fixed position after unlocking
 0.08: Handling exceptions
 0.09: Add option for showing battery high mark
+0.10: Fix background color

--- a/apps/hwid_a_battery_widget/metadata.json
+++ b/apps/hwid_a_battery_widget/metadata.json
@@ -3,7 +3,7 @@
   "name": "A Battery Widget (with percentage) - Hanks Mod",
   "shortName":"H Battery Widget",
   "icon": "widget.png",
-  "version":"0.09",
+  "version":"0.10",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/hwid_a_battery_widget/widget.js
+++ b/apps/hwid_a_battery_widget/widget.js
@@ -26,6 +26,7 @@
 	var	y = this.y;
 	if ((typeof x === 'undefined') || (typeof y === 'undefined')) {
 	} else {
+		g.setBgColor(COLORS.white);
 		g.clearRect(old_x, old_y, old_x + width, old_y + height);
 
 		const l = E.getBattery(); // debug: Math.floor(Math.random() * 101);


### PR DESCRIPTION
In some cases, if another app/widget changes the background color, hwid_a_battery_widget is drawn incorrectly.