### PR TITLE
boot, setting: whitelist: try to resolve peer address

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -67,3 +67,4 @@
 0.56: Settings.log = 0,1,2,3 for off,display, log, both
 0.57: Handle the whitelist being disabled
 0.58: "Make Connectable" temporarily bypasses the whitelist
+0.59: Whitelist: Try to resolve peer addresses using NRF.resolveAddress() - for 2v19 or 2v18 cutting edge builds

--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -79,7 +79,7 @@ if (global.save) boot += `global.save = function() { throw new Error("You can't 
 if (s.options) boot+=`Bangle.setOptions(${E.toJS(s.options)});\n`;
 if (s.brightness && s.brightness!=1) boot+=`Bangle.setLCDBrightness(${s.brightness});\n`;
 if (s.passkey!==undefined && s.passkey.length==6) boot+=`NRF.setSecurity({passkey:${E.toJS(s.passkey.toString())}, mitm:1, display:1});\n`;
-if (s.whitelist && !s.whitelist_disabled) boot+=`NRF.on('connect', function(addr) { if (!NRF.ignoreWhitelist && !(require('Storage').readJSON('setting.json',1)||{}).whitelist.includes(addr)) NRF.disconnect(); });\n`;
+if (s.whitelist && !s.whitelist_disabled) boot+=`NRF.on('connect', function(addr) { if (!NRF.ignoreWhitelist) { let whitelist = (require('Storage').readJSON('setting.json',1)||{}).whitelist; if (NRF.resolveAddress !== undefined) { let resolvedAddr = NRF.resolveAddress(addr); if (resolvedAddr !== undefined) addr = resolvedAddr + " (resolved)"; } if (!whitelist.includes(addr)) NRF.disconnect(); }});\n`;
 if (s.rotate) boot+=`g.setRotation(${s.rotate&3},${s.rotate>>2});\n` // screen rotation
 // ================================================== FIXING OLDER FIRMWARES
 if (FWVERSION<215.068) // 2v15.68 and before had compass heading inverted.

--- a/apps/boot/metadata.json
+++ b/apps/boot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boot",
   "name": "Bootloader",
-  "version": "0.58",
+  "version": "0.59",
   "description": "This is needed by Bangle.js to automatically load the clock, menu, widgets and settings",
   "icon": "bootloader.png",
   "type": "bootloader",

--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -69,3 +69,4 @@ of 'Select Clock'
       LCD calibration will now error if the calibration is obviously wrong
 0.61: Permit temporary bypass of the BLE whitelist
 0.62: Fix whitelist showing as 'on' by default when it's not after 0.59
+0.63: Whitelist: Try to resolve peer addresses using NRF.resolveAddress() - for 2v19 or 2v18 cutting edge builds

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.62",
+  "version": "0.63",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -383,6 +383,12 @@ function showWhitelistMenu() {
     NRF.on('connect', function(addr) {
       if (!settings.whitelist) settings.whitelist=[];
       delete settings.whitelist_disabled;
+      if (NRF.resolveAddress !== undefined) {
+        let resolvedAddr = NRF.resolveAddress(addr);
+        if (resolvedAddr !== undefined) {
+          addr = resolvedAddr + " (resolved)";
+        }
+      }
       settings.whitelist.push(addr);
       updateSettings();
       NRF.removeAllListeners('connect');


### PR DESCRIPTION
This uses NRF.resolveAddress() on newer firmwares, to try to resolve "random private resolvable addresses" of peers that connect, before checking the whitelist.

Now we can finally whitelist smartphones that change their address :)