### PR TITLE
lightswitch: fix tap listener widget assumption

### DIFF
--- a/apps/lightswitch/ChangeLog
+++ b/apps/lightswitch/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Fix issue where .draw was being called by reference (not allowing widgets to be hidden)
 0.07: Handle the swipe event that is generated when draging to change light intensity, so it doesn't trigger some other swipe handler.
 0.08: Ensure boot code doesn't allocate and leave a gloval variable named 'settings'
+0.09: Handle lightswitch logic running before its widget has loaded

--- a/apps/lightswitch/lib.js
+++ b/apps/lightswitch/lib.js
@@ -6,7 +6,7 @@ exports = {
     // check for double tap and direction
     if (data.double) {
       // setup shortcut to this widget or load from storage
-      var w = global.WIDGETS ? WIDGETS.lightswitch : Object.assign({
+      var w = global.WIDGETS && WIDGETS.lightswitch || Object.assign({
         unlockSide: "",
         tapSide: "right",
         tapOn: "always",
@@ -31,7 +31,7 @@ exports = {
   // function to flash backlight
   flash: function(tOut) {
     // setup shortcut to this widget or load from storage
-    var w = global.WIDGETS ? WIDGETS.lightswitch : Object.assign({
+    var w = global.WIDGETS && WIDGETS.lightswitch || Object.assign({
       tOut: 3000,
       minFlash: 0.2,
       value: 1,

--- a/apps/lightswitch/metadata.json
+++ b/apps/lightswitch/metadata.json
@@ -2,7 +2,7 @@
   "id": "lightswitch",
   "name": "Light Switch Widget",
   "shortName": "Light Switch",
-  "version": "0.08",
+  "version": "0.09",
   "description": "A fast way to switch LCD backlight on/off, change the brightness and show the lock status. All in one widget.",
   "icon": "images/app.png",
   "screenshots": [


### PR DESCRIPTION
This ensures we always have a widget object (not `undefined`), even if the widget hasn't loaded.

Fixes #2985