### PR TITLE
scicalc: Add swipe up action

### DIFF
--- a/apps/scicalc/ChangeLog
+++ b/apps/scicalc/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Swiping up has now the same effect as hitting the "<" button.

--- a/apps/scicalc/README.md
+++ b/apps/scicalc/README.md
@@ -5,7 +5,7 @@ by the JS interpreter.
 
 ## Usage
 
-Buttons are arranged on 3 separate screens, swiping left or right switches between them. Swiping down has the same effect as hitting the "=" button.
+Buttons are arranged on 3 separate screens, swiping left or right switches between them. Swiping down has the same effect as hitting the "=" button. Swiping up has the same effect as hitting the "<" button.
 
 ## Features
 

--- a/apps/scicalc/app.js
+++ b/apps/scicalc/app.js
@@ -114,5 +114,6 @@ function swipeHandler(e,d) {
 
 Bangle.on("touch", touchHandler);
 Bangle.on("swipe", swipeHandler);
+setWatch(() => load(), BTN, { repeat: false, edge: "falling" });
 g.clear();
 drawPage(curPage);

--- a/apps/scicalc/app.js
+++ b/apps/scicalc/app.js
@@ -69,8 +69,8 @@ function compute() {
   var res;
   console.log(processInp(inputStr));
   try { res = eval(processInp(inputStr)); }
-  catch(e) { res = "error"; } 
-  inputStr = res;
+  catch(e) { res = "error"; }
+  inputStr = res === undefined ? '' : res;
   qResult = true;
   updateDisp(inputStr, 19);
 }
@@ -105,6 +105,11 @@ function swipeHandler(e,d) {
   if (curPage<0) curPage = buttons.length-1;
   drawPage(curPage);
   if (d==1) compute();
+  else if (d==-1) {
+    if (inputStr.length>0) inputStr = inputStr.slice(0, -1); // delete last character
+    qResult = false;
+    updateDisp(inputStr, 32);
+  }
 }
 
 Bangle.on("touch", touchHandler);

--- a/apps/scicalc/metadata.json
+++ b/apps/scicalc/metadata.json
@@ -1,7 +1,7 @@
 { "id": "scicalc",
   "name": "Scientific Calculator",
   "shortName":"SciCalc",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Scientific calculator",
   "icon": "scicalc.png",
   "screenshots" : [ { "url":"scicalc_screenshot1.png" }, { "url":"scicalc_screenshot2.png" }, { "url":"scicalc_screenshot3.png" } ],


### PR DESCRIPTION
Swiping up has now the same effect as hitting the "<" button.

@berkenbu Hope this is ok with you. I find it easier to correct typos that quickly appear with a single swipe instead of navigating to the correct screen first.