### PR TITLE
forge: Compatibility with Fastload Utils

### DIFF
--- a/apps/forge/ChangeLog
+++ b/apps/forge/ChangeLog
@@ -1,1 +1,2 @@
 0.01: attempt to import
+0.02: Make it possible for Fastload Utils to fastload into this app.

--- a/apps/forge/forge.app.js
+++ b/apps/forge/forge.app.js
@@ -1,5 +1,7 @@
 // App Forge
 
+"Bangle.loadWidgets()"; // Facilitates fastloading to this app via Fastload Utils, while still not loading widgets on standard `load` calls.
+
 st = require('Storage');
 
 l = /^a\..*\.js$/;

--- a/apps/forge/metadata.json
+++ b/apps/forge/metadata.json
@@ -1,6 +1,6 @@
 { "id": "forge",
   "name": "App Forge",
-  "version":"0.01",
+  "version":"0.02",
   "description": "Easy way to run development versions of your apps",
   "icon": "app.png",
   "readme": "README.md",


### PR DESCRIPTION
... by adding the string `"Bangle.loadWidget()";`. This way Fastload Utils thinks widgets would be present and so fastloads. But in the absence of Fastload Utils no widgets will be loaded, and so no overhead is added for the usual case.

Exiting forge will be done with a regular `load()` call in both cases, since no remove-handler is added to a `Bangle.setUI({})` call.