### PR TITLE
fastreset:(partly) fix accidental load of launcher

### DIFF
--- a/apps/fastreset/ChangeLog
+++ b/apps/fastreset/ChangeLog
@@ -1,2 +1,5 @@
 0.01: New App!
 0.02: Shorten the timeout before executing to 250 ms.
+0.03: Add inner timeout of 150 ms so user has more time to release the button
+	before clock ui is initialized and adds it's button watch for going to
+	launcher.

--- a/apps/fastreset/boot.js
+++ b/apps/fastreset/boot.js
@@ -1,5 +1,5 @@
 {let buzzTimeout;
 setWatch((e)=>{
-  if (e.state) buzzTimeout = setTimeout(()=>{Bangle.buzz(80,0.40);Bangle.showClock();}, 250);
+  if (e.state) buzzTimeout = setTimeout(()=>{Bangle.buzz(80,0.40);setTimeout(Bangle.showClock,150);}, 250);
   if (!e.state && buzzTimeout) clearTimeout(buzzTimeout);},
-BTN,{repeat:true, edge:'both' });}
+BTN,{repeat:true,edge:'both'});}

--- a/apps/fastreset/metadata.json
+++ b/apps/fastreset/metadata.json
@@ -1,7 +1,7 @@
 { "id": "fastreset",
   "name": "Fast Reset",
   "shortName":"Fast Reset",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Reset the watch by pressing the hardware button just a little bit longer than a click. If 'Fastload Utils' is installed this will typically be done with fastloading. A buzz acts as indicator.",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Add inner timeout of 150 ms so user has more time to release the button before clock ui is initialized and adds it's button watcher for going to launcher.

Install this update (v.0.03) from my app loader: https://thyttan.github.io/BangleApps/?q=fastreset

Ideally I'd want to use something else than the inner timeout. But the other things I tested didn't work out. I haven't tried with a promise which maybe could be better. But I don't see how I'd make it work here.

I tried e.g.:
```js
{let buzzTimeout;
 let shouldReset;
 setWatch((e)=>{
   if (buzzTimeout) {clearTimeout(buzzTimeout); buzzTimeout=undefined;}
   if (shouldReset) {shouldReset=undefined; Bangle.showClock();}
   if (e.state) buzzTimeout = setTimeout(()=>{Bangle.buzz(80,0.40);shouldReset=true;}, 250);
 },
 BTN,{repeat:true,edge:'both'});
}
```
*If button is held for 250 ms and then released the Bangle.showClock() in the second if-statement is called.*

... but that will break fastloading (with and without fastload utils present) and will even slow load the launcher from the clock face (instead of reinitialising the clock by fastloading which would be the desired behavior).