### PR TITLE
widget_utils: use correct variable to clear interval

### DIFF
--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -109,7 +109,7 @@ exports.swipeOn = function(autohide) {
   };
 
   function anim(dir, callback) {
-    if (exports.animInterval) clearInterval(exports.interval);
+    if (exports.animInterval) clearInterval(exports.animInterval);
     exports.animInterval = setInterval(function() {
       offset += dir;
       let stop = false;


### PR DESCRIPTION
Hi
A clock I'm developing is using hideable widgets. I've noticed that every now-and-then the clock stops updating after showing the widgets. I'm using an interval (not timeout) to update the clock.
I think I found the culprit.