### PR TITLE
android: Fix alarms created in Gadgetbridge not repeating

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -32,3 +32,4 @@
       Allow alarm enable/disable
 0.31: Implement API for activity fetching
 0.32: Added support for loyalty cards from gadgetbridge
+0.33: Fix alarms created in Gadgetbridge not repeating

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -81,7 +81,12 @@
         for (var j = 0; j < event.d.length; j++) {
           // prevents all alarms from going off at once??
           var dow = event.d[j].rep;
-          if (!dow) dow = 127; //if no DOW selected, set alarm to all DOW
+          var rp = false;
+          if (!dow) {
+            dow = 127; //if no DOW selected, set alarm to all DOW
+          } else {
+            rp = true;
+          }
           var last = (event.d[j].h * 3600000 + event.d[j].m * 60000 < currentTime) ? (new Date()).getDate() : 0;
           var a = require("sched").newDefaultAlarm();
           a.id = "gb"+j;
@@ -89,6 +94,7 @@
           a.on = event.d[j].on !== undefined ? event.d[j].on : true;
           a.t = event.d[j].h * 3600000 + event.d[j].m * 60000;
           a.dow = ((dow&63)<<1) | (dow>>6); // Gadgetbridge sends DOW in a different format
+          a.rp = rp;
           a.last = last;
           alarms.push(a);
         }

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.32",
+  "version": "0.33",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",


### PR DESCRIPTION
Fix for issue #3174 