### PR TITLE
sched: add day selection to interface.html

### DIFF
--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -163,6 +163,26 @@ function renderAlarm(alarm, exists) {
   tr.appendChild(tdTime);
   tdTime.appendChild(inputTime);
 
+  const tdDays = document.createElement('td');
+  tr.appendChild(tdDays);
+  const selectDays = document.createElement('select');
+  selectDays.multiple = true;
+  selectDays.classList.add('form-input');
+  selectDays.dataset.uid = alarm.id;
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const options = days.map((day, i) => {
+    const option = document.createElement('option');
+    option.value = day;
+    option.text = day;
+    option.selected = alarm.dow & (1 << i);
+    selectDays.appendChild(option);
+    return option;
+  });
+  selectDays.onchange = (e => {
+    alarm.dow = options.reduce((bits, opt, i) => bits | (opt.selected ? 1 << i : 0), 0);
+  });
+  tdDays.appendChild(selectDays);
+
   const tdSummary = document.createElement('td');
   tr.appendChild(tdSummary);
   const inputSummary = document.createElement('input');
@@ -320,6 +340,7 @@ function onInit() {
         <tr>
           <th>Type</th>
           <th>Date/Time</th>
+          <th>Days</th>
           <th>Summary</th>
           <th>On?</th>
           <th></th>

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -4,11 +4,12 @@
     <link rel="stylesheet" href="../../css/spectre-icons.min.css">
     <style>
       .multi-select {
-        height: 100%; /* e.g. day <select> */
+        /* e.g. day <select> */
+        height: 100%;
       }
 
       .single-row {
-        /* no border between single rowspans, 1st & $th */
+        /* no border between single rowspans */
         border-bottom: none;
       }
 
@@ -256,14 +257,16 @@ function renderAlarm(alarm, exists) {
     document.getElementById('events').removeChild(tr2);
   });
 
-  tr.appendChild(tdType); tdType.classList.add('single-row');
   tr.appendChild(tdOptions); tdType.classList.add('single-row');
+  tr.appendChild(tdType); tdType.classList.add('single-row');
   tr.appendChild(tdInfo); tdType.classList.add('single-row');
   tr2.appendChild(tdTime); tdTime.colSpan = 3;
   if (tdDays) {
     tr.appendChild(tdDays); tdDays.rowSpan = 2;
+  } else {
+    tdSummary.colSpan = 2;
   }
-  tr.appendChild(tdSummary); tdType.classList.add('single-row');
+  tr.appendChild(tdSummary); tdSummary.rowSpan = 2;
 
   document.getElementById('events').appendChild(tr);
   document.getElementById('events').appendChild(tr2);
@@ -370,10 +373,11 @@ function onInit() {
     <table class="table">
       <thead>
         <tr>
-          <th>Date/Time</th>
+          <th>Options</th>
+          <th>Type</th>
+          <th></th>
           <th>Days</th>
           <th>Summary</th>
-          <th></th>
         </tr>
       </thead>
       <tbody id="events">

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -4,7 +4,22 @@
     <link rel="stylesheet" href="../../css/spectre-icons.min.css">
     <style>
       .multi-select {
-        height: 100%;
+        height: 100%; /* e.g. day <select> */
+      }
+
+      #events > tr.event-row {
+        /* thick borders between double-rows */
+        border-top: 2px solid grey;
+      }
+
+      #events > tr.event-row > td:last-child,
+      #events > tr.event-row > td:first-child {
+        /* no border between single rowspans, 1st & $th */
+        border-bottom: none;
+      }
+
+      .event-summary {
+        text-align: center;
       }
     </style>
     <script src="../../core/lib/interface.js"></script>

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -7,15 +7,15 @@
         height: 100%; /* e.g. day <select> */
       }
 
-      #events > tr.event-row {
-        /* thick borders between double-rows */
-        border-top: 2px solid grey;
-      }
-
       #events > tr.event-row > td:last-child,
       #events > tr.event-row > td:first-child {
         /* no border between single rowspans, 1st & $th */
         border-bottom: none;
