### PR TITLE
gipy: fix links and trim whitespace

### DIFF
--- a/apps/gipy/README.md
+++ b/apps/gipy/README.md
@@ -19,7 +19,7 @@ It provides the following features :
 - display a local map around you, downloaded from openstreetmap
 - detects and buzzes if you leave the path
 - (optional) buzzes before sharp turns
-- (optional) buzzes before waypoints 
+- (optional) buzzes before waypoints
 (for example when you need to turn in https://mapstogpx.com/)
 - display instant / average speed
 - display distance to next point
@@ -114,7 +114,7 @@ slopes between path points. Don't expect to see small bumps on the road.
 Few settings for now (feel free to suggest me more) :
 
 - buzz on turns : should the watch buzz when reaching a waypoint ?
-- disable bluetooth : turn bluetooth off completely to try to save some power. 
+- disable bluetooth : turn bluetooth off completely to try to save some power.
 - lost distance : at which distance from path are you considered to be lost ?
 - wake-up speed : if you drive below this speed powersaving will disable itself
 - active-time : how long (in seconds) the screen should be turned on if activated before going back to sleep.
@@ -133,7 +133,7 @@ There are now two display modes :
 
 The algorithm works in the following ways :
 
-- some events will *activate* : the display will turn *active* 
+- some events will *activate* : the display will turn *active*
 - if no activation event occur for at least 10 seconds (or *active-time* setting) we switch back to *inactive*
 
 Activation events are the following :
@@ -167,8 +167,8 @@ I had to go back uphill by quite a distance.
 
 Feel free to give me feedback : is it useful for you ? what other features would you like ?
 
-If you want to raise issues the main repository is [https://github.com/wagnerf42/BangleApps](here) and
-the rust code doing the actual map computations is located [https://github.com/wagnerf42/gps](here).
+If you want to raise issues the main repository is [here](https://github.com/wagnerf42/BangleApps) and
+the rust code doing the actual map computations is located [here](https://github.com/wagnerf42/gps).
 You can try the cutting edge version at [https://wagnerf42.github.io/BangleApps/](https://wagnerf42.github.io/BangleApps/)
 
 frederic.wagner@imag.fr


### PR DESCRIPTION
@wagnerf42 coincidentally I used gipy the other morning - great app! This PR fixes the links in the readme (no need for a version bump since there's no code changes)

Closes #3010 