### PR TITLE
sleeplog: only write log if we have something to write

### DIFF
--- a/apps/sleeplog/ChangeLog
+++ b/apps/sleeplog/ChangeLog
@@ -11,3 +11,4 @@
 0.13: Prevent to stay in consecutive sleep if not worn, correct trigger calling, add trigger object itself as argument to the fn function
 0.14: Add "Delete all logfiles before" to interface.html, display all logfiles in the interface
 0.15: Issue newline before GB commands (solves issue with console.log and ignored commands)
+0.16: Only write logs if we have a non-empty log to write

--- a/apps/sleeplog/lib.js
+++ b/apps/sleeplog/lib.js
@@ -169,7 +169,8 @@ exports = {
         // check if before this fortnight period
         if (firstDay < thisFirstDay) {
           // write log in seperate file
-          require("Storage").writeJSON("sleeplog_" + this.msToFn(firstDay) + ".log", log);
+          if(log.length > 0)
+            require("Storage").writeJSON("sleeplog_" + this.msToFn(firstDay) + ".log", log);
           // set last day as first
           firstDay = lastDay;
         } else {

--- a/apps/sleeplog/metadata.json
+++ b/apps/sleeplog/metadata.json
@@ -2,7 +2,7 @@
   "id":"sleeplog",
   "name":"Sleep Log",
   "shortName": "SleepLog",
-  "version": "0.15",
+  "version": "0.16",
   "description": "Log and view your sleeping habits. This app is using the built in movement calculation.",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
@storm64 is this a change you'd be happy with? I found my storage would populate with files containing an empty array, which slowed down listing files (e.g. connecting from the app loader)