+      }
+
+      #events > tr:nth-child(2n) > td:nth-child(2) {
+        justify-content: center;
+        display: flex;
       }
 
       .event-summary {
@@ -207,7 +207,7 @@ function renderAlarm(alarm, exists) {
   tdDays.appendChild(selectDays);
 
   const tdSummary = document.createElement('td');
-  tr.appendChild(tdSummary); tdSummary.rowSpan = 2;
+  tr.appendChild(tdSummary); tdSummary.rowSpan = 1; tdSummary.colSpan = 2;
   const inputSummary = document.createElement('input');
   inputSummary.type = "text";
   inputSummary.classList.add('event-summary');
@@ -224,7 +224,7 @@ function renderAlarm(alarm, exists) {
   inputSummary.onchange();
 
   const tdOptions = document.createElement('td');
-  tr.appendChild(tdOptions); tdOptions.rowSpan = 1;
+  tr2.appendChild(tdOptions); tdOptions.rowSpan = 1;
 
   const onOffCheck = document.createElement('input');
   onOffCheck.type = 'checkbox';
@@ -366,7 +366,7 @@ function onInit() {
           <th>Date/Time</th>
           <th>Days</th>
           <th>Summary</th>
-          <th>State</th>
+          <th></th>
         </tr>
       </thead>
       <tbody id="events">

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -142,8 +142,9 @@ function renderAlarm(alarm, exists) {
   tdType.type = "text";
   tdType.classList.add('event-summary');
   const inputTime = document.createElement('input');
+  let type;
   if (localDate) {
-    tdType.textContent = "Event";
+    type = "Event";
     inputTime.type = "datetime-local";
     inputTime.value = localDate.toISOString().slice(0,16);
     inputTime.onchange = (e => {
@@ -159,18 +160,19 @@ function renderAlarm(alarm, exists) {
     inputTime.value = `${hours}:${mins}:${secs}`;
 
     if (alarm.timer) {
-      tdType.textContent = "Timer";
+      type = "Timer";
       inputTime.onchange = e => {
         alarm.timer = hmsToMs(inputTime.value);
         // alarm.t is set on upload
       };
     } else {
-      tdType.textContent = "Alarm";
+      type = "Alarm";
       inputTime.onchange = e => {
         alarm.t = hmsToMs(inputTime.value);
       };
     }
   }
+  tdType.textContent = type;
   if (!exists) {
     const asterisk = document.createElement('sup');
     asterisk.textContent = '*';
@@ -182,26 +184,29 @@ function renderAlarm(alarm, exists) {
   const tdTime = document.createElement('td');
   tdTime.appendChild(inputTime);
 
-  const tdDays = document.createElement('td');
-  const selectDays = document.createElement('select');
-  selectDays.multiple = true;
-  selectDays.classList.add('form-input', 'multi-select');
-  selectDays.dataset.uid = alarm.id;
-  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const options = days.map((day, i) => {
-    const option = document.createElement('option');
-    option.value = day;
-    option.text = day;
-    option.selected = alarm.dow & (1 << i);
-    if(day !== "Sun")
-      selectDays.appendChild(option);
-    return option;
-  });
-  selectDays.appendChild(options.find(o => o.text === "Sun"));
-  selectDays.onchange = (e => {
-    alarm.dow = options.reduce((bits, opt, i) => bits | (opt.selected ? 1 << i : 0), 0);
-  });
-  tdDays.appendChild(selectDays);
+  let tdDays;
+  if (type === "Alarm") {
+    tdDays = document.createElement('td');
+    const selectDays = document.createElement('select');
+    selectDays.multiple = true;
+    selectDays.classList.add('form-input', 'multi-select');
+    selectDays.dataset.uid = alarm.id;
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const options = days.map((day, i) => {
+      const option = document.createElement('option');
+      option.value = day;
+      option.text = day;
+      option.selected = alarm.dow & (1 << i);
+      if(day !== "Sun")
+        selectDays.appendChild(option);
+      return option;
+    });
+    selectDays.appendChild(options.find(o => o.text === "Sun"));
+    selectDays.onchange = (e => {
+      alarm.dow = options.reduce((bits, opt, i) => bits | (opt.selected ? 1 << i : 0), 0);
+    });
+    tdDays.appendChild(selectDays);
+  }
 
   const tdSummary = document.createElement('td');
   const inputSummary = document.createElement('input');
@@ -255,7 +260,9 @@ function renderAlarm(alarm, exists) {
   tr.appendChild(tdOptions); tdType.classList.add('single-row');
   tr.appendChild(tdInfo); tdType.classList.add('single-row');
   tr2.appendChild(tdTime); tdTime.colSpan = 3;
-  tr.appendChild(tdDays); tdDays.rowSpan = 2;
+  if (tdDays) {
+    tr.appendChild(tdDays); tdDays.rowSpan = 2;
+  }
   tr.appendChild(tdSummary); tdType.classList.add('single-row');
 
   document.getElementById('events').appendChild(tr);

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -255,6 +255,7 @@ function renderAlarm(alarm, exists) {
   buttonDelete.onclick = (e => {
     alarms = alarms.filter(a => a !== alarm);
     document.getElementById('events').removeChild(tr);
+    document.getElementById('events').removeChild(tr2);
   });
 
   document.getElementById('events').appendChild(tr);

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -257,10 +257,10 @@ function renderAlarm(alarm, exists) {
     document.getElementById('events').removeChild(tr2);
   });
 
-  tr.appendChild(tdOptions); tdType.classList.add('single-row');
-  tr.appendChild(tdType); tdType.classList.add('single-row');
-  tr.appendChild(tdInfo); tdType.classList.add('single-row');
-  tr2.appendChild(tdTime); tdTime.colSpan = 3;
+  tr.appendChild(tdTime); tdTime.colSpan = 3; tdTime.classList.add('single-row');
+  tr2.appendChild(tdOptions);
+  tr2.appendChild(tdType);
+  tr2.appendChild(tdInfo);
   if (tdDays) {
     tr.appendChild(tdDays); tdDays.rowSpan = 2;
   } else {
@@ -373,9 +373,7 @@ function onInit() {
     <table class="table">
       <thead>
         <tr>
-          <th>Options</th>
-          <th>Type</th>
-          <th></th>
+          <th colspan="3">Time & Options</th>
           <th>Days</th>
           <th>Summary</th>
         </tr>

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -8,7 +8,7 @@
         height: 100%;
       }
 
-      .single-row {
+      td.single-row {
         /* no border between single rowspans */
         border-bottom: none;
       }

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -7,13 +7,12 @@
         height: 100%; /* e.g. day <select> */
       }
 
-      #events > tr.event-row > td:last-child,
-      #events > tr.event-row > td:first-child {
+      .single-row {
         /* no border between single rowspans, 1st & $th */
         border-bottom: none;
       }
 
-      #events > tr:nth-child(2n) > td:nth-child(2) {
+      .btn-center {
         justify-content: center;
         display: flex;
       }
@@ -138,10 +137,10 @@ function renderAlarm(alarm, exists) {
   const tr2 = document.createElement('tr');
   tr.classList.add('event-row');
   tr.dataset.uid = alarm.id;
+
   const tdType = document.createElement('td');
   tdType.type = "text";
   tdType.classList.add('event-summary');
-  tr.appendChild(tdType); tdType.rowSpan = 1;
   const inputTime = document.createElement('input');
   if (localDate) {
     tdType.textContent = "Event";
@@ -181,11 +180,9 @@ function renderAlarm(alarm, exists) {
   inputTime.classList.add('form-input');
   inputTime.dataset.uid = alarm.id;
   const tdTime = document.createElement('td');
-  tr2.appendChild(tdTime); tdTime.rowSpan = 1;
   tdTime.appendChild(inputTime);
 
   const tdDays = document.createElement('td');
-  tr.appendChild(tdDays); tdDays.rowSpan = 2;
   const selectDays = document.createElement('select');
   selectDays.multiple = true;
   selectDays.classList.add('form-input', 'multi-select');
@@ -207,7 +204,6 @@ function renderAlarm(alarm, exists) {
   tdDays.appendChild(selectDays);
 
   const tdSummary = document.createElement('td');
-  tr.appendChild(tdSummary); tdSummary.rowSpan = 1; tdSummary.colSpan = 2;
   const inputSummary = document.createElement('input');
   inputSummary.type = "text";
   inputSummary.classList.add('event-summary');
@@ -224,9 +220,8 @@ function renderAlarm(alarm, exists) {
   inputSummary.onchange();
 
   const tdOptions = document.createElement('td');
-  tr2.appendChild(tdOptions); tdOptions.rowSpan = 1;
-
   const onOffCheck = document.createElement('input');
+  tdOptions.classList.add('btn-center');
   onOffCheck.type = 'checkbox';
   onOffCheck.checked = alarm.on;
   onOffCheck.onchange = e => {
@@ -242,8 +237,6 @@ function renderAlarm(alarm, exists) {
   tdOptions.appendChild(onOff);
 
   const tdInfo = document.createElement('td');
-  tr2.appendChild(tdInfo); tdInfo.rowSpan = 1;
-
   const buttonDelete = document.createElement('button');
   buttonDelete.classList.add('btn');
   buttonDelete.classList.add('btn-action');
@@ -257,6 +250,13 @@ function renderAlarm(alarm, exists) {
     document.getElementById('events').removeChild(tr);
     document.getElementById('events').removeChild(tr2);
   });
+
+  tr.appendChild(tdType); tdType.classList.add('single-row');
+  tr.appendChild(tdOptions); tdType.classList.add('single-row');
+  tr.appendChild(tdInfo); tdType.classList.add('single-row');
+  tr2.appendChild(tdTime); tdTime.colSpan = 3;
+  tr.appendChild(tdDays); tdDays.rowSpan = 2;
+  tr.appendChild(tdSummary); tdType.classList.add('single-row');
 
   document.getElementById('events').appendChild(tr);
   document.getElementById('events').appendChild(tr2);

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -175,9 +175,11 @@ function renderAlarm(alarm, exists) {
     option.value = day;
     option.text = day;
     option.selected = alarm.dow & (1 << i);
-    selectDays.appendChild(option);
+    if(day !== "Sun")
+      selectDays.appendChild(option);
     return option;
   });
+  selectDays.appendChild(options.find(o => o.text === "Sun"));
   selectDays.onchange = (e => {
     alarm.dow = options.reduce((bits, opt, i) => bits | (opt.selected ? 1 << i : 0), 0);
   });

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -126,7 +126,7 @@ function renderAlarm(alarm, exists) {
   const tdType = document.createElement('td');
   tdType.type = "text";
   tdType.classList.add('event-summary');
-  tr.appendChild(tdType); tdType.rowSpan = 2;
+  tr.appendChild(tdType); tdType.rowSpan = 1;
   const inputTime = document.createElement('input');
   if (localDate) {
     tdType.textContent = "Event";
@@ -166,7 +166,7 @@ function renderAlarm(alarm, exists) {
   inputTime.classList.add('form-input');
   inputTime.dataset.uid = alarm.id;
   const tdTime = document.createElement('td');
-  tr.appendChild(tdTime); tdTime.rowSpan = 2;
+  tr2.appendChild(tdTime); tdTime.rowSpan = 1;
   tdTime.appendChild(inputTime);
 
   const tdDays = document.createElement('td');
@@ -347,7 +347,6 @@ function onInit() {
     <table class="table">
       <thead>
         <tr>
-          <th>Type</th>
           <th>Date/Time</th>
           <th>Days</th>
           <th>Summary</th>

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -258,8 +258,8 @@ function renderAlarm(alarm, exists) {
   });
 
   tr.appendChild(tdTime); tdTime.colSpan = 3; tdTime.classList.add('single-row');
-  tr2.appendChild(tdOptions);
   tr2.appendChild(tdType);
+  tr2.appendChild(tdOptions);
   tr2.appendChild(tdInfo);
   if (tdDays) {
     tr.appendChild(tdDays); tdDays.rowSpan = 2;

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -2,6 +2,11 @@
   <head>
     <link rel="stylesheet" href="../../css/spectre.min.css">
     <link rel="stylesheet" href="../../css/spectre-icons.min.css">
+    <style>
+      .multi-select {
+        height: 100%;
+      }
+    </style>
     <script src="../../core/lib/interface.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.5.0/ical.min.js"></script>
     <script>
@@ -115,12 +120,13 @@ function renderAlarm(alarm, exists) {
   const localDate = alarm.date ? dateFromAlarm(alarm) : null;
 
   const tr = document.createElement('tr');
+  const tr2 = document.createElement('tr');
   tr.classList.add('event-row');
   tr.dataset.uid = alarm.id;
   const tdType = document.createElement('td');
   tdType.type = "text";
   tdType.classList.add('event-summary');
-  tr.appendChild(tdType);
+  tr.appendChild(tdType); tdType.rowSpan = 2;
   const inputTime = document.createElement('input');
   if (localDate) {
     tdType.textContent = "Event";
@@ -160,14 +166,14 @@ function renderAlarm(alarm, exists) {
   inputTime.classList.add('form-input');
   inputTime.dataset.uid = alarm.id;
   const tdTime = document.createElement('td');
-  tr.appendChild(tdTime);
+  tr.appendChild(tdTime); tdTime.rowSpan = 2;
   tdTime.appendChild(inputTime);
 
   const tdDays = document.createElement('td');
-  tr.appendChild(tdDays);
+  tr.appendChild(tdDays); tdDays.rowSpan = 2;
   const selectDays = document.createElement('select');
   selectDays.multiple = true;
-  selectDays.classList.add('form-input');
+  selectDays.classList.add('form-input', 'multi-select');
   selectDays.dataset.uid = alarm.id;
   const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const options = days.map((day, i) => {
@@ -186,7 +192,7 @@ function renderAlarm(alarm, exists) {
   tdDays.appendChild(selectDays);
 
   const tdSummary = document.createElement('td');
-  tr.appendChild(tdSummary);
+  tr.appendChild(tdSummary); tdSummary.rowSpan = 2;
   const inputSummary = document.createElement('input');
   inputSummary.type = "text";
   inputSummary.classList.add('event-summary');
@@ -203,7 +209,7 @@ function renderAlarm(alarm, exists) {
   inputSummary.onchange();
 
   const tdOptions = document.createElement('td');
-  tr.appendChild(tdOptions);
+  tr.appendChild(tdOptions); tdOptions.rowSpan = 1;
 
   const onOffCheck = document.createElement('input');
   onOffCheck.type = 'checkbox';
@@ -221,7 +227,7 @@ function renderAlarm(alarm, exists) {
   tdOptions.appendChild(onOff);
 
   const tdInfo = document.createElement('td');
-  tr.appendChild(tdInfo);
+  tr2.appendChild(tdInfo); tdInfo.rowSpan = 1;
 
   const buttonDelete = document.createElement('button');
   buttonDelete.classList.add('btn');
@@ -237,6 +243,7 @@ function renderAlarm(alarm, exists) {
   });
 
   document.getElementById('events').appendChild(tr);
+  document.getElementById('events').appendChild(tr2);
   document.getElementById('upload').disabled = false;
 }
 
@@ -344,8 +351,7 @@ function onInit() {
           <th>Date/Time</th>
           <th>Days</th>
           <th>Summary</th>
-          <th>On?</th>
-          <th></th>
+          <th>State</th>
         </tr>
       </thead>
       <tbody id="events">


### PR DESCRIPTION
This gives `sched`'s `interface.html` the ability to select which days an alarm will trigger on.

Deployed on [my gh-pages](https://bobrippling.github.io/BangleApps/?q=sched)