### PR TITLE
altimeter: use system variables to calibrate altimeter.

### DIFF
--- a/apps/altimeter/ChangeLog
+++ b/apps/altimeter/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Actually upload correct code
 0.03: Display sea-level pressure, too, and allow calibration
+0.04: Switch to using system code for pressure calibration

--- a/apps/altimeter/app.js
+++ b/apps/altimeter/app.js
@@ -6,8 +6,7 @@ Bangle.drawWidgets();
 var R = Bangle.appRect;
 var y = R.y + R.h/2;
 var MEDIANLENGTH = 20;
-var avr = [], median;
-var value = 0;
+var avr = [];
 
 function fmt(t) {
   if ((t > -100) && (t < 1000))
@@ -20,25 +19,28 @@ function fmt(t) {
 Bangle.on('pressure', function(e) {
   while (avr.length>MEDIANLENGTH) avr.pop();
   avr.unshift(e.altitude);
-  median = avr.slice().sort();
+  let median = avr.slice().sort();
   g.reset().clearRect(0,y-30,g.getWidth()-10,R.h);
   if (median.length>10) {
     var mid = median.length>>1;
-    value = E.sum(median.slice(mid-4,mid+5)) / 9;
-    t = fmt(value);
-    g.setFont("Vector",50).setFontAlign(0,0).drawString(t, g.getWidth()/2, y);
+    var value = E.sum(median.slice(mid-4,mid+5)) / 9;
+  } else {
+    var value = median[median.length>>1];
+  }
+  t = fmt(value);
 
-    let o = Bangle.getOptions();
-    let sea = o.seaLevelPressure;
-    t = fmt(sea) + " " + e.temperature.toFixed(1);
-    if (0) {
+  g.setFont("Vector",50).setFontAlign(0,0).drawString(t, g.getWidth()/2, y);
+
+  let o = Bangle.getOptions();
+  let sea = o.seaLevelPressure;
+  t = sea.toFixed(1) + " " + e.temperature.toFixed(1);
+  if (0) {
       print("alt raw:", value.toFixed(1));
       print("temperature:", e.temperature);
       print("pressure:", e.pressure);
       print("sea pressure:", sea);
-    }
-    g.setFont("Vector",25).setFontAlign(-1,0).drawString(t, 10, R.y+R.h - 35);
   }
+    g.setFont("Vector",25).setFontAlign(-1,0).drawString(t, 10, R.y+R.h - 35);
 });
 
 function setPressure(m, a) {
@@ -46,6 +48,7 @@ function setPressure(m, a) {
   print(o);
   o.seaLevelPressure = o.seaLevelPressure * m + a;
   Bangle.setOptions(o);
+  avr = [];
 }
 
 print(g.getFonts());
@@ -57,7 +60,7 @@ g.drawString(/*LANG*/"SEA L (hPa) TEMP (C)", g.getWidth()/2, y+62);
 g.flip();
 g.setFont("6x8").setFontAlign(0,0,3).drawString(/*LANG*/"STD", g.getWidth()-5, g.getHeight()/2);
 Bangle.setUI("updown", btn=> {
-  if (!btn) setPressure(0, 1023.25);
+  if (!btn) setPressure(0, 1013.25);
   if (btn<0) setPressure(1, 1);
   if (btn>0) setPressure(1, -1);
 });

--- a/apps/altimeter/app.js
+++ b/apps/altimeter/app.js
@@ -3,29 +3,18 @@ Bangle.setBarometerPower(true, "altimeter");
 g.clear(1);
 Bangle.loadWidgets();
 Bangle.drawWidgets();
-var zero = 0;
 var R = Bangle.appRect;
 var y = R.y + R.h/2;
 var MEDIANLENGTH = 20;
 var avr = [], median;
 var value = 0;
 
-function getStandardPressure(altitude) {
-  const P0 = 1013.25; // standard pressure at sea level in hPa
-  const T0 = 288.15; // standard temperature at sea level in K
-  const g0 = 9.80665; // standard gravitational acceleration in m/s^2
-  const R = 8.31432; // gas constant in J/(mol*K)
-  const M = 0.0289644; // molar mass of air in kg/mol
-  const L = -0.0065; // temperature lapse rate in K/m
-
-  const temperature = T0 + L * altitude; // temperature at the given altitude
-  const pressure = P0 * Math.pow((temperature / T0), (-g0 * M) / (R * L)); // pressure at the given altitude
-
-  return pressure;
-}
-
-function convertToSeaLevelPressure(pressure, altitude) {
-  return 1013.25 * (pressure / getStandardPressure(altitude));
+function fmt(t) {
+  if ((t > -100) && (t < 1000))
+    t = t.toFixed(1);
+  else
+    t = t.toFixed(0);
+  return t;
 }
 
 Bangle.on('pressure', function(e) {
@@ -36,25 +25,28 @@ Bangle.on('pressure', function(e) {
   if (median.length>10) {
     var mid = median.length>>1;
     value = E.sum(median.slice(mid-4,mid+5)) / 9;
-    t = value-zero;
-    if ((t > -100) && (t < 1000))
-      t = t.toFixed(1);
-    else
-      t = t.toFixed(0);
+    t = fmt(value);
     g.setFont("Vector",50).setFontAlign(0,0).drawString(t, g.getWidth()/2, y);
-    sea = convertToSeaLevelPressure(e.pressure, value-zero);
-    t = sea.toFixed(1) + " " + e.temperature.toFixed(1);
+
+    let o = Bangle.getOptions();
+    let sea = o.seaLevelPressure;
+    t = fmt(sea) + " " + e.temperature.toFixed(1);
     if (0) {
       print("alt raw:", value.toFixed(1));
       print("temperature:", e.temperature);
       print("pressure:", e.pressure);
       print("sea pressure:", sea);
-      print("std pressure:", getStandardPressure(value-zero));
     }
-    g.setFont("Vector",25).setFontAlign(-1,0).drawString(t,
-                                                        10, R.y+R.h - 35);
+    g.setFont("Vector",25).setFontAlign(-1,0).drawString(t, 10, R.y+R.h - 35);
   }
 });
+
+function setPressure(m, a) {
+  o = Bangle.getOptions();
+  print(o);
+  o.seaLevelPressure = o.seaLevelPressure * m + a;
+  Bangle.setOptions(o);
+}
 
 print(g.getFonts());
 g.reset();
@@ -63,9 +55,9 @@ g.setFontAlign(0,0);
 g.drawString(/*LANG*/"ALTITUDE (m)", g.getWidth()/2, y-40);
 g.drawString(/*LANG*/"SEA L (hPa) TEMP (C)", g.getWidth()/2, y+62);
 g.flip();
-g.setFont("6x8").setFontAlign(0,0,3).drawString(/*LANG*/"ZERO", g.getWidth()-5, g.getHeight()/2);
+g.setFont("6x8").setFontAlign(0,0,3).drawString(/*LANG*/"STD", g.getWidth()-5, g.getHeight()/2);
 Bangle.setUI("updown", btn=> {
-  if (!btn) zero=value;
-  if (btn<0) zero-=5;
-  if (btn>0) zero+=5;
+  if (!btn) setPressure(0, 1023.25);
+  if (btn<0) setPressure(1, 1);
+  if (btn>0) setPressure(1, -1);
 });

--- a/apps/altimeter/metadata.json
+++ b/apps/altimeter/metadata.json
@@ -1,6 +1,6 @@
 { "id": "altimeter",
   "name": "Altimeter",
-  "version":"0.03",
+  "version":"0.04",
   "description": "Simple altimeter that can display height changed using Bangle.js 2's built in pressure sensor.",
   "icon": "app.png",
   "tags": "tool,outdoors",


### PR DESCRIPTION
Use system variables to calibrate altimeter. That means that calibration works for other applications, too, and persists between altimeter starts.

Immediately show altitude after calibration changes, otherwise it is hard to set the calibration as the actual values lag behind reality.