### PR TITLE
backswipe: ignore `undefined` handlers

### DIFF
--- a/apps/backswipe/ChangeLog
+++ b/apps/backswipe/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Don't fire if the app uses swipes already.
+0.03: Only count defined handlers in the handler array.

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -26,7 +26,7 @@
     if (Bangle["#on"+eventType] === undefined) {
       return 0;
     } else if (Bangle["#on"+eventType] instanceof Array) {
-      return Bangle["#on"+eventType].length;
+      return Bangle["#on"+eventType].filter(x=>x).length;
     } else if (Bangle["#on"+eventType] !== undefined) {
       return 1;
     }

--- a/apps/backswipe/metadata.json
+++ b/apps/backswipe/metadata.json
@@ -1,7 +1,7 @@
 { "id": "backswipe",
   "name": "Back Swipe",
   "shortName":"BackSwipe",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Service that allows you to use an app's back button using left to right swipe gesture",
   "icon": "app.png",
   "tags": "back,gesture,swipe",


### PR DESCRIPTION
`undefined` handlers are created when we [remove listeners] part-way through the array. This fixes `backswipe` for all firmwares, but leaves the door open for a potential firmware change.

See also https://github.com/espruino/BangleApps/issues/2953#issuecomment-1747428051

[remove listeners]: https://github.com/bobrippling/Espruino/blob/0f16231a4369bb2d154b9fab5a0d806122cddb39/src/jswrap_object.c#L1035-L1035