### PR TITLE
lcars 0.31: Fix Battery vref due to nRF52840: jsvReadVRef now reads V…

### DIFF
--- a/apps/lcars/ChangeLog
+++ b/apps/lcars/ChangeLog
@@ -28,3 +28,4 @@
 0.28: Battery Vref implemented correctly.
 0.29: Support fastload.
 0.30: Add many new colors to the settings and allows random colors on startup if enabled.
+0.31: Fix Battery vref due to nRF52840: jsvReadVRef now reads VDDH value.

--- a/apps/lcars/lcars.app.js
+++ b/apps/lcars/lcars.app.js
@@ -327,7 +327,7 @@ let _drawData = function(key, y, c){
 
   } else if (key =="BATTVOLT" ) {
     text = "BATV";
-    value = (E.getAnalogVRef()*analogRead(3)*4).toFixed(2) + "V";
+    value = (3.3*analogRead(3)*4).toFixed(2) + "V";
   } else if(key == "HRM"){
     value = Math.round(Bangle.getHealthStatus().bpm||Bangle.getHealthStatus("last").bpm);
 

--- a/apps/lcars/metadata.json
+++ b/apps/lcars/metadata.json
@@ -3,7 +3,7 @@
   "name": "LCARS Clock",
   "shortName":"LCARS",
   "icon": "lcars.png",
-  "version":"0.30",
+  "version":"0.31",
   "readme": "README.md",
   "supports": ["BANGLEJS2"],
   "description": "Library Computer Access Retrieval System (LCARS) clock.",


### PR DESCRIPTION
[E.getAnalogVRef](https://www.espruino.com/Reference#t_l_E_getAnalogVRef) no longer returns a mostly fixed 3.3. Thus breaking the calculation for battery volts.  Using 3.3 instead, works.