### PR TITLE
settings: lcd calibration bug

### DIFF
--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -922,7 +922,7 @@ function showTouchscreenCalibration() {
     }
     showTapSpot();
   }
-  Bangle.prependListener&&Bangle.prependListener('touch',touchHandler)||Bangle.on('touch',touchHandler);
+  Bangle.prependListener?Bangle.prependListener('touch',touchHandler):Bangle.on('touch',touchHandler);
 
   showTapSpot();
 }


### PR DESCRIPTION
The code logic does not work because the function with no return, returns undefined. Ends up that both `prependListener` and `on` are called, creating 2 callbacks, yet only 1 is removed.

Noticed it from running lcd calibration, then touch anything else and it goes back into calibration.