### PR TITLE
Don't delete variables

### DIFF
--- a/apps/.eslintrc.json
+++ b/apps/.eslintrc.json
@@ -144,7 +144,6 @@
         ],
         "no-case-declarations": "off",
         "no-constant-condition": "off",
-        "no-delete-var": "off",
         "no-empty": "off",
         "no-global-assign": "off",
         "no-inner-declarations": "off",

--- a/apps/advcasio/app.js
+++ b/apps/advcasio/app.js
@@ -32,7 +32,6 @@ function getRocketSequences() {
 let rocketSequence = 1;
 let settings = storage.readJSON("cassioWatch.settings.json", true) || {};
 let rocketSpeed = settings.rocketSpeed || 700;
-delete settings;
 
 // schedule a draw for the next minute
 let rocketInterval;

--- a/apps/aiclock/aiclock.app.js
+++ b/apps/aiclock/aiclock.app.js
@@ -172,7 +172,6 @@ Bangle.on('lock', function(isLocked) {
 
 E.on("kill", function(){
     clockInfoMenu.remove();
-    delete clockInfoMenu;
 });
 
 

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -379,7 +379,4 @@
       if (!Bangle.isGPSOn()) gbSend({ t: "gps_power", status: false });
     },3000);
   }
-
-  // remove settings object so it's not taking up RAM
-  delete settings;
 })();

--- a/apps/boot/bootloader.js
+++ b/apps/boot/bootloader.js
@@ -23,7 +23,5 @@ if (!_clkApp) {
     require("Storage").writeJSON("setting.json", s);
   }
 }
-delete s;
 if (!_clkApp) _clkApp=`E.showMessage("No Clock Found");setWatch(()=>{Bangle.showLauncher();}, global.BTN2||BTN, {repeat:false,edge:"falling"});`;
 eval(_clkApp);
-delete _clkApp;

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -332,7 +332,6 @@ Bangle.on('charging', charging);
 
 let kill = function(){
   clockInfoMenu.remove();
-  delete clockInfoMenu;
 };
 E.on("kill", kill);
 

--- a/apps/bwclklite/app.js
+++ b/apps/bwclklite/app.js
@@ -292,7 +292,6 @@ Bangle.on('charging', charging);
 
 let kill = function(){
   clockInfoMenu.remove();
-  delete clockInfoMenu;
 };
 E.on("kill", kill);
 

--- a/apps/cassioWatch/app.js
+++ b/apps/cassioWatch/app.js
@@ -32,7 +32,6 @@ function getRocketSequences() {
 let rocketSequence = 1;
 let settings = storage.readJSON("cassioWatch.settings.json", true) || {};
 let rocketSpeed = settings.rocketSpeed || 700;
-delete settings;
 
 // schedule a draw for the next minute
 let rocketInterval;

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -352,7 +352,6 @@ exports.addInteractive = function(menu, options) {
 
     return true;
   };
-  delete settings; // don't keep settings in RAM - save space
   return options;
 };
 

--- a/apps/clockcal/app.js
+++ b/apps/clockcal/app.js
@@ -83,7 +83,6 @@ function drawFullCalendar(monthOffset) {
             rD.setDate(rDate + 1);
         }
     }
-    delete addMonths;
     if (DEBUG) console.log("Calendar performance (ms):" + (Date().getTime() - start));
 }
 function caldrawMonth(rDate, c, m, rD) {

--- a/apps/game1024/app.js
+++ b/apps/game1024/app.js
@@ -11,8 +11,6 @@ const debugMode = settings.debugMode!==undefined ? settings.debugMode : false; /
 const maxUndoLevels = settings.maxUndoLevels!==undefined ? settings.maxUndoLevels : 4; // #settings
 const charIndex = settings.charIndex!==undefined ? settings.charIndex : 0; // #settings -- plain numbers on the grid
 
-delete settings; // remove unneeded settings from memory
-
 const middle = {x:Math.floor(g.getWidth()/2)-20, y: Math.floor(g.getHeight()/2)};
 const rows = 4, cols = 4; // #settings
 const borderWidth = 6; 

--- a/apps/gpsautotime/widget.js
+++ b/apps/gpsautotime/widget.js
@@ -6,7 +6,6 @@
 		show: true,
 	}, require('Storage').readJSON("gpsautotime.json", true) || {});
 	const show = settings.show;
