### PR TITLE
Remove unnecessary boolean formatters

### DIFF
--- a/apps/90sclk/settings.js
+++ b/apps/90sclk/settings.js
@@ -21,7 +21,6 @@
       '< Back': back,
       'Full Screen': {
         value: settings.fullscreen,
-        format: () => (settings.fullscreen ? 'Yes' : 'No'),
         onchange: () => {
           settings.fullscreen = !settings.fullscreen;
           save();

--- a/apps/banglexercise/settings.js
+++ b/apps/banglexercise/settings.js
@@ -11,7 +11,6 @@
     '< Back': back,
     'Buzz': {
       value: "buzz" in settings ? settings.buzz : false,
-      format: () => (settings.buzz ? 'Yes' : 'No'),
       onchange: () => {
         settings.buzz = !settings.buzz;
         save('buzz', settings.buzz);

--- a/apps/bwclk/settings.js
+++ b/apps/bwclk/settings.js
@@ -32,7 +32,6 @@
       },
       'Show Lock': {
         value: settings.showLock,
-        format: () => (settings.showLock ? 'Yes' : 'No'),
         onchange: () => {
           settings.showLock = !settings.showLock;
           save();
@@ -40,7 +39,6 @@
       },
       'Hide Colon': {
         value: settings.hideColon,
-        format: () => (settings.hideColon ? 'Yes' : 'No'),
         onchange: () => {
           settings.hideColon = !settings.hideColon;
           save();

--- a/apps/bwclklite/settings.js
+++ b/apps/bwclklite/settings.js
@@ -32,7 +32,6 @@
       },
       'Show Lock': {
         value: settings.showLock,
-        format: () => (settings.showLock ? 'Yes' : 'No'),
         onchange: () => {
           settings.showLock = !settings.showLock;
           save();
@@ -40,7 +39,6 @@
       },
       'Hide Colon': {
         value: settings.hideColon,
-        format: () => (settings.hideColon ? 'Yes' : 'No'),
         onchange: () => {
           settings.hideColon = !settings.hideColon;
           save();

--- a/apps/circlesclock/settings.js
+++ b/apps/circlesclock/settings.js
@@ -30,7 +30,6 @@
       },
       /*LANG*/'show widgets': {
         value: !!settings.showWidgets,
-        format: () => (settings.showWidgets ? 'Yes' : 'No'),
         onchange: x => save('showWidgets', x),
       },
       /*LANG*/'update interval': {
@@ -45,7 +44,6 @@
       },
       /*LANG*/'show big weather': {
         value: !!settings.showBigWeather,
-        format: () => (settings.showBigWeather ? 'Yes' : 'No'),
         onchange: x => save('showBigWeather', x),
       },
       /*LANG*/'colorize icons': ()=>showCircleMenus()
@@ -87,8 +85,7 @@
       const colorizeIconKey = circleName + "colorizeIcon";
       menu[/*LANG*/'circle ' + circleId] = {
         value: settings[colorizeIconKey] || false,
-          format: () => (settings[colorizeIconKey]? /*LANG*/'Yes': /*LANG*/'No'),
-          onchange: x => save(colorizeIconKey, x),
+        onchange: x => save(colorizeIconKey, x),
       };
     }
     E.showMenu(menu);

--- a/apps/clicompleteclk/settings.js
+++ b/apps/clicompleteclk/settings.js
@@ -9,7 +9,6 @@
     '': { 'title': 'CLI complete clk' },
     'Show battery': {
       value: "battery" in settings ? settings.battery : false,
-      format: () => (settings.battery ? 'Yes' : 'No'),
       onchange: () => {
         settings.battery = !settings.battery;
         save('battery', settings.battery);
@@ -27,7 +26,6 @@
     },
     'Show weather': {
       value: "weather" in settings ? settings.weather : false,
-      format: () => (settings.weather ? 'Yes' : 'No'),
       onchange: () => {
         settings.weather = !settings.weather;
         save('weather', settings.weather);
@@ -35,7 +33,6 @@
     },
     'Show steps': {
       value: "steps" in settings ? settings.steps : false,
-      format: () => (settings.steps ? 'Yes' : 'No'),
       onchange: () => {
         settings.steps = !settings.steps;
         save('steps', settings.steps);
@@ -43,7 +40,6 @@
     },
     'Show heartrate': {
       value: "heartrate" in settings ? settings.heartrate : false,
-      format: () => (settings.heartrate ? 'Yes' : 'No'),
       onchange: () => {
         settings.heartrate = !settings.heartrate;
         save('heartrate', settings.heartrate);

--- a/apps/fuzzyw/fuzzyw.settings.js
+++ b/apps/fuzzyw/fuzzyw.settings.js
@@ -23,7 +23,6 @@
     '< Back': back,
     'Show Widgets': {
       value: settings.showWidgets,
-      format: () => (settings.showWidgets ? 'Yes' : 'No'),
       onchange: () => {
         settings.showWidgets = !settings.showWidgets;
         save();

--- a/apps/health/settings.js
+++ b/apps/health/settings.js
@@ -43,7 +43,6 @@
 
     /*LANG*/"Step Goal Notification": {
       value: "stepGoalNotification" in settings ? settings.stepGoalNotification : false,
-      format: () => (settings.stepGoalNotification ? 'Yes' : 'No'),
       onchange: () => {
         settings.stepGoalNotification = !settings.stepGoalNotification;
         setSettings();

--- a/apps/lcars/lcars.settings.js
+++ b/apps/lcars/lcars.settings.js
@@ -76,7 +76,6 @@ var bg_code = [
     },
     'Full Screen': {
       value: settings.fullscreen,
-      format: () => (settings.fullscreen ? 'Yes' : 'No'),
       onchange: () => {
         settings.fullscreen = !settings.fullscreen;
         save();
@@ -120,7 +119,6 @@ var bg_code = [
     },
     'Disable alarm functionality': {
       value: settings.disableAlarms,
-      format: () => (settings.disableAlarms ? 'Yes' : 'No'),
       onchange: () => {
         settings.disableAlarms = !settings.disableAlarms;
         save();
@@ -128,7 +126,6 @@ var bg_code = [
     },
     'Disable data pages functionality': {
       value: settings.disableData,
-      format: () => (settings.disableData ? 'Yes' : 'No'),
       onchange: () => {
         settings.disableData = !settings.disableData;
         save();
@@ -136,7 +133,6 @@ var bg_code = [
     },
     'Random colors on open': {
       value: settings.randomColors,
-      format: () => (settings.randomColors ? 'Yes' : 'No'),
       onchange: () => {
         settings.randomColors = !settings.randomColors;
         save();

--- a/apps/limelight/limelight.settings.js
+++ b/apps/limelight/limelight.settings.js
@@ -27,13 +27,12 @@
   }
 
   var font_options = ["Limelight","GochiHand","Grenadier","Monoton"];
-  
+
   E.showMenu({
     '': { 'title': 'Limelight Clock' },
     '< Back': back,
     'Full Screen': {
       value: s.fullscreen,
-      format: () => (s.fullscreen ? 'Yes' : 'No'),
       onchange: () => {
         s.fullscreen = !s.fullscreen;
         save();
@@ -50,7 +49,6 @@
     },
     'Vector Font': {
       value: s.vector,
-      format: () => (s.vector ? 'Yes' : 'No'),
       onchange: () => {
         s.vector = !s.vector;
         save();
@@ -68,7 +66,6 @@
     },
     'Second Hand': {
       value: s.secondhand,
-      format: () => (s.secondhand ? 'Yes' : 'No'),
       onchange: () => {
         s.secondhand = !s.secondhand;
         save();

--- a/apps/linuxclock/settings.js
+++ b/apps/linuxclock/settings.js
@@ -32,7 +32,6 @@
       },
       'Show Lock': {
         value: settings.showLock,
-        format: () => (settings.showLock ? 'Yes' : 'No'),
         onchange: () => {
           settings.showLock = !settings.showLock;
           save();
@@ -40,7 +39,6 @@
       },
       'Hide Colon': {
         value: settings.hideColon,
-        format: () => (settings.hideColon ? 'Yes' : 'No'),
         onchange: () => {
           settings.hideColon = !settings.hideColon;
           save();

--- a/apps/mosaic/mosaic.settings.js
+++ b/apps/mosaic/mosaic.settings.js
@@ -25,7 +25,6 @@
     '< Back': back,
     'Show Widgets': {
       value: settings.showWidgets,
-      format: () => (settings.showWidgets ? 'Yes' : 'No'),
       onchange: () => {
         settings.showWidgets = !settings.showWidgets;
         save();

--- a/apps/pebble/pebble.settings.js
+++ b/apps/pebble/pebble.settings.js
@@ -23,7 +23,7 @@
   var color_options = ['Green','Orange','Cyan','Purple','Red','Blue'];
   var bg_code = ['#0f0','#ff0','#0ff','#f0f','#f00','#00f'];
   var theme_options = ['System', 'Light', 'Dark'];
-  
+
   E.showMenu({
     '': { 'title': 'Pebble Clock' },
     /*LANG*/'< Back': back,
@@ -48,7 +48,6 @@
     },
     /*LANG*/'Show Lock': {
       value: settings.showlock,
-      format: () => (settings.showlock ? /*LANG*/'Yes' : /*LANG*/'No'),
       onchange: () => {
         settings.showlock = !settings.showlock;
         save();

--- a/apps/slopeclockpp/settings.js
+++ b/apps/slopeclockpp/settings.js
@@ -21,42 +21,34 @@
       },
       /*LANG*/'Red': {
         value: !!settings.colorRed,
-        format: () => (settings.colorRed ? 'Yes' : 'No'),
         onchange: x => save('colorRed', x),
       },
       /*LANG*/'Green': {
         value: !!settings.colorGreen,
-        format: () => (settings.colorGreen ? 'Yes' : 'No'),
         onchange: x => save('colorGreen', x),
       },
       /*LANG*/'Blue': {
         value: !!settings.colorBlue,
-        format: () => (settings.colorBlue ? 'Yes' : 'No'),
         onchange: x => save('colorBlue', x),
       },
       /*LANG*/'Magenta': {
         value: !!settings.colorMagenta,
-        format: () => (settings.colorMagenta ? 'Yes' : 'No'),
         onchange: x => save('colorMagenta', x),
       },
       /*LANG*/'Cyan': {
         value: !!settings.colorCyan,
-        format: () => (settings.colorCyan ? 'Yes' : 'No'),
         onchange: x => save('colorCyan', x),
       },
       /*LANG*/'Yellow': {
         value: !!settings.colorYellow,
-        format: () => (settings.colorYellow ? 'Yes' : 'No'),
         onchange: x => save('colorYellow', x),
       },
       /*LANG*/'Black': {
         value: !!settings.colorBlack,
-        format: () => (settings.colorBlack ? 'Yes' : 'No'),
         onchange: x => save('colorBlack', x),
       },
       /*LANG*/'White': {
         value: !!settings.colorWhite,
-        format: () => (settings.colorWhite ? 'Yes' : 'No'),
         onchange: x => save('colorWhite', x),
       }
     };

--- a/apps/weather/settings.js
+++ b/apps/weather/settings.js
@@ -21,7 +21,6 @@
     },
     'Hide Widget': {
       value: "hide" in settings ? settings.hide : false,
-      format: () => (settings.hide ? 'Yes' : 'No'),
       onchange: () => {
         settings.hide = !settings.hide
         save('hide', settings.hide);

--- a/apps/widbgjs/settings.js
+++ b/apps/widbgjs/settings.js
@@ -43,7 +43,6 @@
         },
         'Hide Widget': {
             value: s.hide,
-            format: () => (s.hide ? 'Yes' : 'No'),
             onchange: () => {
                 s.hide = !s.hide;
                 save();

--- a/apps/widpedom/settings.js
+++ b/apps/widpedom/settings.js
@@ -37,7 +37,6 @@
     },
     'Show Progress': {
       value: s.progress,
-      format: () => (s.progress ? 'Yes' : 'No'),
       onchange: () => {
         s.progress = !s.progress
         save();
@@ -45,7 +44,6 @@
     },
     'Large Digits': {
       value: s.large,
-      format: () => (s.large ? 'Yes' : 'No'),
       onchange: () => {
         s.large = !s.large
         save();
@@ -53,7 +51,6 @@
     },
     'Hide Widget': {
       value: s.hide,
-      format: () => (s.hide ? 'Yes' : 'No'),
       onchange: () => {
         s.hide = !s.hide
         save();

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -263,7 +263,7 @@ apps.forEach((app,appIdx) => {
           WARN(`App ${app.id} has a setting file but no corresponding data entry (add \`"data":[{"name":"${app.id}.settings.json"}]\`)`, {file:appDirRelative+file.url});
         }
         // check for manual boolean formatter
-        const m = fileContents.match(/format: *\(\) *=>.*["']Yes["']/);
+        const m = fileContents.match(/format: *\(\) *=>.*["'](yes|on)["']/i);
         if (m) {
           WARN(`Settings for ${app.id} has a boolean formatter - this is handled automatically, the line can be removed`, {file:appDirRelative+file.url, line: fileContents.substr(0, m.index).split("\n").length});
         }

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -256,9 +256,17 @@ apps.forEach((app,appIdx) => {
         if (a>=0 && b>=0 && a<b)
           WARN(`Clock ${app.id} file calls loadWidgets before setUI (clock widget/etc won't be aware a clock app is running)`, {file:appDirRelative+file.url, line : fileContents.substr(0,a).split("\n").length});
       }
-      // if settings, suggest adding to datafiles
-      if (/\.settings?\.js$/.test(file.name) && (!app.data || app.data.every(d => !d.name || !d.name.endsWith(".json")))) {
-        WARN(`App ${app.id} has a setting file but no corresponding data entry (add \`"data":[{"name":"${app.id}.settings.json"}]\`)`, {file:appDirRelative+file.url});
+      // if settings
+      if (/\.settings?\.js$/.test(file.name)) {
+        // suggest adding to datafiles
+        if (!app.data || app.data.every(d => !d.name || !d.name.endsWith(".json"))) {
+          WARN(`App ${app.id} has a setting file but no corresponding data entry (add \`"data":[{"name":"${app.id}.settings.json"}]\`)`, {file:appDirRelative+file.url});
+        }
+        // check for manual boolean formatter
+        const m = fileContents.match(/format: *\(\) *=>.*["']Yes["']/);
+        if (m) {
+          WARN(`Settings for ${app.id} has a boolean formatter - this is handled automatically, the line can be removed`, {file:appDirRelative+file.url, line: fileContents.substr(0, m.index).split("\n").length});
+        }
       }
     }
     for (const key in file) {


### PR DESCRIPTION
Remove manual boolean formatters - rely on pre-existing default formatter. This continues the work done by @alessandrococco in #1980 / 42c2b5c8a2 and introduces a change to `bin/sanitycheck.js` to catch future introductions.