### PR TITLE
pomoplus: new setting and minor changes

### DIFF
--- a/apps/pomoplus/ChangeLog
+++ b/apps/pomoplus/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New app!
 0.02-0.04: Bug fixes
 0.05: Submitted to the app loader
+0.06: Added setting to show clock after start/resume

--- a/apps/pomoplus/app.js
+++ b/apps/pomoplus/app.js
@@ -1,3 +1,5 @@
+g.clear();
+
 Bangle.POMOPLUS_ACTIVE = true;  //Prevent the boot code from running. To avoid having to reload on every interaction, we'll control the vibrations from here when the user is in the app.
 
 const storage = require("Storage");
@@ -13,32 +15,36 @@ if (
 }
 
 function drawButtons() {
+  let w = g.getWidth();
+  let h = g.getHeight();
   //Draw the backdrop
-  const BAR_TOP = g.getHeight() - 24;
+  const BAR_TOP = h - 24;
   g.setColor(0, 0, 1).setFontAlign(0, -1)
-    .clearRect(0, BAR_TOP, g.getWidth(), g.getHeight())
-    .fillRect(0, BAR_TOP, g.getWidth(), g.getHeight())
+    .clearRect(0, BAR_TOP, w, h)
+    .fillRect(0, BAR_TOP, w, h)
     .setColor(1, 1, 1);
 
   if (!common.state.wasRunning) {  //If the timer was never started, only show a play button
-    g.drawImage(common.BUTTON_ICONS.play, g.getWidth() / 2, BAR_TOP);
+    g.drawImage(common.BUTTON_ICONS.play, w / 2, BAR_TOP);
   } else {
-    g.drawLine(g.getWidth() / 2, BAR_TOP, g.getWidth() / 2, g.getHeight());
+    g.drawLine(w / 2, BAR_TOP, w / 2, h);
     if (common.state.running) {
-      g.drawImage(common.BUTTON_ICONS.pause, g.getWidth() / 4, BAR_TOP)
-        .drawImage(common.BUTTON_ICONS.skip, g.getWidth() * 3 / 4, BAR_TOP);
+      g.drawImage(common.BUTTON_ICONS.pause, w / 4, BAR_TOP)
+        .drawImage(common.BUTTON_ICONS.skip, w * 3 / 4, BAR_TOP);
     } else {
-      g.drawImage(common.BUTTON_ICONS.reset, g.getWidth() / 4, BAR_TOP)
-        .drawImage(common.BUTTON_ICONS.play, g.getWidth() * 3 / 4, BAR_TOP);
+      g.drawImage(common.BUTTON_ICONS.reset, w / 4, BAR_TOP)
+        .drawImage(common.BUTTON_ICONS.play, w * 3 / 4, BAR_TOP);
     }
   }
 }
 
 function drawTimerAndMessage() {
+  let w = g.getWidth();
+  let h = g.getHeight();
   g.reset()
     .setFontAlign(0, 0)
     .setFont("Vector", 36)
-    .clearRect(0, 24, 176, 152)
+    .clearRect(w / 2 - 60, h / 2 - 34, w / 2 + 60, h / 2 + 34)
 
     //Draw the timer
     .drawString((() => {
@@ -53,7 +59,7 @@ function drawTimerAndMessage() {
 
       if (hours >= 1) return `${parseInt(hours)}:${pad(minutes)}:${pad(seconds)}`;
       else return `${parseInt(minutes)}:${pad(seconds)}`;
-    })(), g.getWidth() / 2, g.getHeight() / 2)
+    })(), w / 2, h / 2)
 
     //Draw the phase label
     .setFont("Vector", 12)
@@ -63,7 +69,7 @@ function drawTimerAndMessage() {
       else if (currentPhase == common.PHASE_SHORT_BREAK) return `Short break ${numShortBreaks + 1}/${common.settings.numShortBreaks}`;
       else return "Long break!";
     })(common.state.phase, common.state.numShortBreaks),
-      g.getWidth() / 2, g.getHeight() / 2 + 18);
+      w / 2, h / 2 + 18);
 
   //Update phase with vibation if needed
   if (common.getTimeLeft() <= 0) {
@@ -91,6 +97,7 @@ Bangle.on("touch", (button, xy) => {
     };
     setupTimerInterval();
     drawButtons();
+    if (common.settings.showClock) Bangle.showClock();
 
   } else if (common.state.running) {
     //If we are running, there are two buttons: pause and skip
@@ -127,6 +134,7 @@ Bangle.on("touch", (button, xy) => {
       drawTimerAndMessage();
       setupTimerInterval();
       drawButtons();
+      if (common.settings.showClock) Bangle.showClock();
     }
   }
 });

--- a/apps/pomoplus/common.js
+++ b/apps/pomoplus/common.js
@@ -105,14 +105,13 @@ exports.nextPhase = function (vibrate) {
 
     if (vibrate) {
         if (exports.state.phase == exports.PHASE_WORKING) {
-            Bangle.buzz(750, 1);
+            Bangle.buzz(800, 1);
         } else if (exports.state.phase == exports.PHASE_SHORT_BREAK) {
             Bangle.buzz();
             setTimeout(Bangle.buzz, 400);
         } else {
             Bangle.buzz();
-            setTimeout(Bangle.buzz, 400);
-            setTimeout(Bangle.buzz, 600);
+            setTimeout(Bangle.buzz, 400, 400);
         }
     }
 }

--- a/apps/pomoplus/metadata.json
+++ b/apps/pomoplus/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "pomoplus",
   "name": "Pomodoro Plus",
-  "version": "0.05",
+  "version": "0.06",
   "description": "A configurable pomodoro timer that runs in the background.",
   "icon": "icon.png",
   "type": "app",

--- a/apps/pomoplus/settings.js
+++ b/apps/pomoplus/settings.js
@@ -10,7 +10,8 @@ const storage = require("Storage");
             longBreak: 900000,                  //15 minute long break
             numShortBreaks: 3,                  //3 short breaks for every long break
             pausedTimerExpireTime: 21600000,    //If the timer was left paused for >6 hours, reset it on next launch
-            widget: false                       //If a widget is added in the future, whether the user wants it
+            showClock: false,                   //Show clock after start/resume
+            widget: false,                      //If a widget is added in the future, whether the user wants it
         };
     }
 
@@ -88,6 +89,13 @@ const storage = require("Storage");
                 if (value == 0) return "Off"
                 else return `${Math.floor(value / 3600000)}h ${(value % 3600000) / 60000}m`
             }
+        },
+        'Show clock': {
+            value: settings.showClock,
+            onchange: function(value) {
+                settings.showClock = value;
+                save();
+            },
         },
     };
     E.showMenu(menu)


### PR DESCRIPTION
see https://notevil.github.io/BangleApps/?q=pomoplus

- adds setting "Show clock"

If set, returns to clock (`Bangle.showClock()`) after start/resume.

- minor changes
  - (changed*) buzz pattern of long break
  - added `g.clear()` and adjusted `.clearRect` in `drawTimerAndMessage`
  - replaced `g.getWidth()` and `g.getHeight()` with `w` and `h`

@bruceblore is this in conflict with your vision for this app?

*nothing changed since atm the last buzz immediately follows the second one