-	delete settings;
 
 	Bangle.on('GPS',function(fix) {
 		if (fix.fix && fix.time) {

--- a/apps/hardalarm/widget.js
+++ b/apps/hardalarm/widget.js
@@ -2,7 +2,6 @@
   var alarms = require('Storage').readJSON('hardalarm.json',1)||[];
   alarms = alarms.filter(alarm=>alarm.on);
   if (!alarms.length) return; // no alarms, no widget!
-  delete alarms;
   // add the widget
   WIDGETS["alarm"]={area:"tl",width:24,draw:function() {
     g.setColor(-1);

--- a/apps/lato/app.js
+++ b/apps/lato/app.js
@@ -124,7 +124,6 @@ Graphics.prototype.setFontLatoSmall = function(scale) {
       drawTimeout = undefined;
       // remove info menu
       clockInfoMenu.remove();
-      delete clockInfoMenu;
       // delete the custom fonts
       delete Graphics.prototype.setFontLato;
       delete Graphics.prototype.setFontLatoSmall;

--- a/apps/lato/lato.fast.js
+++ b/apps/lato/lato.fast.js
@@ -124,7 +124,6 @@ Graphics.prototype.setFontLatoSmall = function(scale) {
       drawTimeout = undefined;
       // remove info menu
       clockInfoMenu.remove();
-      delete clockInfoMenu;
       // delete the custom fonts
       delete Graphics.prototype.setFontLato;
       delete Graphics.prototype.setFontLatoSmall;

--- a/apps/lcdclock/app.js
+++ b/apps/lcdclock/app.js
@@ -54,9 +54,7 @@ Bangle.setUI({
     delete Graphics.prototype.setFont7Seg;
     // remove info menu
     clockInfoMenu.remove();
-    delete clockInfoMenu;
     clockInfoMenu2.remove();
-    delete clockInfoMenu2;
     // reset theme
     g.setTheme(oldTheme);
   }});

--- a/apps/lcdclockplus/app.js
+++ b/apps/lcdclockplus/app.js
@@ -66,13 +66,9 @@ Bangle.setUI({
     delete Graphics.prototype.setFont7Seg;
     // remove info menu
     clockInfoMenu.remove();
-    delete clockInfoMenu;
     clockInfoMenu2.remove();
-    delete clockInfoMenu2;
     clockInfoMenu3.remove();
-    delete clockInfoMenu3;
     clockInfoMenu4.remove();
-    delete clockInfoMenu4;
     // reset theme
     g.setTheme(oldTheme);
   }});

--- a/apps/lightswitch/widget.js
+++ b/apps/lightswitch/widget.js
@@ -270,7 +270,4 @@
     if (locked === false) Bangle.setLCDBrightness(w.isOn ? w.value : 0);
     w.draw()
   });
-
-  // clear variable
-  delete settings;
 })()

--- a/apps/nightwatch/nightwatch.app.js
+++ b/apps/nightwatch/nightwatch.app.js
@@ -8,7 +8,6 @@ var settings = Object.assign({
 }, require('Storage').readJSON("nightwatch.json", true) || {});
 
 let dt = settings.dt;
-delete settings;
 
 var timerID;
 

--- a/apps/powermanager/widget.js
+++ b/apps/powermanager/widget.js
@@ -110,7 +110,4 @@ currently-running apps */
   };
 
   Bangle.on("lock", ()=>{WIDGETS.powermanager.draw(WIDGETS.powermanager);});
-
-  // conserve memory
-  delete settings;
 })();

--- a/apps/qmsched/app.js
+++ b/apps/qmsched/app.js
@@ -7,7 +7,6 @@ const B2 = process.env.HWVERSION===2;
 const STORAGE = require('Storage');
 let bSettings = STORAGE.readJSON('setting.json',true)||{};
 let current = 0|bSettings.quiet;
-delete bSettings; // we don't need any other global settings
 
 
 

--- a/apps/qmsched/boot.js
+++ b/apps/qmsched/boot.js
@@ -4,7 +4,6 @@
   delete Bangle.qmTimeout;
   let bSettings = require('Storage').readJSON('setting.json',true)||{};
   const curr = 0|bSettings.quiet;
-  delete bSettings;
   if (curr) require("qmsched").applyOptions(curr); // no need to re-apply default options
 
   let settings = require('Storage').readJSON('qmsched.json',true)||{};

--- a/apps/recorder/app.js
+++ b/apps/recorder/app.js
@@ -85,7 +85,6 @@ function showMainMenu() {
   Object.keys(recorders).forEach(id=>{
     mainmenu[/*LANG*/"Log "+recorders[id]().name] = menuRecord(id);
   });
-  delete recorders;
   return E.showMenu(mainmenu);
 }
 

--- a/apps/rings/app.js
+++ b/apps/rings/app.js
@@ -25,7 +25,6 @@ if(settings.minute){
   watch.dateRing.numbers = settings.date.numbers;
   watch.screen.bubble = settings.bubble;
 }
