### PR TITLE
sunrise: redraw the clock exactly when a minute ticks

### DIFF
--- a/apps/sunrise/ChangeLog
+++ b/apps/sunrise/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Show day/month, add animations, fix !mylocation and text glitch
 0.04: Always show the widgets, swifter animations and lighter sea line
 0.05: Fixed hours increasing too early, added missing 23 o'clock, simplified code
+0.06: Draw the screen exactly on the minute boundary

--- a/apps/sunrise/app.js
+++ b/apps/sunrise/app.js
@@ -358,13 +358,18 @@ function initialAnimation () {
   initialAnimationFrame();
 }
 
+function renderAndQueue() {
+  setTimeout(renderAndQueue, 60000 - (Date.now() % 60000));
+  renderScreen();
+}
+
 function main () {
   sunRiseX = xfromTime(sunrise.getHours() + sunrise.getMinutes() / 60);
   sunSetX = xfromTime(sunset.getHours() + sunset.getMinutes() / 60);
   
   g.setBgColor(0, 0, 0);
   g.clear();
-  setInterval(renderScreen, 60 * 1000);
+  renderAndQueue();
   initialAnimation();
 }
 

--- a/apps/sunrise/metadata.json
+++ b/apps/sunrise/metadata.json
@@ -2,7 +2,7 @@
   "id": "sunrise",
   "name": "Sunrise",
   "shortName": "Sunrise",
-  "version": "0.05",
+  "version": "0.06",
   "type": "clock",
   "description": "Show sunrise and sunset times",
   "icon": "app.png",


### PR DESCRIPTION
A minor tweak to sunrise - ensure we render the clock when a minute ticks over, so the time shown on screen lines up with other widgets (e.g. chimer).

Leaving as a draft until #3063 is merged, to avoid introducing conflicts.