### PR TITLE
Warn about empty blocks

### DIFF
--- a/apps/.eslintrc.json
+++ b/apps/.eslintrc.json
@@ -144,7 +144,7 @@
         ],
         "no-constant-condition": "off",
         "no-delete-var": "off",
-        "no-empty": "off",
+        "no-empty": ["warn", { "allowEmptyCatch": true }],
         "no-global-assign": "off",
         "no-inner-declarations": "off",
         "no-prototype-builtins": "off",

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -104,7 +104,6 @@ Bangle.on('lcdPower',on=>{
   if (on) {
       secondInterval = setInterval(draw, 1000);
       draw(); // draw immediately
-  }else{
   }
 });
 Bangle.on('lock',on=>{

--- a/apps/aptsciclk/ChangeLog
+++ b/apps/aptsciclk/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Formatting
 0.07: Added potato GLaDOS and quote functionality when you tap her
 0.08: Fixed drawing issues with the quotes and added more 
+0.09: Minor code improvements

--- a/apps/aptsciclk/app.js
+++ b/apps/aptsciclk/app.js
@@ -270,8 +270,7 @@ function queueDraw() {
 
 
 function draw() {
-  if (pause){}
-  else{
+  if (!pause){
     // get date
     var d = new Date();
     var da = d.toString().split(" ");

--- a/apps/aptsciclk/metadata.json
+++ b/apps/aptsciclk/metadata.json
@@ -2,7 +2,7 @@
     "id": "aptsciclk",
     "name": "Apeture Science Clock",
     "shortName":"AptSci Clock",
-    "version": "0.08",
+    "version": "0.09",
     "description": "A clock based on the portal series",
     "icon": "app.png",
     "screenshots": [{"url":"screenshot.png"}],

--- a/apps/carcrazy/ChangeLog
+++ b/apps/carcrazy/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Car Crazy is now avialable for testing in beta!
 0.02: 10 Levels are now added making the game harder as it goes along. Some of the levels include multiple cars and faster cars. More levels coming soon.
 0.03: Settings are now added so that you can reset your high score.
+0.04: Minor code improvements.

--- a/apps/carcrazy/app.js
+++ b/apps/carcrazy/app.js
@@ -66,10 +66,8 @@ function moveEnemyPosition(){
       enemyPositonCenterX2 = 120;
     }else if((randomRoadPositionIndicator2 == 3)){
       enemyPositonCenterX2 = 155;
-    }else if(level == 7||level == 8){
-
     }
-  }
+  } // TODO: else if(level == 7)
 }
 
 function collision(){

--- a/apps/carcrazy/metadata.json
+++ b/apps/carcrazy/metadata.json
@@ -2,7 +2,7 @@
   "id": "carcrazy",
   "name": "Car Crazy",
   "shortName": "Car Crazy",
-  "version": "0.03",
+  "version": "0.04",
   "description": "A simple car game where you try to avoid the other cars by tilting your wrist left and right. Hold down button 2 to start.",
   "icon": "carcrash.png",
   "tags": "game",

--- a/apps/doztime/ChangeLog
+++ b/apps/doztime/ChangeLog
@@ -5,3 +5,4 @@
 0.05: extraneous comments and code removed
       display improved
       now supports Adjust Clock widget, if installed
+0.06: minor code improvements

--- a/apps/doztime/app-bangle1.js
+++ b/apps/doztime/app-bangle1.js
@@ -223,9 +223,8 @@ function fixTime() {
 	Bangle.on("GPS",function cb(g) {
 		Bangle.setGPSPower(0,"time");
 		Bangle.removeListener("GPS",cb);
-		if (!g.time || (g.time.getFullYear()<2000) ||
-			(g.time.getFullYear()>2200)) {
-		} else {
+		if (g.time && (g.time.getFullYear()>=2000) &&
+			(g.time.getFullYear()<=2200)) {
 			// We have a GPS time. Set time
 			setTime(g.time.getTime()/1000);
 		}

--- a/apps/doztime/metadata.json
+++ b/apps/doztime/metadata.json
@@ -2,7 +2,7 @@
   "id": "doztime",
   "name": "Dozenal Digital Time",
   "shortName": "Dozenal Digital",
-  "version": "0.05",
+  "version": "0.06",
   "description": "A dozenal Holocene calendar and dozenal diurnal digital clock",
   "icon": "app.png",
   "type": "clock",

--- a/apps/hwid_a_battery_widget/ChangeLog
+++ b/apps/hwid_a_battery_widget/ChangeLog
@@ -8,3 +8,4 @@
 0.08: Handling exceptions
 0.09: Add option for showing battery high mark
 0.10: Fix background color
+0.11: Minor code improvements

--- a/apps/hwid_a_battery_widget/metadata.json
+++ b/apps/hwid_a_battery_widget/metadata.json
@@ -3,7 +3,7 @@
   "name": "A Battery Widget (with percentage) - Hanks Mod",
   "shortName":"H Battery Widget",
   "icon": "widget.png",
-  "version":"0.10",
+  "version":"0.11",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/hwid_a_battery_widget/widget.js
+++ b/apps/hwid_a_battery_widget/widget.js
@@ -24,8 +24,7 @@
 	var s = width - 1;
 	var x = this.x;
 	var	y = this.y;
-	if ((typeof x === 'undefined') || (typeof y === 'undefined')) {
-	} else {
+	if (x !== undefined && y !== undefined) {
 		g.setBgColor(COLORS.white);
 		g.clearRect(old_x, old_y, old_x + width, old_y + height);
 

--- a/apps/novaclock/app.js
+++ b/apps/novaclock/app.js
@@ -85,7 +85,7 @@ function novaOpenEyes(speed, white, animation) {
           scale: 2.2
         });
       }, speed * 5);
-    } else {}
+    }
   } else {
 
     g.drawImage(novaEyesStage4(), -10, -10, {
@@ -126,7 +126,7 @@ function novaOpenEyes(speed, white, animation) {
         });
         open = true;
       }, speed * 5);
-    } else {}
+    }
   }
 }
 
