### PR TITLE
widlockunlock: disable tap-to-lock if back button is present

### DIFF
--- a/apps/widlockunlock/ChangeLog
+++ b/apps/widlockunlock/ChangeLog
@@ -1,2 +1,3 @@
 0.01: First commit
 0.02: Add tap-to-lock functionality
+0.03: Disable tap-to-lock if back button is present

--- a/apps/widlockunlock/metadata.json
+++ b/apps/widlockunlock/metadata.json
@@ -2,7 +2,7 @@
   "id": "widlockunlock",
   "name": "Lock/Unlock Widget",
   "version": "0.03",
-  "description": "On devices with always-on display (Bangle.js 2) this displays lock icon whenever the display is locked, or an unlock icon otherwise. Tap to lock the lcd",
+  "description": "On devices with always-on display (Bangle.js 2) this displays lock icon whenever the display is locked, or an unlock icon otherwise. Tap to lock the lcd (unless the back button is shown, in which case it takes priority)",
   "icon": "widget.png",
   "type": "widget",
   "tags": "widget,lock",

--- a/apps/widlockunlock/metadata.json
+++ b/apps/widlockunlock/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widlockunlock",
   "name": "Lock/Unlock Widget",
-  "version": "0.02",
+  "version": "0.03",
   "description": "On devices with always-on display (Bangle.js 2) this displays lock icon whenever the display is locked, or an unlock icon otherwise. Tap to lock the lcd",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widlockunlock/widget.js
+++ b/apps/widlockunlock/widget.js
@@ -1,6 +1,8 @@
 Bangle.on("lock", () => Bangle.drawWidgets());
 
 Bangle.on('touch', (_btn, xy) => {
+  if (WIDGETS["back"]) return;
+
   const oversize = 5;
 
   const w = WIDGETS.lockunlock;

--- a/apps/widlockunlock/widget.js
+++ b/apps/widlockunlock/widget.js
@@ -11,6 +11,8 @@ Bangle.on('touch', (_btn, xy) => {
   if(w.x - oversize <= x && x < w.x + 14 + oversize
   && w.y - oversize <= y && y < w.y + 24 + oversize)
   {
+    E.stopEventPropagation && E.stopEventPropagation();
+
     Bangle.setLocked(true);
 
     const backlightTimeout = Bangle.getOptions().backlightTimeout; // ms


### PR DESCRIPTION
This avoids having to try to dodge the lock/unlock widget when going back