### PR TITLE
[alarm] show alarm groups if setting is ON; scroll alarms menu to previous position when going back

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -48,4 +48,4 @@
 0.43: New settings: Show confirm, Show Overflow, Show Group.
 0.44: Add "delete timer after expiration" setting to events.
 0.45: Fix new alarm when selectedAlarm is undefined
-0.46: Show alarm groups if the Show Group setting is ON.
+0.46: Show alarm groups if the Show Group setting is ON.  Scroll alarms menu back to previous position when getting back to it.

--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -45,6 +45,7 @@
 0.40: Use substring of message when it's longer than fits the designated menu entry.
 0.41: Fix a menu bug affecting alarms with empty messages.
 0.42: Fix date not getting saved in event edit menu when tapping Confirm
-0.43: New settings: Show confirm, Show Overflow, Show Type.
+0.43: New settings: Show confirm, Show Overflow, Show Group.
 0.44: Add "delete timer after expiration" setting to events.
 0.45: Fix new alarm when selectedAlarm is undefined
+0.46: Show alarm groups if the Show Group setting is ON.

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -84,7 +84,7 @@ function showMainMenu(scroll, group) {
   var showAlarm;
 
   alarms.forEach((e, index) => {
-    showAlarm = !settings.showGroup || (getGroups && !e.group) || (settings.showGroup && !getGroups && e.group === group);
+    showAlarm = !settings.showGroup || (!group && !e.group) || (group && e.group === group);
     if(showAlarm) {
       menu[trimLabel(getLabel(e),40)] = {
         value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -76,7 +76,7 @@ function formatAlarmProperty(msg) {
 function showMainMenu(scroll, group) {
   const menu = {
     "": { "title": group ? group : /*LANG*/"Alarms & Timers", scroll: scroll },
-    "< Back": () => !group ? load() : showMainMenu(),
+    "< Back": () => group ? showMainMenu() : load(),
     /*LANG*/"New...": () => showNewMenu(group)
   };
   const getGroups = settings.showGroup && !group;

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -73,39 +73,54 @@ function formatAlarmProperty(msg) {
   }
 }
 
-function showMainMenu() {
+function showMainMenu(group) {
   const menu = {
-    "": { "title": /*LANG*/"Alarms & Timers" },
-    "< Back": () => load(),
-    /*LANG*/"New...": () => showNewMenu()
+    "": { "title": group ? group : /*LANG*/"Alarms & Timers" },
+    "< Back": () => !group ? load() : showMainMenu(),
+    /*LANG*/"New...": () => showNewMenu(group)
   };
+  const getGroups = settings.showGroup && !group;
+  const groups = getGroups ? {} : undefined;
+  var showAlarm;
 
   alarms.forEach((e, index) => {
-    menu[trimLabel(getLabel(e),40)] = {
-      value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),
-      onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index)
-    };
+    showAlarm = !settings.showGroup || (getGroups && !e.group) || (settings.showGroup && !getGroups && e.group === group);
+    if(showAlarm) {
+      menu[trimLabel(getLabel(e),40)] = {
+        value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),
+        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, group)
+      };
+    } else if (getGroups) {
+      groups[e.group] = undefined;
+    }
   });
 
-  menu[/*LANG*/"Advanced"] = () => showAdvancedMenu();
+  if (!group) {
+    Object.keys(groups).sort().forEach(g => menu[g] = () => showMainMenu(g));
+    menu[/*LANG*/"Advanced"] = () => showAdvancedMenu();
+  }
 
   E.showMenu(menu);
 }
 
-function showNewMenu() {
-  E.showMenu({
+function showNewMenu(group) {
+  const newMenu = {
     "": { "title": /*LANG*/"New..." },
-    "< Back": () => showMainMenu(),
-    /*LANG*/"Alarm": () => showEditAlarmMenu(undefined, undefined),
+    "< Back": () => showMainMenu(group),
+    /*LANG*/"Alarm": () => showEditAlarmMenu(undefined, undefined, false, null, group),
     /*LANG*/"Timer": () => showEditTimerMenu(undefined, undefined),
-    /*LANG*/"Event": () => showEditAlarmMenu(undefined, undefined, true)
-  });
+    /*LANG*/"Event": () => showEditAlarmMenu(undefined, undefined, true, null, group)
+  };
+
+  if (group) delete newMenu[/*LANG*/"Timer"];
+  E.showMenu(newMenu);
 }
 
-function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
+function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, group) {
   var isNew = alarmIndex === undefined;
 
   var alarm = require("sched").newDefaultAlarm();
+  if (isNew && group) alarm.group = group;
   if (withDate || (selectedAlarm && selectedAlarm.date)) {
     alarm.del = require("sched").getSettings().defaultDeleteExpiredTimers;
   }
@@ -127,7 +142,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
     "< Back": () => {
       prepareAlarmForSave(alarm, alarmIndex, time, date);
       saveAndReload();
-      showMainMenu();
+      showMainMenu(group);
     },
     /*LANG*/"Hour": {
       value: time.h,
@@ -171,7 +186,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
           keyboard.input({text:alarm.msg}).then(result => {
             alarm.msg = result;
             prepareAlarmForSave(alarm, alarmIndex, time, date, true);
-            setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate);
+            setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate, scroll, group);
           });
         }, 100);
       }
