### PR TITLE
messagegui: swipe up/down on msg goes to newer/older msg

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -102,3 +102,5 @@
 0.73: Add sharp left+right nav icons
 0.74: Add option for driving on left (affects roundabout icons in navigation)
 0.75: Handle text with images in messages list by just displaying the first line
+0.76: Swipe up/down on a shown message to show the next newer/older message.
+

--- a/apps/messagegui/README.md
+++ b/apps/messagegui/README.md
@@ -38,6 +38,7 @@ When a message is shown, you'll see a screen showing the message title and text.
 * The 'back-arrow' button (or physical button on Bangle.js 2) goes back to Messages, marking the current message as read.
 * The top-left icon shows more options, for instance deleting the message of marking unread
 * On Bangle.js 2 you can tap on the message body to view a scrollable version of the title and text (or can use the top-left icon + `View Message`)
+- On Bangle.js 2 swipe up/down to show newer/older message
 * If shown, the 'tick' button:
    * **Android** opens the notification on the phone
    * **iOS** responds positively to the notification (accept call/etc)

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -289,7 +289,8 @@ function showMessageSettings(msg) {
 }
 
 function showMessage(msgid) {
-  var msg = MESSAGES.find(m=>m.id==msgid);
+  let idx = MESSAGES.findIndex(m=>m.id==msgid);
+  var msg = MESSAGES[idx];
   if (updateLabelsInterval) {
     clearInterval(updateLabelsInterval);
     updateLabelsInterval=undefined;
@@ -389,9 +390,11 @@ function showMessage(msgid) {
     {type:"h",fillx:1, c: footer}
   ]},{back:goBack});
 
-  Bangle.swipeHandler = lr => {
+  Bangle.swipeHandler = (lr,ud) => {
     if (lr>0 && posHandler) posHandler();
     if (lr<0 && negHandler) negHandler();
+    if (ud>0 && idx<MESSAGES.length-1) showMessage(MESSAGES[idx+1].id);
+    if (ud<0 && idx>0) showMessage(MESSAGES[idx-1].id);
   };
   Bangle.on("swipe", Bangle.swipeHandler);
   g.reset().clearRect(Bangle.appRect);

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.75",
+  "version": "0.76",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
Swipe up/down on a shown message to show newer/older message.

I would personally rather map up/down to older/newer. But I think up/down mapped with newer/older makes more sense with how 'tick' and 'cross' swipes are done and how the messages are presented in the scroller list. 

Thoughts? @gfwilliams @bobrippling

The change can be tried by installing from my app loader: https://thyttan.github.io/BangleApps/?q=messagegui