### PR TITLE
pebbled: prevent exceptions halting the draw cycle

### DIFF
--- a/apps/pebbled/ChangeLog
+++ b/apps/pebbled/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Swipe down to see widgets
       Support for fast loading
 0.04: Localisation request: added Miles and AM/PM
+0.05: Prevent exceptions from halting the draw cycle

--- a/apps/pebbled/metadata.json
+++ b/apps/pebbled/metadata.json
@@ -2,7 +2,7 @@
   "id": "pebbled",
   "name": "Pebble Clock with distance",
   "shortName": "Pebble + distance",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Fork of Pebble Clock with distance in KM. Both step count and the distance are on the main screen. Default step length = 0.75m (can be changed in settings).",
   "readme": "README.md",
   "icon": "pebbled.png",

--- a/apps/pebbled/pebbled.app.js
+++ b/apps/pebbled/pebbled.app.js
@@ -37,6 +37,13 @@ const h3 = 7*h/8 - 10;
 let batteryWarning = false;
 
 let draw = function() {
+  // queue next draw
+  if (drawTimeout) clearTimeout(drawTimeout);
+  drawTimeout = setTimeout(function() {
+    drawTimeout = undefined;
+    draw();
+  }, 60000 - (Date.now() % 60000));
+
   let date = new Date();
   let da = date.toString().split(" ");
   let timeStr = settings.localization === "US" ? tConv24(da[4].substr(0,5)) : da[4].substr(0,5);
@@ -101,13 +108,6 @@ let draw = function() {
   else
     g.setColor('#000'); // otherwise black regardless of theme
   g.drawString(distanceStr, w/2, ha + 107);
-
-  // queue next draw
-  if (drawTimeout) clearTimeout(drawTimeout);
-  drawTimeout = setTimeout(function() {
-    drawTimeout = undefined;
-    draw();
-  }, 60000 - (Date.now() % 60000));
 };
 
 // at x,y width:wi thicknes:th


### PR DESCRIPTION
This ensures `pebbled` continues to draw - similar changes could be made to `pebble` and `pebblepp`, but the former has had no bugs reported and the latter's code is simple enough that it doesn't appear likely to raise exceptions when drawing.

The issue is likely an exception in `pebbled`'s drawing code, but this solves the watch redraw problem while we wait to hear about possible debug logs.

Closes #3043.