@@ -136,7 +136,7 @@ function novaCloseEyes(speed, white, animation) {
       g.drawImage(novaEyesStage0(), -10, -10, {
         scale: 2.2
       });
-    } else {}
+    }
     setTimeout(function() {
       g.drawImage(novaEyesStage1(), -10, -10, {
         scale: 2.2
@@ -164,7 +164,7 @@ function novaCloseEyes(speed, white, animation) {
       g.drawImage(novaEyesWhiteStage0(), -10, -10, {
         scale: 2.2
       });
-    } else {}
+    }
     setTimeout(function() {
       timedraw(true);
       g.drawImage(novaEyesTransStage1(), -10, -10, {

--- a/apps/red7game/ChangeLog
+++ b/apps/red7game/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Update cards to draw rounded on newer firmware. Make sure in-game menu can't be pulled up during end of game.
 0.05: add confirmation prompt to new game to prevent fat fingering new game during existing one.
 0.06: fix AI logic typo and add prompt to show what AI played each turn.
+0.07: Minor code improvements.

--- a/apps/red7game/metadata.json
+++ b/apps/red7game/metadata.json
@@ -2,7 +2,7 @@
   "name": "Red 7 Card Game",
   "shortName" : "Red 7",
   "icon": "icon.png",
-  "version":"0.06",
+  "version":"0.07",
   "description": "An implementation of the card game Red 7 for your watch. Play against the AI and be the last player still in the game to win!",
   "tags": "game",
   "supports":["BANGLEJS2"],

--- a/apps/red7game/red7.js
+++ b/apps/red7game/red7.js
@@ -486,8 +486,7 @@ function canPlay(hand, palette, otherPalette) {
       } else {
         //Check if any palette play can win with rule.
         for(let h of hand.handCards) {
-          if(h === c) {}
-          else {
+          if(h !== c) {
             clonePalette.addCard(c);
             if(isWinningCombo(c, clonePalette, otherPalette)) {
               return true;
@@ -531,8 +530,7 @@ class AI {
       } else {
         //Check if any palette play can win with rule.
         for(let h of this.hand.handCards) {
-          if(h === c) {}
-          else {
+          if(h !== c) {
             clonePalette.addCard(h);
             if(isWinningCombo(c, clonePalette, otherPalette)) {
               ruleStack.addCard(c);

--- a/apps/spacew/prep/minitar.js
+++ b/apps/spacew/prep/minitar.js
@@ -8,8 +8,6 @@ const hs = require('./heatshrink.js');
 if (pc) {
     fs = require('fs');
     var print=console.log;
-} else {
-  
 }
 
 function writeDir(json) {

--- a/apps/tabanchi/ChangeLog
+++ b/apps/tabanchi/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial implementation
 0.02: Fix app icon
 0.03: Fix clock animation issue and reduce source size
+0.04: Minor code improvements

--- a/apps/tabanchi/app.js
+++ b/apps/tabanchi/app.js
@@ -968,8 +968,7 @@ function activateItem () {
       animateToClock();
       break;
     case 0: // food
-      if (tama.sleep) {
-      } else {
+      if (!tama.sleep) {
       // evolution = 0;
         mode = 'food';
         lightSelect = 0;
@@ -979,8 +978,7 @@ function activateItem () {
       mode = 'light';
       break;
     case 2: // game
-      if (tama.sleep) {
-      } else {
+      if (!tama.sleep) {
         animateToGame();
       }
       break;

--- a/apps/tabanchi/metadata.json
+++ b/apps/tabanchi/metadata.json
@@ -2,7 +2,7 @@
   "id": "tabanchi",
   "name": "Tabanchi",
   "shortName": "Tabanchi",
-  "version": "0.03",
+  "version": "0.04",
   "type": "app",
   "description": "Tamagotchi WatchApp",
   "icon": "app.png",


### PR DESCRIPTION
The `no-empty` rule checks that there are no empty blocks defined in the code, similar to the check for unused variables.

I have disabled the check for empty catch blocks, because they are a useful shortcut for trying something and failing softly. Obviously it would be better to enforce explicit error handling for all try blocks, but I think this is one of the cases where the benefit doesn't outweigh the extra work for contributors.

Warnings about empty blocks can make the developer restructure their code to be more readable, have less overhead, and can help them find bugs. I actually think I found one in the `carcrazy` app. @Ronin0000 is it on purpose that level 7 is ignored? It seems like it should be included in the check at line 49 :)

I have tested these apps to the point where I'm convinced that I have introduced 0 new bugs.