### PR TITLE
alarm auto expiration for events + fix repeat back

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -46,3 +46,4 @@
 0.41: Fix a menu bug affecting alarms with empty messages.
 0.42: Fix date not getting saved in event edit menu when tapping Confirm
 0.43: New settings: Show confirm, Show Overflow, Show Type.
+0.44: Add "delete timer after expiration" setting to events.

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -106,6 +106,9 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
   var isNew = alarmIndex === undefined;
 
   var alarm = require("sched").newDefaultAlarm();
+  if (withDate) {
+    alarm.del = require("sched").getSettings().defaultDeleteExpiredTimers;
+  }
   alarm.dow = handleFirstDayOfWeek(alarm.dow);
 
   if (selectedAlarm) {
@@ -193,6 +196,9 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     /*LANG*/"Repeat": {
       value: decodeRepeat(alarm),
       onchange: () => setTimeout(showEditRepeatMenu, 100, alarm.rp, date || alarm.dow, (repeat, dow) => {
+        if (repeat) {
+          alarm.del = false; // do not auto delete a repeated alarm
+        }
         alarm.rp = repeat;
         alarm.dow = dow;
         prepareAlarmForSave(alarm, alarmIndex, time, date, true);
@@ -203,6 +209,10 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     /*LANG*/"Auto Snooze": {
       value: alarm.as,
       onchange: v => alarm.as = v
+    },
+    /*LANG*/"Delete After Expiration": {
+      value: alarm.del,
+      onchange: v => alarm.del = v
     },
     /*LANG*/"Hidden": {
       value: alarm.hidden || false,
@@ -225,6 +235,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     delete menu[/*LANG*/"Day"];
     delete menu[/*LANG*/"Month"];
     delete menu[/*LANG*/"Year"];
+    delete menu[/*LANG*/"Delete After Expiration"];
   }
 
   if (!isNew) {

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -106,7 +106,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
   var isNew = alarmIndex === undefined;
 
   var alarm = require("sched").newDefaultAlarm();
-  if (withDate) {
+  if (withDate || selectedAlarm.date) {
     alarm.del = require("sched").getSettings().defaultDeleteExpiredTimers;
   }
   alarm.dow = handleFirstDayOfWeek(alarm.dow);

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -294,7 +294,6 @@ function decodeRepeat(alarm) {
 }
 
 function showEditRepeatMenu(repeat, day, dowChangeCallback) {
-  var originalRepeat = repeat;
   var dow;
 
   const menu = {
@@ -327,26 +326,32 @@ function showEditRepeatMenu(repeat, day, dowChangeCallback) {
       },
       /*LANG*/"Custom": {
         value: isCustom ? decodeRepeat({ rp: true, dow: dow }) : false,
-        onchange: () => setTimeout(showCustomDaysMenu, 10, dow, dowChangeCallback, originalRepeat, originalDow)
+        onchange: () => setTimeout(showCustomDaysMenu, 10, dow, dowChangeCallback, repeat, originalDow)
       }
     };
   } else {
     // var date = day; // eventually: detect day of date and configure a repeat e.g. 3rd Monday of Month
     dow = EVERY_DAY;
-    repeat = repeat || {interval: "month", num: 1};
+    const repeatObj = repeat || {interval: "month", num: 1};
 
     restOfMenu = {
       /*LANG*/"Every": {
-        value: repeat.num,
+        value: repeatObj.num,
         min: 1,
-        onchange: v => repeat.num = v
+        onchange: v => {
+          repeat = repeatObj;
+          repeat.num = v;
+        }
       },
       /*LANG*/"Interval": {
-        value: INTERVALS.indexOf(repeat.interval),
+        value: INTERVALS.indexOf(repeatObj.interval),
         format: v => INTERVAL_LABELS[v],
         min: 0,
         max: INTERVALS.length - 1,
-        onchange: v => repeat.interval = INTERVALS[v]
+        onchange: v => {
+          repeat = repeatObj;
+          repeat.interval = INTERVALS[v];
+        }
       }
     };
   }

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.43",
+  "version": "0.44",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
auto expiration for events:
- Set default value
- Add "delete after expiration" checkbox to events.

repeat menu: Do not change value on back (fixes #2930)
Instead of saving repeat argument as originalRepeat create a new changed repeatObj