### PR TITLE
linuxclock - Bugfix Add 1 to month received from Date.getMonth (0..11)

### DIFF
--- a/apps/linuxclock/ChangeLog
+++ b/apps/linuxclock/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Update clock_info to avoid a redraw
 0.04: Fix clkinfo -- use .get instead of .show
 0.05: Use clock_info module as an app
+0.06: Fix month in date (jan 0 -> 1, etc)

--- a/apps/linuxclock/app.js
+++ b/apps/linuxclock/app.js
@@ -112,7 +112,7 @@ function getTime(){
 
 function getDate(){
   var date = new Date();
-  return twoD(date.getDate()) + "." + twoD(date.getMonth());
+  return twoD(date.getDate()) + "." + twoD(date.getMonth() + 1);
 }
 
 function getDay(){

--- a/apps/linuxclock/metadata.json
+++ b/apps/linuxclock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "linuxclock",
   "name": "Linux Clock",
-  "version": "0.05",
+  "version": "0.06",
   "description": "A Linux inspired clock.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
Date.getMonth() returns an integer from 0 to 11, so to display the date I think it's better to add 1.

I did not try to install the app by deploying the full website but I did test the simple change by modifying the app directly with the IDE.

For such a simple change I hope it's enough.

