### PR TITLE
sched: permit buzz count to be infinite

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -23,3 +23,4 @@
 0.20: Alarm dismiss and snooze events
 0.21: Fix crash in clock_info
 0.22: Dated event repeat option
+0.23: Allow buzzing forever when an alarm fires

--- a/apps/sched/README.md
+++ b/apps/sched/README.md
@@ -14,9 +14,9 @@ Global Settings
 ---------------
 
 - `Unlock at Buzz` - If `Yes` the alarm/timer will unlock the watch
+- `Delete Expired Timers` - Default for whether expired timers are removed after firing.
 - `Default Auto Snooze` - Default _Auto Snooze_ value for newly created alarms (_Alarms_ only)
 - `Default Snooze` - Default _Snooze_ value for newly created alarms/timers
-- `Default Repeat` - Default _Repeat_ value for newly created alarms (_Alarms_ only)
 - `Buzz Count` - The number of buzzes before the watch goes silent
 - `Buzz Interval` - The interval between one buzz and the next
 - `Default Alarm/Timer Pattern` - Default vibration pattern for newly created alarms/timers

--- a/apps/sched/README.md
+++ b/apps/sched/README.md
@@ -17,7 +17,7 @@ Global Settings
 - `Delete Expired Timers` - Default for whether expired timers are removed after firing.
 - `Default Auto Snooze` - Default _Auto Snooze_ value for newly created alarms (_Alarms_ only)
 - `Default Snooze` - Default _Snooze_ value for newly created alarms/timers
-- `Buzz Count` - The number of buzzes before the watch goes silent
+- `Buzz Count` - The number of buzzes before the watch goes silent, or "forever" to buzz until stopped.
 - `Buzz Interval` - The interval between one buzz and the next
 - `Default Alarm/Timer Pattern` - Default vibration pattern for newly created alarms/timers
 

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.22",
+  "version": "0.23",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -71,7 +71,7 @@ function showAlarm(alarm) {
 
     const pattern = alarm.vibrate || (alarm.timer ? settings.defaultTimerPattern : settings.defaultAlarmPattern);
     require("buzz").pattern(pattern).then(() => {
-      if (buzzCount--) {
+      if (buzzCount == null || buzzCount--) {
         setTimeout(buzz, settings.buzzIntervalMillis);
       } else if (alarm.as) { // auto-snooze
         buzzCount = settings.buzzCount;

--- a/apps/sched/settings.js
+++ b/apps/sched/settings.js
@@ -44,11 +44,12 @@
 
     /*LANG*/"Buzz Count": {
       value: settings.buzzCount,
-      min: 5,
+      min: 4,
       max: 15,
       step: 1,
+      format: v => v === 4 ? "Forever" : v,
       onchange: v => {
-        settings.buzzCount = v;
+        settings.buzzCount = v === 4 ? null : v;
         require("sched").setSettings(settings);
       }
     },

--- a/apps/sched/settings.js
+++ b/apps/sched/settings.js
@@ -43,7 +43,7 @@
     },
 
     /*LANG*/"Buzz Count": {
-      value: settings.buzzCount,
+      value: settings.buzzCount == null ? 4 : settings.buzzCount,
       min: 4,
       max: 15,
       step: 1,

--- a/typescript/types/sched.d.ts
+++ b/typescript/types/sched.d.ts
@@ -87,7 +87,7 @@ declare module Sched {
     defaultSnoozeMillis: number,
     defaultAutoSnooze: boolean,
     defaultDeleteExpiredTimers: boolean,
-    buzzCount: number,
+    buzzCount: number | null, // null means buzz forever
     buzzIntervalMillis: number,
     defaultAlarmPattern: string,
     defaultTimerPattern: string,


### PR DESCRIPTION
... so an alarm will buzz until it is stopped by the user.

Also updated `sched`'s readme to align it with the latest code.