### PR TITLE
health: add hrm info to readme

### DIFF
--- a/apps/health/README.md
+++ b/apps/health/README.md
@@ -4,7 +4,7 @@ Logs health data to a file in a defined interval, and provides an app to view it
 
 ## Usage
 
-Once installed, health data is logged automatically.
+Once installed, health data is logged automatically. Entries are stored with a 10 minute interval.
 
 To view data, run the `Health` app from your watch.
 
@@ -39,6 +39,8 @@ to grab historical health info.
 minifier used in the App Loader, so we use the closure compiler to pre-minify them.
 The easiest way to use it is to install `https://github.com/espruino/EspruinoDocs`
 and run `EspruinoDocs/bin/minify.js lib.js lib.min.js`
+
+HRM data is stored as a number representing the best/average value from a 10 minute period.
 
 ## TODO
 


### PR DESCRIPTION
reference:

> The health app on the Bangle only stores data every 10 minutes. The '3 minute' option is for the heart rate - it'll take 3 HRM samples every 10 minute slot and use the best/average value of HRM readings - but it only stores one reading per 10 minutes.

https://forum.espruino.com/conversations/386312/#comment16972306