### PR TITLE
Fix spirit level when screen rotated

### DIFF
--- a/apps/slevel/ChangeLog
+++ b/apps/slevel/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Updated to work with both Bangle.js 1 and 2.
 0.03: Now also visible on Bangle.js 2
 0.04: Now work with different themes
+0.05: Take default rotation/reflection into account

--- a/apps/slevel/metadata.json
+++ b/apps/slevel/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "slevel",
   "name": "Spirit Level",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Show the current angle of the watch, so you can use it to make sure something is absolutely flat",
   "icon": "spiritlevel.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/slevel/spiritlevel.js
+++ b/apps/slevel/spiritlevel.js
@@ -2,6 +2,7 @@ g.clear();
 var old = {x:0,y:0};
 var W = g.getWidth();
 var H = g.getHeight();
+var defaultRotation = 0 | require('Storage').readJSON("setting.json").rotate;
 
 Bangle.on('accel',function(v) {
   var max = Math.max(Math.abs(v.x),Math.abs(v.y),Math.abs(v.z));
@@ -20,6 +21,17 @@ Bangle.on('accel',function(v) {
   var n = {
     x:E.clip(W/2+v.x*256,4,W-4),
     y:E.clip(H/2+v.y*256,4,H-4)};
+
+  if (defaultRotation === 1) {
+    n = {x:n.y,y:H-n.x};
+  } else if (defaultRotation === 2) {
+    n = {x:W-n.x,y:H-n.y};
+  } else if (defaultRotation === 3) {
+    n = {x:W-n.y,y:n.x};
+  } else if (defaultRotation === 4) {
+    n = {x:W-n.x,y:n.y};
+  }
+
   g.clearRect(old.x-3,old.y-3,old.x+6,old.y+6); // clear old marker
   g.setColor("#0f0");
   g.fillRect(n.x-3,n.y-3,n.x+6,n.y+6); // draw new marker


### PR DESCRIPTION
Take default rotation/reflection into account, as defined via the Settings app.