@@ -184,7 +199,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
           keyboard.input({text:alarm.group}).then(result => {
             alarm.group = result;
             prepareAlarmForSave(alarm, alarmIndex, time, date, true);
-            setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate);
+            setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate, scroll, group);
           });
         }, 100);
       }
@@ -202,7 +217,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
         alarm.rp = repeat;
         alarm.dow = dow;
         prepareAlarmForSave(alarm, alarmIndex, time, date, true);
-        setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate);
+        setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate, scroll, group);
       })
     },
     /*LANG*/"Vibrate": require("buzz_menu").pattern(alarm.vibrate, v => alarm.vibrate = v),
@@ -218,11 +233,11 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
       value: alarm.hidden || false,
       onchange: v => alarm.hidden = v
     },
-    /*LANG*/"Cancel": () => showMainMenu(),
+    /*LANG*/"Cancel": () => showMainMenu(group),
     /*LANG*/"Confirm": () => {
       prepareAlarmForSave(alarm, alarmIndex, time, date);
       saveAndReload();
-      showMainMenu();
+      showMainMenu(group);
     }
   };
 
@@ -244,10 +259,10 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate) {
         if (confirm) {
           alarms.splice(alarmIndex, 1);
           saveAndReload();
-          showMainMenu();
+          showMainMenu(group);
         } else {
           alarm.t = require("time_utils").encodeTime(time);
-          setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate);
+          setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate, scroll, group);
         }
       });
     };

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -75,7 +75,7 @@ function formatAlarmProperty(msg) {
 
 function showMainMenu(scroll, group) {
   const menu = {
-    "": { "title": group ? group : /*LANG*/"Alarms & Timers", scroll: scroll },
+    "": { "title": group || /*LANG*/"Alarms & Timers", scroll: scroll },
     "< Back": () => group ? showMainMenu() : load(),
     /*LANG*/"New...": () => showNewMenu(group)
   };

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -84,7 +84,7 @@ function showMainMenu(scroll, group) {
   var showAlarm;
 
   alarms.forEach((e, index) => {
-    showAlarm = !settings.showGroup || (!group && !e.group) || (group && e.group === group);
+    showAlarm = !settings.showGroup || (group ? e.group === group : !e.group);
     if(showAlarm) {
       menu[trimLabel(getLabel(e),40)] = {
         value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -73,9 +73,9 @@ function formatAlarmProperty(msg) {
   }
 }
 
-function showMainMenu(group) {
+function showMainMenu(scroll, group) {
   const menu = {
-    "": { "title": group ? group : /*LANG*/"Alarms & Timers" },
+    "": { "title": group ? group : /*LANG*/"Alarms & Timers", scroll: scroll },
     "< Back": () => !group ? load() : showMainMenu(),
     /*LANG*/"New...": () => showNewMenu(group)
   };
@@ -88,7 +88,7 @@ function showMainMenu(group) {
     if(showAlarm) {
       menu[trimLabel(getLabel(e),40)] = {
         value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),
-        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, group)
+        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, scroller.scroll, group)
       };
     } else if (getGroups) {
       groups[e.group] = undefined;
@@ -96,11 +96,11 @@ function showMainMenu(group) {
   });
 
   if (!group) {
-    Object.keys(groups).sort().forEach(g => menu[g] = () => showMainMenu(g));
+    Object.keys(groups).sort().forEach(g => menu[g] = () => showMainMenu(null, g));
     menu[/*LANG*/"Advanced"] = () => showAdvancedMenu();
   }
 
-  E.showMenu(menu);
+  var scroller = E.showMenu(menu).scroller;
 }
 
 function showNewMenu(group) {
@@ -116,7 +116,7 @@ function showNewMenu(group) {
   E.showMenu(newMenu);
 }
 
-function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, group) {
+function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, scroll, group) {
   var isNew = alarmIndex === undefined;
 
   var alarm = require("sched").newDefaultAlarm();
@@ -142,7 +142,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, group) {
     "< Back": () => {
       prepareAlarmForSave(alarm, alarmIndex, time, date);
       saveAndReload();
-      showMainMenu(group);
+      showMainMenu(scroll, group);
     },
     /*LANG*/"Hour": {
       value: time.h,
@@ -233,11 +233,11 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, group) {
       value: alarm.hidden || false,
       onchange: v => alarm.hidden = v
     },
-    /*LANG*/"Cancel": () => showMainMenu(group),
+    /*LANG*/"Cancel": () => showMainMenu(scroll, group),
     /*LANG*/"Confirm": () => {
       prepareAlarmForSave(alarm, alarmIndex, time, date);
       saveAndReload();
-      showMainMenu(group);
+      showMainMenu(scroll, group);
     }
   };
 
@@ -259,7 +259,7 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, group) {
         if (confirm) {
           alarms.splice(alarmIndex, 1);
           saveAndReload();
-          showMainMenu(group);
+          showMainMenu(scroll, group);
         } else {
           alarm.t = require("time_utils").encodeTime(time);
           setTimeout(showEditAlarmMenu, 10, alarm, alarmIndex, withDate, scroll, group);

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.45",
+  "version": "0.46",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
If some alarms have their Group set, those groups will appear at the end of the main list of alarms.  Selecting the Group will show the alarms it contains (i.e. alarms that have that same Group).

Also, when coming back from a Group or from editing an existing alarm, the main list of alarms will be scrolled to the position where it was previously (instead of showing the top of the alarm list).