### PR TITLE
Add repeatCalls option

### DIFF
--- a/apps/messages/ChangeLog
+++ b/apps/messages/ChangeLog
@@ -4,3 +4,4 @@
 0.58: show/hide "messages" widget directly, instead of through library stub
 0.59: fixes message timeout by using setinterval, as it was intended. So the buzz is triggered every x seconds until the timeout occours.
 0.60: Bump version to allow new buzz.js module to be loaded - fixes memory/performance hog when buzz called
+0.61: Add repeatCalls option to allow different repeat settings for messages vs calls

--- a/apps/messages/lib.js
+++ b/apps/messages/lib.js
@@ -204,16 +204,18 @@ exports.buzz = function(msgSrc) {
   if ((require("Storage").readJSON("setting.json", 1) || {}).quiet) return Promise.resolve(); // never buzz during Quiet Mode
   const msgSettings = require("Storage").readJSON("messages.settings.json", true) || {};
   let pattern;
+  let repeat;
   if (msgSrc && msgSrc.toLowerCase()==="phone") {
     // special vibration pattern for incoming calls
     pattern = msgSettings.vibrateCalls;
+    repeat = msgSettings.repeatCalls;
   } else {
     pattern = msgSettings.vibrate;
+    repeat = msgSettings.repeat;
   }
   if (pattern===undefined) { pattern = ":"; } // pattern may be "", so we can't use || ":" here
   if (!pattern) return Promise.resolve();
 
-  let repeat = msgSettings.repeat;
   if (repeat===undefined) repeat = 4; // repeat may be zero
   if (repeat)
   {

--- a/apps/messages/metadata.json
+++ b/apps/messages/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messages",
   "name": "Messages",
-  "version": "0.60",
+  "version": "0.61",
   "description": "Library to handle, load and store message events received from Android/iOS",
   "icon": "app.png",
   "type": "module",

--- a/apps/messages/settings.js
+++ b/apps/messages/settings.js
@@ -6,7 +6,7 @@
     if (settings.vibrate===undefined) settings.vibrate=":";
     if (settings.vibrateCalls===undefined) settings.vibrateCalls=":";
     if (settings.repeat===undefined) settings.repeat=4;
-    if (settings.repeatCalls===undefined) settings.repeatCalls=4;
+    if (settings.repeatCalls===undefined) settings.repeatCalls=settings.repeat;
     if (settings.vibrateTimeout===undefined) settings.vibrateTimeout=60;
     if (settings.unreadTimeout===undefined) settings.unreadTimeout=60;
     if (settings.maxMessages===undefined) settings.maxMessages=3;

--- a/apps/messages/settings.js
+++ b/apps/messages/settings.js
@@ -6,6 +6,7 @@
     if (settings.vibrate===undefined) settings.vibrate=":";
     if (settings.vibrateCalls===undefined) settings.vibrateCalls=":";
     if (settings.repeat===undefined) settings.repeat=4;
+    if (settings.repeatCalls===undefined) settings.repeatCalls=4;
     if (settings.vibrateTimeout===undefined) settings.vibrateTimeout=60;
     if (settings.unreadTimeout===undefined) settings.unreadTimeout=60;
     if (settings.maxMessages===undefined) settings.maxMessages=3;
@@ -32,6 +33,12 @@
       min: 0, max: 10,
       format: v => v?v+"s":/*LANG*/"Off",
       onchange: v => updateSetting("repeat", v)
+    },
+    /*LANG*/'Repeat for calls': {
+      value: settings().repeatCalls,
+      min: 0, max: 10,
+      format: v => v?v+"s":/*LANG*/"Off",
+      onchange: v => updateSetting("repeatCalls", v)
     },
     /*LANG*/'Vibrate timer': {
       value: settings().vibrateTimeout,


### PR DESCRIPTION
This adds a second Repeat option for phone calls. I like having a single buzz for messages (sms/emails/etc.), but a continuing repeated buzzing for phone calls.

This seemed like a nice easy/small tweak, but let me know if there's anything that needs to change!