### PR TITLE
Fix health daily movement graph again :-)

### DIFF
--- a/apps/health/ChangeLog
+++ b/apps/health/ChangeLog
@@ -27,3 +27,4 @@
       movement graph in app is now an average, not sum
       fix 11pm slot for daily HRM
 0.26: Implement API for activity fetching
+0.27: Fix typo in daily summary graph code causing graph not to load

--- a/apps/health/app.js
+++ b/apps/health/app.js
@@ -103,8 +103,8 @@ function movementPerDay() {
   var data = new Uint16Array(31);
   var cnt = new Uint8Array(31);
   require("health").readDailySummaries(new Date(), h=>{
-    data[h.hr]+=h.movement
-    cnt[h.hr]++;
+    data[h.day]+=h.movement
+    cnt[h.day]++;
   });
   data.forEach((d,i)=>data[i] = d/cnt[i]);
   setButton(menuMovement);

--- a/apps/health/app.js
+++ b/apps/health/app.js
@@ -89,7 +89,7 @@ function movementPerHour() {
   var data = new Uint16Array(24);
   var cnt = new Uint8Array(24);
   require("health").readDay(new Date(), h=>{
-    data[h.hr]+=h.movement
+    data[h.hr]+=h.movement;
     cnt[h.hr]++;
   });
   data.forEach((d,i)=>data[i] = d/cnt[i]);
@@ -103,7 +103,7 @@ function movementPerDay() {
   var data = new Uint16Array(31);
   var cnt = new Uint8Array(31);
   require("health").readDailySummaries(new Date(), h=>{
-    data[h.day]+=h.movement
+    data[h.day]+=h.movement;
     cnt[h.day]++;
   });
   data.forEach((d,i)=>data[i] = d/cnt[i]);

--- a/apps/health/metadata.json
+++ b/apps/health/metadata.json
@@ -2,7 +2,7 @@
   "id": "health",
   "name": "Health Tracking",
   "shortName": "Health",
-  "version": "0.26",
+  "version": "0.27",
   "description": "Logs health data and provides an app to view it",
   "icon": "app.png",
   "tags": "tool,system,health",


### PR DESCRIPTION
This just fixes a typo introduced by commit 31fb8f8d02 which causes the movement daily summary graph to freeze on the “Loading…” screen and print an error to the console due to trying to access the field name “hr” when it should be “day”.

While I was at it, I noticed what I thought might have been a potential out-of-bounds subscripting error in the *PerDay() functions. The array size is 31 (indeces 0…30) but the indeces actually returned by readDailySummaries are 1…31. However, it appears that the graph never displays a partial day's data before it rolls over, so maybe this would never be a problem because presumably the 31st day of the month would not display? It's technically inconsistent with the fact that the hourly funcs dimension the array to 24 rather than 23, though, but since I'm not sure, I decided to leave that alone for now.