### PR TITLE
calendar: Load holidays before events

### DIFF
--- a/apps/calendar/ChangeLog
+++ b/apps/calendar/ChangeLog
@@ -17,3 +17,4 @@
 0.15: Edit holidays on device in settings
 0.16: Add menu to fast open settings to edit holidays
       Display Widgets in menus
+0.17: Load holidays before events so the latter is not overpainted

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -280,18 +280,12 @@ const showMenu = function() {
       setUI();
     },
     /*LANG*/"Exit": () => load(),
-    /*LANG*/"Settings": () => {
-      const appSettings = () => eval(require('Storage').read('calendar.settings.js'))(() => {
+    /*LANG*/"Settings": () =>
+      eval(require('Storage').read('calendar.settings.js'))(() => {
         loadSettings();
         loadEvents();
         showMenu();
-      });
-      appSettings(() => {
-        loadSettings();
-        loadEvents();
-        showMenu();
-      });
-    },
+      }),
   };
   if (require("Storage").read("alarm.app.js")) {
     menu[/*LANG*/"Launch Alarms"] = () => {

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -141,7 +141,6 @@ const calcDays = (month, monthMaxDayMap, dowNorm) => {
 };
 
 const drawCalendar = function(date) {
-  d1 = new Date();
   g.setBgColor(bgColor);
   g.clearRect(0, 0, maxX, maxY);
   g.setBgColor(bgColorMonth);

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -43,24 +43,24 @@ const dowLbls = function() {
 }();
 
 const loadEvents = () => {
+  // add holidays & other events
+  events = (require("Storage").readJSON("calendar.days.json",1) || []).map(d => {
+    const date = new Date(d.date);
+    const o = {date: date, msg: d.name, type: d.type};
+    if (d.repeat) {
+      o.repeat = d.repeat;
+    }
+    return o;
+  });
   // all alarms that run on a specific date
-  events = (require("Storage").readJSON("sched.json",1) || []).filter(a => a.on && a.date).map(a => {
+  events = events.concat((require("Storage").readJSON("sched.json",1) || []).filter(a => a.on && a.date).map(a => {
     const date = new Date(a.date);
     const time = timeutils.decodeTime(a.t);
     date.setHours(time.h);
     date.setMinutes(time.m);
     date.setSeconds(time.s);
     return {date: date, msg: a.msg, type: "e"};
-  });
-  // add holidays & other events
-  (require("Storage").readJSON("calendar.days.json",1) || []).forEach(d => {
-    const date = new Date(d.date);
-    const o = {date: date, msg: d.name, type: d.type};
-    if (d.repeat) {
-      o.repeat = d.repeat;
-    }
-    events.push(o);
-  });
+  }));
 };
 
 const loadSettings = () => {
@@ -141,6 +141,7 @@ const calcDays = (month, monthMaxDayMap, dowNorm) => {
 };
 
 const drawCalendar = function(date) {
+  d1 = new Date();
   g.setBgColor(bgColor);
   g.clearRect(0, 0, maxX, maxY);
   g.setBgColor(bgColorMonth);
@@ -281,7 +282,11 @@ const showMenu = function() {
     },
     /*LANG*/"Exit": () => load(),
     /*LANG*/"Settings": () => {
-      const appSettings = eval(require('Storage').read('calendar.settings.js'));
+      const appSettings = () => eval(require('Storage').read('calendar.settings.js'))(() => {
+        loadSettings();
+        loadEvents();
+        showMenu();
+      });
       appSettings(() => {
         loadSettings();
         loadEvents();

--- a/apps/calendar/metadata.json
+++ b/apps/calendar/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "calendar",
   "name": "Calendar",
-  "version": "0.16",
+  "version": "0.17",
   "description": "Monthly calendar, displays holidays uploaded from the web interface and scheduled events.",
   "icon": "calendar.png",
   "screenshots": [{"url":"screenshot_calendar.png"}],


### PR DESCRIPTION
Previously events were loaded and as result painted first and a following draw on a holiday would overwrite the event indicator