### PR TITLE
OpenHaystack: Keep advertising when connected

### DIFF
--- a/apps/openhaystack/ChangeLog
+++ b/apps/openhaystack/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Keep advertising when connected

--- a/apps/openhaystack/custom.html
+++ b/apps/openhaystack/custom.html
@@ -40,7 +40,7 @@ const key = E.toUint8Array(atob(${JSON.stringify(keyValue)})); // public key
 const mac = [ key[0] | 0b11000000, key[1], key[2], key[3], key[4], key[5] ].map(x => x.toString(16).padStart(2, '0')).join(':'); // mac address
 const adv = [ 0x1e, 0xff, 0x4c, 0x00, 0x12, 0x19, 0x00, key[6], key[7], key[8], key[9], key[10], key[11], key[12], key[13], key[14], key[15], key[16], key[17], key[18], key[19], key[20], key[21], key[22], key[23], key[24], key[25], key[26], key[27], key[0] >> 6, 0x00 ]; // advertising packet
 NRF.setAddress(mac);
-NRF.setAdvertising([adv,{}]); // advertise AirTag *and* normal device name (to remain connectable)
+NRF.setAdvertising([adv,{}],{whenConnected: true, interval: 1000}); // advertise AirTag *and* normal device name (to remain connectable)
 }
 `;
         // send finished app

--- a/apps/openhaystack/metadata.json
+++ b/apps/openhaystack/metadata.json
@@ -1,7 +1,7 @@
 { "id": "openhaystack",
   "name": "OpenHaystack (AirTag)",
   "icon": "icon.png",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Copy a base64 key from https://github.com/seemoo-lab/openhaystack and make your Bangle.js trackable as if it's an AirTag",
   "tags": "openhaystack,bluetooth,ble,tracking,airtag",
   "type": "bootloader",


### PR DESCRIPTION
A small modification to keep advertising as airtag when connected.

It still advertises both airtag and normal device name when connected.
Ideally it should be only airtag advertissment when connected (every 2000ms), and back to both (every 375ms) when disconnected.
