### PR TITLE
Add weather and calendar data to iOS integration

### DIFF
--- a/apps/ios/ChangeLog
+++ b/apps/ios/ChangeLog
@@ -13,3 +13,4 @@
 0.13: Making ANCS message receive more resilient (#2402)
 0.14: Add settings page, allow time sync
       Allow negative/positive actions to pass through to message GUI
+0.15: Enable calendar and weather updates via custom notifications (via shortcuts app)

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -29,6 +29,24 @@ for now. It's just a few bucks/pounds/euro's.
 If you like to try a free app first, you can always use NRF Toolbox or
 Bluetooth BLE Device Finder to find and connect your Bangle.
 
+### Weather and Calendar
+
+By using the `Shortcuts` app on your phone, you can send weather and calendar data to your watch. This works by sending a notification, which is read by the watch through ANCS. The watch then parses the notification for the data.
+
+While you may write your own shortcuts if you prefer (for example, to get weather from a different source), two are provided:
+
+- Calendar shortcut: https://www.icloud.com/shortcuts/4eac12548b4c424dbcdb1bd58cff338f
+- Weather shortcut: https://www.icloud.com/shortcuts/106c68bfac3746fe9a55761a3be8d092
+
+The weather shortcut requires an OpenWeatherMap api key, which you can get for free from https://openweathermap.org/api. The shortcut will prompt you for this when you add it to your phone.
+
+These shortcuts can also be automated to run periodically, for example every hour, using the `Automation` tab in the Shortcuts app.
+
+The shortcuts will send a notification, which can be annoying. One potential workaround for this would be to create a focus mode, and have an automation:
+- activate the focus mode (hiding notifications from the shortcut)
+- run the shortcut
+- deactivate the focus mode
+
 
 ## Requests
 

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -190,7 +190,7 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
-    Terminal.println("'" + msg.Title + "'");
+    Terminal.println("'" + msg.subtitle + "'");
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -160,7 +160,6 @@ E.on('notify',msg=>{
   };
   var replacer = ""; //(n)=>print('Unknown unicode '+n.toString(16));
   //if (appNames[msg.appId]) msg.a
-  Terminal.println("'" + msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) + "'");
   if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpCalendar") {
     // parse the message body into json:
     const d = JSON.parse(msg.message);
@@ -205,6 +204,7 @@ E.on('notify',msg=>{
     return;
   }
   if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpWeather") {
+    Terminal.println("Weather");
     const d = JSON.parse(msg.message);
     /* Example:
     {"temp":"291.07","hi":"293.02","lo":"288.18","hum":"49","rain":"0","uv":"0","wind":"1.54","code":"01d","txt":"Mostly Sunny","wdir":"303","loc":"Berlin"}
@@ -226,7 +226,6 @@ E.on('notify',msg=>{
         loc: d.loc
     }
     require("weather").update(weatherEvent);
-    Terminal.println("received weather data");
     NRF.ancsAction(msg.uid, false);
     return;
   }

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -160,7 +160,7 @@ E.on('notify',msg=>{
   };
   var replacer = ""; //(n)=>print('Unknown unicode '+n.toString(16));
   //if (appNames[msg.appId]) msg.a
-  if (msg.title === "BangleDumpCalendar") {
+  if (msg.appId === "com.apple.shortcuts") {
     // parse the message body into json:
     const d = JSON.parse(msg.message);
     /* Example:

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -204,7 +204,6 @@ E.on('notify',msg=>{
     return;
   }
   if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpWeather") {
-    Terminal.println("Weather");
     const d = JSON.parse(msg.message);
     /* Example:
     {"temp":"291.07","hi":"293.02","lo":"288.18","hum":"49","rain":"0","uv":"0","wind":"1.54","code":"01d","txt":"Mostly Sunny","wdir":"303","loc":"Berlin"}

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -191,6 +191,7 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
+    Terminal.println("Calendar event " + calEvent.title + " received.")
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -204,7 +204,7 @@ E.on('notify',msg=>{
     NRF.ancsAction(msg.uid, false);
     return;
   }
-  else if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpWeather") {
+  if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpWeather") {
     const d = JSON.parse(msg.message);
     /* Example:
     {"temp":"291.07","hi":"293.02","lo":"288.18","hum":"49","rain":"0","uv":"0","wind":"1.54","code":"01d","txt":"Mostly Sunny","wdir":"303","loc":"Berlin"}

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -170,11 +170,39 @@ E.on('notify',msg=>{
     "duration":"1:00:00",
     "notes": "This is a test event.",
     "location": "Stonehenge Amesbury, Wiltshire, SP4 7DE, England",
-    "calName": "Home"
+    "calName": "Home",
+    "id": "1234567890"
     }
+    and we want to convert to:
+    {t:"calendar", id:int, type:int, timestamp:seconds, durationInSeconds, title:string, description:string,location:string,calName:string.color:int,allDay:bool
+    for gadgetbridge
      */
     console.log(d, d.title, d.start_time, d.duration, d.notes, d.location, d.calName);
+    calEvent = {
+      t: "calendar",
+      id: parseInt(d.id),
+      type: 0,
+      timestamp: Date.parse(d.start_time) / 1000,
+      durationInSeconds: d.duration ? d.duration.split(":").reduce((a, b) => a * 60 + parseInt(b)) : 0,
+      title: d.title,
+      description: d.notes,
+      location: d.location,
+      calName: d.calName,
+      color: 0,
+      allday: false
+    }
+    calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
+    var cal = require("Storage").readJSON("android.calendar.json",true);
+    if (!cal || !Array.isArray(cal)) cal = [];
+    var i = cal.findIndex(e=>e.id==calEvent.id);
+    if(i<0)
+      cal.push(calEvent);
+    else
+      cal[i] = calEvent;
+    require("Storage").writeJSON("android.calendar.json", cal);
+    NRF.ancsAction(msg.uid, false);
+    return;
   }
   require("messages").pushMessage({
     t : msg.event,

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -160,6 +160,7 @@ E.on('notify',msg=>{
   };
   var replacer = ""; //(n)=>print('Unknown unicode '+n.toString(16));
   //if (appNames[msg.appId]) msg.a
+  Terminal.println("'" + msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) + "'");
   if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpCalendar") {
     // parse the message body into json:
     const d = JSON.parse(msg.message);
@@ -190,7 +191,6 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
-    Terminal.println("'" + msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) + "'");
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -226,6 +226,7 @@ E.on('notify',msg=>{
         loc: d.loc
     }
     require("weather").update(weatherEvent);
+    Terminal.println("received weather data");
     NRF.ancsAction(msg.uid, false);
     return;
   }

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -199,6 +199,7 @@ E.on('notify',msg=>{
       cal.push(calEvent);
     else
       cal[i] = calEvent;
+    cal = cal.filter(e=>e.timestamp>=Date.now()/1000);
     require("Storage").writeJSON("android.calendar.json", cal);
     NRF.ancsAction(msg.uid, false);
     return;

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -160,7 +160,7 @@ E.on('notify',msg=>{
   };
   var replacer = ""; //(n)=>print('Unknown unicode '+n.toString(16));
   //if (appNames[msg.appId]) msg.a
-  if (msg.appId === "com.apple.shortcuts") {
+  if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpCalendar") {
     // parse the message body into json:
     const d = JSON.parse(msg.message);
     /* Example:
@@ -204,6 +204,32 @@ E.on('notify',msg=>{
     NRF.ancsAction(msg.uid, false);
     return;
   }
+  else if (msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) === "BangleDumpWeather") {
+    const d = JSON.parse(msg.message);
+    /* Example:
+    {"temp":"291.07","hi":"293.02","lo":"288.18","hum":"49","rain":"0","uv":"0","wind":"1.54","code":"01d","txt":"Mostly Sunny","wdir":"303","loc":"Berlin"}
+    what we want:
+    t:"weather", temp,hi,lo,hum,rain,uv,code,txt,wind,wdir,loc
+     */
+    weatherEvent = {
+        t: "weather",
+        temp: d.temp,
+        hi: d.hi,
+        lo: d.lo,
+        hum: d.hum,
+        rain: d.rain,
+        uv: d.uv,
+        code: d.code,
+        txt: d.txt,
+        wind: d.wind,
+        wdir: d.wdir,
+        loc: d.loc
+    }
+    require("weather").update(weatherEvent);
+    NRF.ancsAction(msg.uid, false);
+    return;
+  }
+
   require("messages").pushMessage({
     t : msg.event,
     id : msg.uid,

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -177,12 +177,11 @@ E.on('notify',msg=>{
     {t:"calendar", id:int, type:int, timestamp:seconds, durationInSeconds, title:string, description:string,location:string,calName:string.color:int,allDay:bool
     for gadgetbridge
      */
-    console.log(d, d.title, d.start_time, d.duration, d.notes, d.location, d.calName);
     calEvent = {
       t: "calendar",
       id: parseInt(d.id),
       type: 0,
-      timestamp: Date.parse(d.start_time) / 1000,
+      timestamp: Date.parse(d.start_time.slice(0, -5)) / 1000,
       durationInSeconds: d.duration ? d.duration.split(":").reduce((a, b) => a * 60 + parseInt(b)) : 0,
       title: d.title,
       description: d.notes,
@@ -191,7 +190,7 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
-    Terminal.println("Calendar event " + calEvent.title + " received.")
+    Terminal.println("'" + msg.Title + "'");
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -190,7 +190,7 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
-    Terminal.println("'" + msg.name + "'");
+    Terminal.println("'" + msg.title&&E.decodeUTF8(msg.title, unicodeRemap, replacer) + "'");
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -160,6 +160,22 @@ E.on('notify',msg=>{
   };
   var replacer = ""; //(n)=>print('Unknown unicode '+n.toString(16));
   //if (appNames[msg.appId]) msg.a
+  if (msg.title === "BangleDumpCalendar") {
+    // parse the message body into json:
+    const d = JSON.parse(msg.message);
+    /* Example:
+    {
+    "title": "Test Event",
+    "start_time": "2023-11-10T11:00:00-08:00",
+    "duration":"1:00:00",
+    "notes": "This is a test event.",
+    "location": "Stonehenge Amesbury, Wiltshire, SP4 7DE, England",
+    "calName": "Home"
+    }
+     */
+    console.log(d, d.title, d.start_time, d.duration, d.notes, d.location, d.calName);
+
+  }
   require("messages").pushMessage({
     t : msg.event,
     id : msg.uid,

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -190,7 +190,7 @@ E.on('notify',msg=>{
       color: 0,
       allday: false
     }
-    Terminal.println("'" + msg.subtitle + "'");
+    Terminal.println("'" + msg.name + "'");
     calEvent.allday = calEvent.durationInSeconds >= 24 * 56 * 60 - 1; // 24 hours for IOS is 23:59:59
 
     var cal = require("Storage").readJSON("android.calendar.json",true);

--- a/apps/ios/metadata.json
+++ b/apps/ios/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "ios",
   "name": "iOS Integration",
-  "version": "0.14",
+  "version": "0.15",
   "description": "Display notifications/music/etc from iOS devices",
   "icon": "app.png",
   "tags": "tool,system,ios,apple,messages,notifications",

--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -22,3 +22,4 @@
 0.23: Update clock_info to avoid a redraw
 0.24: Redraw clock_info on update and provide color field for condition
 0.25: Added monochrome parameter to drawIcon in lib
+0.26: Expose update function (for use by iOS integration)

--- a/apps/weather/lib.js
+++ b/apps/weather/lib.js
@@ -36,11 +36,12 @@ function update(weatherEvent) {
     delete json.weather;
   }
 
+
   storage.write('weather.json', json);
   scheduleExpiry(json);
   exports.emit("update", json.weather);
 }
-
+exports.update = update;
 const _GB = global.GB;
 global.GB = (event) => {
   if (event.t==="weather") update(event);

--- a/apps/weather/metadata.json
+++ b/apps/weather/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "weather",
   "name": "Weather",
-  "version": "0.25",
-  "description": "Show Gadgetbridge weather report",
+  "version": "0.26",
+  "description": "Show Gadgetbridge/iOS weather report",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],
   "tags": "widget,outdoors,clkinfo",


### PR DESCRIPTION
Adds the ability for the bangle.js to receive weather data contained in custom notifications.

Calendar shortcut: https://www.icloud.com/shortcuts/baee5a95a55a4c5c8e6e582e09db020f
Weather shortcut: https://www.icloud.com/shortcuts/f21cd4c1753445a4aadec84b55c3e7e6
(requires OWM api key)

- [x] Calendar
    - [x] on Bangle.js
    - [x] ios shortcut
- [x] Weather
    - [x] on Bangle.js
    - [x] ios shortcut
    
**Caveats:**

While notifications are automatically dismissed, they take up the top of the screen for a few seconds
 - this can be avoided with a focus mode

Calendar does not send the `color` field
 - defaults to `0`
 - I couldn't figure out how to do this on the side of iOS. It may be possible to replicate this by assigning calendar names to colors.

Weather does not give a forecast--just the current weather conditions
 - this might be an issue with my understanding of the bangle.js weather library

relevant forums discussion: https://forum.espruino.com/conversations/387583/