### PR TITLE
aviatorclk: added tap event to scroll METAR and toggle seconds display

### DIFF
--- a/apps/aviatorclk/ChangeLog
+++ b/apps/aviatorclk/ChangeLog
@@ -1,1 +1,2 @@
 1.00: initial release
+1.01: added tap event to scroll METAR and toggle seconds display

--- a/apps/aviatorclk/README.md
+++ b/apps/aviatorclk/README.md
@@ -18,15 +18,20 @@ module after installing this app.
 - Latest METAR for the nearest airport (scrollable)
 
 Tap the screen in the top or bottom half to scroll the METAR text (in case not
-the whole report fits on the screen).
+the whole report fits on the screen). You can also tap the watch from the top
+or bottom to scroll, which works even with the screen locked.
 
 The colour of the METAR text will change to orange if the report is more than
 1h old, and red if it's older than 1.5h.
 
+To toggle the seconds display, double tap the watch from either the left or
+right. This only changes the display "temporarily" (ie. it doesn't change the
+default configured through the settings).
+
 
 ## Settings
 
-- **Show Seconds**: to conserve battery power, you can turn the seconds display off
+- **Show Seconds**: to conserve battery power, you can turn the seconds display off (as the default)
 - **Invert Scrolling**: swaps the METAR scrolling direction of the top and bottom taps
 
 

--- a/apps/aviatorclk/metadata.json
+++ b/apps/aviatorclk/metadata.json
@@ -2,7 +2,7 @@
   "id": "aviatorclk",
   "name": "Aviator Clock",
   "shortName":"AV8R Clock",
-  "version":"1.00",
+  "version":"1.01",
   "description": "A clock for aviators, with local time and UTC - and the latest METAR for the nearest airport",
   "icon": "aviatorclk.png",
   "screenshots": [{ "url": "screenshot.png" }, { "url": "screenshot2.png" }],


### PR DESCRIPTION
This is an update for the "aviatorclk". Triggered by @nxdefiant 's comment when the app was originally submitted, I've added a way to easily toggle the seconds display (through double taps left or right).
And I found the taps useful to scroll the METAR display, too.

This PR also includes a minor bug fix (set the background colour prior to seconds updates).