### PR TITLE
flightdash: drop unnecessary boolean formatter

### DIFF
--- a/apps/flightdash/flightdash.settings.js
+++ b/apps/flightdash/flightdash.settings.js
@@ -316,7 +316,6 @@
     },
     'Use Baro': {
       value: !!settings.useBaro,  // !! converts undefined to false
-      format: v => v ? 'On' : 'Off',
       onchange: v => {
         settings.useBaro = v;
         writeSettings();


### PR DESCRIPTION
This drops the warning we keep seeing (`Settings for flightdash has a boolean formatter - this is handled automatically, the line can be removed`). No change in behaviour, no need for a version bump.