### PR TITLE
setting: Prepend 'LCD->Calibration' touch listener

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -72,3 +72,5 @@ of 'Select Clock'
 0.63: Whitelist: Try to resolve peer addresses using NRF.resolveAddress() - for 2v19 or 2v18 cutting edge builds
       Remove 'beta' label from passkey - it's been around for a while and works ok
 0.64: Default to wakeOnTwist being off
+0.65: Prepend 'LCD->Calibration' touch listener and stop event propagation.
+

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.64",
+  "version": "0.65",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -899,6 +899,7 @@ function showTouchscreenCalibration() {
   }
 
   function touchHandler(_,e) {
+    E.stopEventPropagation&&E.stopEventPropagation();
     var spot = corners[currentCorner];
     // store averages
     if (spot[0]*2 < g.getWidth())
@@ -921,7 +922,7 @@ function showTouchscreenCalibration() {
     }
     showTapSpot();
   }
-  Bangle.on('touch', touchHandler);
+  Bangle.prependListener&&Bangle.prependListener('touch',touchHandler)||Bangle.on('touch',touchHandler);
 
   showTapSpot();
 }


### PR DESCRIPTION
...and stop event propagation.

Closes https://github.com/espruino/BangleApps/issues/2188

I thought about intercepting drag events as well. But didn't bother. Can add it if wanted.