### PR TITLE
CalClock: Add buzzing before events

### DIFF
--- a/apps/calclock/ChangeLog
+++ b/apps/calclock/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Improve current time readability in light theme.
 0.05: Show calendar colors & improved all day events.
 0.06: Improved multi-line locations & titles
+0.07: Buzz 30, 15 and 1 minute before an event

--- a/apps/calclock/calclock.js
+++ b/apps/calclock/calclock.js
@@ -117,6 +117,17 @@ function fullRedraw() {
   drawFutureEvents(y);
 }
 
+function buzzForEvents() {
+  let nextEvent = next[0]; if (!nextEvent) return;
+  if (nextEvent.allDay) return;
+  let minToEvent = Math.round((nextEvent.timestamp - getTime()) / 60.0);
+  switch (minToEvent) {
+    case 30: require("buzz").pattern(","); break;
+    case 15: require("buzz").pattern(", ,"); break;
+    case 1: require("buzz").pattern(": : :"); break;
+  }
+}
+
 function redraw() {
   g.reset();
   if (current.find(e=>!isActive(e)) || next.find(isActive)) {
@@ -124,10 +135,12 @@ function redraw() {
   } else {
     drawCurrentEvents(30);
   }
+  buzzForEvents();
 }
 
 g.clear();
 fullRedraw();
+buzzForEvents();
 var minuteInterval = setInterval(redraw, 60 * 1000);
 
 Bangle.setUI("clock");

--- a/apps/calclock/metadata.json
+++ b/apps/calclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "calclock",
   "name": "Calendar Clock",
   "shortName": "CalClock",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Show the current and upcoming events synchronized from Gadgetbridge",
   "icon": "calclock.png",
   "type": "clock",


### PR DESCRIPTION
The main reason why I developed CalClock is for me to not make sure I don't forget any upcoming events I have in my calendar.

So I added a subtle buzzing that notifies me of upcoming events.

TODO: In future I want to put this into the boot code, as then I could always be reminded of upcoming events, even if I have any other app open.