### PR TITLE
settings: fix typo

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -78,3 +78,4 @@ of 'Select Clock'
 0.67: Rename 'Wake on BTN1/Touch' to 'Wake on Button/Tap' on Bangle.js 2
 0.68: Fix syntax error
 0.69: Add option to wake on double tap
+0.70: Fix load() typo

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.69",
+  "version": "0.70",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -641,7 +641,7 @@ function showUtilMenu() {
           storage.writeJSON("setting.json",s);
           E.showAlert(/*LANG*/"Calibrated!").then(() => load("setting.app.js"));
         } else {
-          E.showAlert(/*LANG*/"Please charge Bangle.js for 3 hours and try again").then(() => load("settings.app.js"));
+          E.showAlert(/*LANG*/"Please charge Bangle.js for 3 hours and try again").then(() => load("setting.app.js"));
         }
       });
     };


### PR DESCRIPTION
This was breaking a reload of the settings app after cancelling battery recalibration