### PR TITLE
Require switch blocks when declaring variables

### DIFF
--- a/apps/.eslintrc.json
+++ b/apps/.eslintrc.json
@@ -142,7 +142,6 @@
                 "SwitchCase": 1
             }
         ],
-        "no-case-declarations": "off",
         "no-constant-condition": "off",
         "no-delete-var": "off",
         "no-empty": "off",

--- a/apps/calculator/app.js
+++ b/apps/calculator/app.js
@@ -369,7 +369,7 @@ function buttonPress(val) {
       }
       hasPressedNumber = false;
       break;
-    default:
+    default: {
       specials.R.val = 'C';
       if (!swipeEnabled) drawKey('R', specials.R);
       const is0Negative = (currNumber === 0 && 1/currNumber === -Infinity);
@@ -385,6 +385,7 @@ function buttonPress(val) {
       hasPressedNumber = currNumber;
       displayOutput(currNumber);
       break;
+    }
   }
 }
 

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -99,7 +99,7 @@ const sameDay = function(d1, d2) {
 const drawEvent = function(ev, curDay, x1, y1, x2, y2) {
   "ram";
   switch(ev.type) {
-    case "e": // alarm/event
+    case "e": { // alarm/event
       const hour = 0|ev.date.getHours() + 0|ev.date.getMinutes()/60.0;
       const slice = hour/24*(eventsPerDay-1); // slice 0 for 0:00 up to eventsPerDay for 23:59
       const height = (y2-2) - (y1+2); // height of a cell
@@ -107,6 +107,7 @@ const drawEvent = function(ev, curDay, x1, y1, x2, y2) {
       const ystart = (y1+2) + slice*sliceHeight;
       g.setColor(bgEvent).fillRect(x1+1, ystart, x2-2, ystart+sliceHeight);
       break;
+    }
     case "h": // holiday
       g.setColor(bgColorWeekend).fillRect(x1+1, y1+1, x2-1, y2-1);
       break;

--- a/apps/colorwheel/app.js
+++ b/apps/colorwheel/app.js
@@ -64,13 +64,14 @@
       switch (true) {
         case (Radius > outerRadius): Color = '#000000'; break;
         case (Radius < innerRadius): Color = '#FFFFFF'; break;
-        default:
+        default: {
           let Phi = Math.atan2(dy,dx) + halfPi;
           if (Phi < 0)     { Phi += twoPi; }
           if (Phi > twoPi) { Phi -= twoPi; }
 
           let Index = Math.floor(12*Phi/twoPi);
           Color = ColorList[Index];
+        }
       }
     g.setColor(1,1,1);
     g.fillCircle(CenterX,CenterY, innerRadius);

--- a/apps/configurable_clock/app.js
+++ b/apps/configurable_clock/app.js
@@ -894,7 +894,7 @@
         g.setFontAlign(-1,0);
         g.drawString('9', CenterX-outerRadius,CenterY);
         break;
-      case '1-12':
+      case '1-12': {
         let innerRadius = outerRadius * 0.9 - 10;
 
         let dark = g.theme.dark;
@@ -942,6 +942,7 @@
 
           g.drawString(i == 0 ? '12' : '' + i, x,y);
         }
+      }
     }
 
     let now = new Date();

--- a/apps/gbmusic/app.js
+++ b/apps/gbmusic/app.js
@@ -136,19 +136,21 @@ function rIcon(l) {
   const x2 = l.x+l.w-1,
     y2 = l.y+l.h-1;
   switch(l.icon) {
-    case "pause":
+    case "pause": {
       const w13 = l.w/3;
       g.drawRect(l.x, l.y, l.x+w13, y2);
       g.drawRect(l.x+l.w-w13, l.y, x2, y2);
       break;
-    case "play":
+    }
+    case "play": {
       g.drawPoly([
         l.x, l.y,
         x2, l.y+l.h/2,
         l.x, y2,
       ], true);
       break;
-    case "previous":
+    }
+    case "previous": {
       const w15 = l.w*1/5;
       g.drawPoly([
         x2, l.y,
@@ -157,7 +159,8 @@ function rIcon(l) {
       ], true);
       g.drawRect(l.x, l.y, l.x+w15, y2);
       break;
-    case "next":
+    }
+    case "next": {
       const w45 = l.w*4/5;
       g.drawPoly([
         l.x, l.y,
@@ -166,12 +169,14 @@ function rIcon(l) {
       ], true);
       g.drawRect(l.x+w45, l.y, x2, y2);
       break;
-    default: // red X
+    }
+    default: { // red X
       console.log(`Unknown icon: ${l.icon}`);
       g.setColor("#f00")
         .drawRect(l.x, l.y, x2, y2)
         .drawLine(l.x, l.y, x2, y2)
         .drawLine(l.x, y2, x2, l.y);
+    }
   }
 }
 let layout;

--- a/apps/marioclock/marioclock-app.js
+++ b/apps/marioclock/marioclock-app.js
@@ -134,11 +134,12 @@ function truncStr(str, max) {
 
 function phoneInbound(evt) {
   switch (evt.t) {
-    case 'notify':
+    case 'notify': {
       const sender = truncStr(evt.sender, 10);
       const subject = truncStr(evt.subject, 15);
       phoneNewMessage("notify", `${sender} - '${subject}'`);
       break;
+    }
     case 'call':
       if (evt.cmd === "accept") {
         let nameOrNumber = "Unknown";

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -54,7 +54,7 @@ let manageEvent = function(ovr, event) {
         showMessage(ovr, event);
       break;
 
-    case "modify":
+    case "modify": {
       let find = false;
       eventQueue.forEach(element => {
         if (element.id == event.id) {
@@ -68,7 +68,7 @@ let manageEvent = function(ovr, event) {
       if (!callInProgress)
         showMessage(ovr, event);
       break;
-
+    }
     case "remove":
       if (eventQueue.length == 0 && !callInProgress)
         next(ovr);

--- a/apps/score/score.app.js
+++ b/apps/score/score.app.js
@@ -318,7 +318,7 @@ function handleInput(button) {
       showSettingsMenu();
       return;
     case 3:
-    case 4:
+    case 4: {
       let hLimit = currentSet() - setsPerPage() + 1;
       let lLimit = 0;
       let val = (button * 2 - 7);
@@ -326,6 +326,7 @@ function handleInput(button) {
       if (firstShownSet > hLimit) firstShownSet = hLimit;
       if (firstShownSet < lLimit) firstShownSet = lLimit;
       break;
+    }
   }
 
   draw();

--- a/apps/waternet/app.js
+++ b/apps/waternet/app.js
@@ -1391,13 +1391,14 @@ function initLevel(aRandomSeed, noLoading) {
       boardWidth = 10;
       boardHeight = 8;
       break;
-    case DIFFRANDOM:
+    case DIFFRANDOM: {
       let rnd = random(255);
       boardWidth = 5 + (rnd % (MAXBOARDWIDTH - 5 + 1)); //5 is smallest level width from very easy
       rnd = random(255);
       boardHeight = 5 + (rnd % (MAXBOARDHEIGHT - 5 + 1)); //5 is smallest level height from very easy
       maxLevel = 0; //special value with random
       break;
+    }
   }
   //add space for arrows based on same posadd value (1 or 0 depending if sliding is allowed)
   boardWidth -= posAdd + posAdd;


### PR DESCRIPTION
When declaring variables inside switch cases, the variables are also available in the other switch cases, with some special rules. This is basically never the intention, and can lead to weird bugs. I suggest requiring switch blocks when variables are declared, which limits the scope of the variable to the individual case.