### PR TITLE
recorder: handle initial/non-settings load

### DIFF
--- a/apps/recorder/ChangeLog
+++ b/apps/recorder/ChangeLog
@@ -41,3 +41,4 @@
 0.32: Add cadence data to output files
 0.33: Ensure that a new file is always created if the stuff that's being recorded has changed (fix #3081)
 0.34: Avoid prompting when creating a new file (#3081)
+0.35: Handle loading without a settings file (default record setting)

--- a/apps/recorder/metadata.json
+++ b/apps/recorder/metadata.json
@@ -2,7 +2,7 @@
   "id": "recorder",
   "name": "Recorder",
   "shortName": "Recorder",
-  "version": "0.34",
+  "version": "0.35",
   "description": "Record GPS position, heart rate and more in the background, then download to your PC.",
   "icon": "app.png",
   "tags": "tool,outdoors,gps,widget,clkinfo",

--- a/apps/recorder/widget.js
+++ b/apps/recorder/widget.js
@@ -161,7 +161,7 @@
     return recorders;
   }
 
-  let getActiveRecorders = function() {
+  let getActiveRecorders = function(settings) {
     let activeRecorders = [];
     let recorders = getRecorders();
     settings.record.forEach(r => {
@@ -206,7 +206,7 @@
 
     if (settings.recording) {
       // set up recorders
-      activeRecorders = getActiveRecorders();
+      activeRecorders = getActiveRecorders(settings);
       activeRecorders.forEach(activeRecorder => {
         activeRecorder.start();
       });
@@ -255,7 +255,7 @@
       }
       var headers = require("Storage").open(settings.file,"r").readLine();
       if (headers){ // if file exists
-        if(headers.trim()!==getCSVHeaders(getActiveRecorders()).join(",")){
+        if(headers.trim()!==getCSVHeaders(getActiveRecorders(settings)).join(",")){
           // headers don't match, reset (#3081)
           options.force = "new";
         }

--- a/apps/recorder/widget.js
+++ b/apps/recorder/widget.js
@@ -9,6 +9,8 @@
     settings.period = settings.period||10;
     if (!settings.file || !settings.file.startsWith("recorder.log"))
       settings.recording = false;
+    if (!settings.record)
+      settings.record = ["gps"];
     return settings;
   }
 


### PR DESCRIPTION
Resolves [an issue](https://github.com/espruino/BangleApps/pull/3098#issuecomment-1813310835) where the recorder widget might load without having a settings file, leading to:

```
>
Uncaught Error: Cannot read property 'forEach' of undefined
 at line 1 col 2805 in recorder.wid.js
...Recorders();settings.record.forEach(r=>{var recorder=recorders[r...
                                  ^
in function "getActiveRecorders" called from line 1 col 4959 in recorder.wid.js
...Headers(getActiveRecorders()).join(",")){options.force="new"...
                              ^
in function "setRecording" called from line 11 col 368 in recorder.app.js
...["recorder"].setRecording(v).then(function(){loadSettings();showMai...
                                     ^
in function called from system
```