### PR TITLE
messagelist: setUI weirdness workaround

### DIFF
--- a/apps/messagelist/ChangeLog
+++ b/apps/messagelist/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New app!
 0.02: Fix music updates while app is already open
 0.03: Fix invalid use of Bangle.setUI
+0.04: setUI weirdness workaround

--- a/apps/messagelist/metadata.json
+++ b/apps/messagelist/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagelist",
   "name": "Message List",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Display notifications from iOS and Gadgetbridge/Android as a list",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
For some reason `uiRemove()` was called by `Bangle.setUI()`, even though it was unset at the exact time of calling.
Workaround: don't pass `"remove"` in options, but set it inside a timeout.
Also: add some `debug()` lines, enabled by setting `global.DEBUG_MESSAGELIST = true`

I'm not sure why this happens, is it some Espruino quick/bug?

Looks like this has been broken for a while, but with https://github.com/espruino/BangleApps/commit/f4740b149b5649bf0328210de1414ce56c4fb839 it happens more often (before that `setUI` often neglected to set `"remove"`, so this didn't happen but things were otherwise broken)

If I change the [line](https://github.com/espruino/BangleApps/compare/master...rigrig:messagelist-setui-fix?expand=1#diff-1f5021d500659e8f9efc3cf30c0a7355f8950dbf37cbb863cdb39472d8e3c67cR107)
```js
if (remove) setTimeout(() => Bangle.uiRemove = remove);
```
into
```js
if (remove) Bangle.uiRemove = remove;
```

I get this debug log (by setting `global.DEBUG_MESSAGELIST = true`) when a new `"music"` message arrives:

```
messagelist: setUI( undefined undefined
messagelist: Bangle.uiRemove: undefined
messagelist: call Bangle.setUI( {
  "mode": "custom",
  "remove": function () {return uiRemove()}
 } undefined
messagelist: Bangle.setUI() done!
messagelist: uiRemove()
```
(that last line should not happen)