### PR TITLE
[fwupdate] Add links to firmware changelogs; couple minor fixes

### DIFF
--- a/apps/fwupdate/custom.html
+++ b/apps/fwupdate/custom.html
@@ -58,6 +58,15 @@
 
     <pre id="log"></pre>
 
+    <p><a href="#" id="changelog-btn">Firmware ChangeLog ▼</a></p>
+    <div id="changelog-div" style="display:none">
+      <p><b>Firmware ChangeLog</b></p>
+      <ul>
+        <li><a href="https://www.espruino.com/ChangeLog" target="_blank">Released</a></li>
+        <li><a href="https://github.com/espruino/Espruino/blob/master/ChangeLog" target="_blank">Cutting Edge</a></li>
+      </ul>
+    </div>
+
     <script src="../../core/lib/customize.js"></script>
     <script src="../../core/lib/espruinotools.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.js"></script>
@@ -444,6 +453,11 @@ document.getElementById("info-btn").addEventListener("click", function(e) {
 document.getElementById("advanced-btn").addEventListener("click", function(e) {
   document.getElementById("advanced-btn").style = "display:none";
   document.getElementById("advanced-div").style = "";
+  e.preventDefault();
+});
+document.getElementById("changelog-btn").addEventListener("click", function(e) {
+  document.getElementById("changelog-btn").style = "display:none";
+  document.getElementById("changelog-div").style = "";
   e.preventDefault();
 });
 setTimeout(checkForFileOnServer, 10);

--- a/apps/fwupdate/custom.html
+++ b/apps/fwupdate/custom.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../../css/spectre.min.css">
   </head>
   <body>
-    <p>This tool allows you to update the firmware on <a href="https://www.espruino.com/Bangle.js2">Bangle.js 2</a> devices
+    <p>This tool allows you to update the firmware on <a href="https://www.espruino.com/Bangle.js2" target="_blank">Bangle.js 2</a> devices
       from within the App Loader.</p>
 
     <div id="fw-unknown">
@@ -32,7 +32,7 @@
         bit of code that runs when Bangle.js starts, and it is able to update the
         Bangle.js firmware. Normally you would update firmware via this Firmware
         Updater app, but if for some reason Bangle.js will not boot, you can
-        <a href="https://www.espruino.com/Bangle.js2#firmware-updates">always use DFU to do the update manually</a>.
+        <a href="https://www.espruino.com/Bangle.js2#firmware-updates" target="_blank">always use DFU to do the update manually</a>.
         On DFU 2v19 and earlier, iOS devices could have issues updating firmware - 2v20 fixes this.</p>
         <p>DFU is itself a bootloader, but here we're calling it DFU to avoid confusion
         with the Bootloader app in the app loader (which prepares Bangle.js for running apps).</p>
@@ -42,7 +42,7 @@
       <div id="advanced-div" style="display:none">
         <p><b>Advanced</b></p>
         <p>Firmware updates via this tool work differently to the NRF Connect method mentioned on
-          <a href="https://www.espruino.com/Bangle.js2#firmware-updates">the Bangle.js 2 page</a>. Firmware
+          <a href="https://www.espruino.com/Bangle.js2#firmware-updates" target="_blank">the Bangle.js 2 page</a>. Firmware
           is uploaded to a file on the Bangle. Once complete the Bangle reboots and DFU copies
           the new firmware into internal Storage.</p>
         <p>In addition to the links above, you can upload a hex or zip file directly below. This file should be an <code>.app_hex</code>

--- a/apps/fwupdate/custom.html
+++ b/apps/fwupdate/custom.html
@@ -436,13 +436,15 @@ function handleUpload() {
 
 document.getElementById('fileLoader').addEventListener('change', handleFileSelect, false);
 document.getElementById("upload").addEventListener("click", handleUpload);
-document.getElementById("info-btn").addEventListener("click", function() {
+document.getElementById("info-btn").addEventListener("click", function(e) {
   document.getElementById("info-btn").style = "display:none";
   document.getElementById("info-div").style = "";
+  e.preventDefault();
 });
-document.getElementById("advanced-btn").addEventListener("click", function() {
+document.getElementById("advanced-btn").addEventListener("click", function(e) {
   document.getElementById("advanced-btn").style = "display:none";
   document.getElementById("advanced-div").style = "";
+  e.preventDefault();
 });
 setTimeout(checkForFileOnServer, 10);
 


### PR DESCRIPTION
It'd be nice to have the firmware changelogs linked to from the firmware updater. The custom.html page seemed like the best spot for now, until a readme with more detail is made.

I wasn't sure if I should increase the version number or not, since this was more of a documentation fix?

I also fixed a couple small bugs (features?) in the page:

1) When viewed in gadgetbridge, some of the links try to open as a frame inside the popup. It didn't seem intentional, since other links opened in a new window.
 
2) When clicking the DFU or Advanced toggles, it jumps to the top of the page. Other js links on the page use preventDefault, so I assumed those should too.

Link to my updated app loader:
https://thinkpoop.github.io/BangleApps