### PR TITLE
cards: hiding widgets while showing the code

### DIFF
--- a/apps/cards/ChangeLog
+++ b/apps/cards/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Simple app to display loyalty cards
+0.02: Hiding widgets while showing the code

--- a/apps/cards/app.js
+++ b/apps/cards/app.js
@@ -18,9 +18,8 @@ Bangle.drawWidgets();
 const WHITE=-1
 const BLACK=0
 
-var FILE = "android.cards.json";
-
-var Locale = require("locale");
+const Locale = require("locale");
+const widget_utils = require('widget_utils');
 
 var fontSmall = "6x8";
 var fontMedium = g.getFonts().includes("6x15")?"6x15":"6x8:2";
@@ -90,6 +89,7 @@ function printLinearCode(binary) {
 }
 
 function showCode(card) {
+  widget_utils.hide();
   E.showScroller();
   // keeping it on rising edge would come back twice..
   setWatch(()=>showCard(card), BTN, {edge:"falling"});
@@ -151,6 +151,7 @@ function showCard(card) {
   var titleColor = g.theme.fg2;
   if (card.color)
     titleColor = isLight(titleBgColor) ? BLACK : WHITE;
+  widget_utils.show();
   E.showScroller({
     h : g.getFontHeight(), // height of each menu item in pixels
     c : lines.length, // number of menu items

--- a/apps/cards/metadata.json
+++ b/apps/cards/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "cards",
   "name": "Cards",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Display loyalty cards",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot_cards_overview.png"}, {"url":"screenshot_cards_card1.png"}, {"url":"screenshot_cards_card2.png"}, {"url":"screenshot_cards_barcode.png"}, {"url":"screenshot_cards_qrcode.png"}],


### PR DESCRIPTION
With this PR we hide widgets while showing the barcode/QR and show them back while going back to the card's info. In this way, widgets are not covering part of the displayed code

Fixes: https://github.com/espruino/BangleApps/issues/3052