### PR TITLE
widalarmeta: recheck latest alarm when alarms change

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -24,3 +24,4 @@
 0.21: Fix crash in clock_info
 0.22: Dated event repeat option
 0.23: Allow buzzing forever when an alarm fires
+0.24: Emit alarmReload when alarms change (used by widalarm)

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -55,10 +55,7 @@ exports.getTimeToAlarm = function(alarm, time) {
 /// Force a reload of the current alarms and widget
 exports.reload = function() {
   eval(require("Storage").read("sched.boot.js"));
-  if (global.WIDGETS && WIDGETS["alarm"]) {
-    WIDGETS["alarm"].reload();
-    Bangle.drawWidgets();
-  }
+  Bangle.emit("alarmReload");
 };
 // Factory that creates a new alarm with default values
 exports.newDefaultAlarm = function () {

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.23",
+  "version": "0.24",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/widalarm/ChangeLog
+++ b/apps/widalarm/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Moved out of 'alarm' app
+0.02: Decouple reloading of widget when alarms change

--- a/apps/widalarm/metadata.json
+++ b/apps/widalarm/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widalarm",
   "name": "Alarms Widget",
-  "version": "0.01",
+  "version": "0.02",
   "description": "Displays an alarm icon in the widgets bar if any alarm is active",
   "icon": "app.png",
   "type": "widget",

--- a/apps/widalarm/widget.js
+++ b/apps/widalarm/widget.js
@@ -6,3 +6,9 @@ WIDGETS["alarm"]={area:"tl",width:0,draw:function() {
   }
 };
 WIDGETS["alarm"].reload();
+Bangle.on("alarmReload", () => {
+  if (WIDGETS["alarm"]) {
+    WIDGETS["alarm"].reload();
+    Bangle.drawWidgets();
+  }
+});

--- a/apps/widalarmeta/ChangeLog
+++ b/apps/widalarmeta/ChangeLog
@@ -12,3 +12,4 @@
 0.08: Selectable font. Allow to disable hour padding.
 0.09: Match draw() API e.g. to allow wid_edit to alter this widget
 0.10: Change 4x5 font to 6x8, teletext is now default font
+0.11: Bugfix: handle changes in alarms (e.g. done without a load, such as via fastload)

--- a/apps/widalarmeta/metadata.json
+++ b/apps/widalarmeta/metadata.json
@@ -2,7 +2,7 @@
   "id": "widalarmeta",
   "name": "Alarm & Timer ETA",
   "shortName": "Alarm ETA",
-  "version": "0.10",
+  "version": "0.11",
   "description": "A widget that displays the time to the next Alarm or Timer in hours and minutes, maximum 24h (configurable).",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -19,7 +19,10 @@
   loadSettings();
 
   function getNextAlarm(date) {
-    const alarms = (require("Storage").readJSON("sched.json",1) || []).filter(alarm => alarm.on && alarm.hidden !== true);
+    const alarms = require("sched")
+      .getAlarms()
+      .filter(alarm => alarm.on && alarm.hidden !== true);
+
     WIDGETS["widalarmeta"].numActiveAlarms = alarms.length;
     if (alarms.length > 0) {
       const times = alarms.map(alarm => require("sched").getTimeToAlarm(alarm, date) || Number.POSITIVE_INFINITY);
@@ -116,7 +119,6 @@
   } /* draw */
 
   if (config.maxhours > 0) {
-    // add your widget
     WIDGETS["widalarmeta"]={
       area:"tl",
       width: 0, // hide by default = assume no timer

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -128,7 +128,6 @@
         this.nextAlarm = undefined;
 
         loadSettings();
-        g.clear();
         Bangle.drawWidgets();
       },
     };

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -21,6 +21,7 @@
   function getNextAlarm(date) {
     const alarms = require("sched")
       .getAlarms()
+      // more precise filtering is done using getTimeToAlarm() below
       .filter(alarm => alarm.on && alarm.hidden !== true);
 
     WIDGETS["widalarmeta"].numActiveAlarms = alarms.length;
@@ -123,11 +124,15 @@
       area:"tl",
       width: 0, // hide by default = assume no timer
       draw:draw,
-      reload: () => {
+      reload: function () {
+        this.nextAlarm = undefined;
+
         loadSettings();
         g.clear();
         Bangle.drawWidgets();
       },
     };
+
+    Bangle.on("alarmReload", () => WIDGETS["widalarmeta"].reload());
   }
 })();


### PR DESCRIPTION
This allows `widalarmeta` to update itself when alarms change, which happens if we modify them and use fastload utils to return to the clock face without a full widget reload.

@nxdefiant is this change alright by you?