-delete settings;
 const month= ["JANUARY","FEBRUARY","MARCH","APRIL","MAY","JUNE","JULY",
             "AUGUST","SEPTEMBER","OCTOBER","NOVEMBER","DECEMBER"];
 

--- a/apps/run/app.js
+++ b/apps/run/app.js
@@ -129,7 +129,6 @@ lc.push({ type:"h", filly:1, c:[
 var layout = new Layout( {
   type:"v", c: lc
 },{lazy:true, btns:[{ label:"---", cb: onStartStop, id:"button"}]});
-delete lc;
 setStatus(exs.state.active);
 layout.render();
 

--- a/apps/runplus/app.js
+++ b/apps/runplus/app.js
@@ -140,7 +140,6 @@ lc.push({ type:"h", filly:1, c:[
 let layout = new Layout( {
   type:"v", c: lc
 },{lazy:true, btns:[{ label:"---", cb: (()=>{if (karvonenActive) {stopKarvonenUI();run();} onStartStop();}), id:"button"}]});
-delete lc;
 setStatus(exs.state.active);
 layout.render();
 

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -75,8 +75,6 @@ exports.newDefaultAlarm = function () {
     vibrate: settings.defaultAlarmPattern,
   };
 
-  delete settings;
-
   return alarm;
 }
 // Factory that creates a new timer with default values
@@ -93,8 +91,6 @@ exports.newDefaultTimer = function () {
     last: 0,
     vibrate: settings.defaultTimerPattern
   }
-
-  delete settings;
 
   return timer;
 };

--- a/apps/slopeclockpp/app.js
+++ b/apps/slopeclockpp/app.js
@@ -165,9 +165,7 @@ Bangle.setUI({
     delete Graphics.prototype.setFontPaytoneOne;
     // remove info menu
     clockInfoMenu.remove();
-    delete clockInfoMenu;
     clockInfoMenu2.remove();
-    delete clockInfoMenu2;
   }
 });
 // Load widgets

--- a/apps/widhid/wid.js
+++ b/apps/widhid/wid.js
@@ -4,7 +4,6 @@
         console.log("widhid: can't enable, HID setting isn't \"kbmedia\"");
         return;
     }
-    delete settings;
     var anchor = { x: 0, y: 0 };
     var start = { x: 0, y: 0 };
     var dragging = false;
@@ -111,7 +110,6 @@
     };
     if (connected)
         Bangle.on("swipe", onSwipe);
-    delete connected;
     NRF.on("connect", function () {
         WIDGETS["hid"].width = 24;
         Bangle.on("swipe", onSwipe);

--- a/apps/widmsggrid/widget.js
+++ b/apps/widmsggrid/widget.js
@@ -5,7 +5,6 @@
     flash: (settings.flash === undefined) ? true : !!settings.flash,
     showRead: !!settings.showRead,
   };
-  delete settings;
   // widget name needs to be "messages": the library calls WIDGETS["messages'].hide()/show()
   WIDGETS["messages"] = {
     area: "tl", width: 0,
@@ -95,7 +94,6 @@
       delete w.hidden; // always set by w.hide(), but we checked it wasn't there before
     }
   };
-  delete s;
   const w = WIDGETS["messages"];
   Bangle.on("message", w.listener);
 })();

--- a/apps/widpedom/widget.js
+++ b/apps/widpedom/widget.js
@@ -138,7 +138,6 @@
     if (pedomData.lastUpdate)
       lastUpdate = new Date(pedomData.lastUpdate);
     stp_today = pedomData.stepsToday|0;
-    delete pedomData;
   }
   WIDGETS["wpedom"].width = WIDGETS["wpedom"].getWidth();
 })()


### PR DESCRIPTION
Related: [#345](https://github.com/espruino/Espruino/issues/345)

I suggest disallowing variable deletions in the official apps, since they are not allowed per the Ecmascript standard. I think that allowing developers to use a core language feature differently from the standard is a recipe for disaster, as we can suddenly have programs that only work in a specific runtime, even though they are written in JS.

Another reason to remove this code, is that it shouldn't really do anything. Keeping unused data in memory does not have any cost, as long as there is still some free memory. If there is no free memory, the garbage collector should be able to efficiently detect and remove unused data.
Most JS implementations that allow deletion of variables do not actually delete them from memory, as it would unnecessarily interrupt the GC. The GC might know that a different variable will free up more memory, or would free up memory at a better address, or it might know that there is no need to free memory at that time. Then why would you force it to spend cycles freeing your variable?

Of course you know better than me how the Espruino GC works. If you still think that variable deletion is a good feature, I would suggest adding compiler hints. They could look something like:
```js
// espruino free var "foo"
```
Because they are comments, they can be as non-standard as you wish, while keeping comatibility with javascript.