### PR TITLE
astral: setUI before loading widgets

### DIFF
--- a/apps/astral/ChangeLog
+++ b/apps/astral/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Added adjustment for Bangle.js magnetometer heading fix
 0.06: optimized to update much faster
 0.07: added support for bangle.js 2
+0.08: call setUI before loading widgets to indicate we're a clock

--- a/apps/astral/app.js
+++ b/apps/astral/app.js
@@ -850,6 +850,8 @@ g.setBgColor(0, 0, 0);
 g.fillRect(0, 0, 175, 175);
 current_moonphase = getMoonPhase();
 
+Bangle.setUI("clock");
+
 // Load widgets
 Bangle.loadWidgets();
 Bangle.drawWidgets();
@@ -864,8 +866,6 @@ Bangle.setCompassPower(1);
 Bangle.setGPSPower(1);
 
 var secondInterval;
-
-Bangle.setUI("clock");
 
 autoUpdate();
 

--- a/apps/astral/metadata.json
+++ b/apps/astral/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "astral",
   "name": "Astral Clock",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Clock that calculates and displays Alt Az positions of all planets, Sun as well as several other astronomy targets (customizable) and current Moon phase. Coordinates are calculated by GPS & time and onscreen compass assists orienting. See Readme before using.",
   "icon": "app-icon.png",
   "type": "clock",


### PR DESCRIPTION
This fixes the sanity check warning:
```
Clock astral file calls loadWidgets before setUI (clock widget/etc won't be aware a clock app is running)
```

(there's no affected code between the old and new locations of `setUI()`)