### PR TITLE
smpltmr: reset clkinfo to "main" timer after no interaction

### DIFF
--- a/apps/clock_info/ChangeLog
+++ b/apps/clock_info/ChangeLog
@@ -6,3 +6,4 @@
 0.05: Reported image for battery is now transparent (2v18+)
 0.06: When >1 clockinfo, swiping one back tries to ensure they don't display the same thing
 0.07: Developer tweak: clkinfo load errors are emitted
+0.08: Pass options to show(), hide() and run(), and add focus() and blur() item methods

--- a/apps/clock_info/README.md
+++ b/apps/clock_info/README.md
@@ -70,10 +70,12 @@ Note that each item is an object with:
 }
 ```
 
-* `item.show` : called when item should be shown. Enables updates. Call BEFORE 'get'
-* `item.hide` : called when item should be hidden. Disables updates.
+* `item.show` : called when item should be shown. Enables updates. Call BEFORE 'get'. Passed the clockinfo options (same as what's returned from `addInteractive`).
+* `item.hide` : called when item should be hidden. Disables updates. Passed the clockinfo options.
 * `.on('redraw', ...)` : event that is called when 'get' should be called again (only after 'item.show')
 * `item.run` : (optional) called if the info screen is tapped - can perform some action. Return true if the caller should feedback the user.
+* `item.focus` : called when the item is focussed (the user has tapped on it). Passed the clockinfo options.
+* `item.blur` : called when the item is unfocussed (the user has tapped elsewhere, the screen has locked, etc). Passed the clockinfo options.
 
 See the bottom of `lib.js` for example usage...
 

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -294,9 +294,9 @@ exports.addInteractive = function(menu, options) {
     if (redraw) options.redraw();
   };
   const focus = (redraw) => {
+    Bangle.CLKINFO_FOCUS=true;
     if (!options.focus) {
       options.focus=true;
-      Bangle.CLKINFO_FOCUS=true;
       const itm = menu[options.menuA].items[options.menuB];
       if (itm.focus && itm.focus(options) === false)
         redraw = false;
@@ -362,6 +362,7 @@ exports.addInteractive = function(menu, options) {
 
     return true;
   };
+  if (options.focus) focus();
   delete settings; // don't keep settings in RAM - save space
   return options;
 };

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -292,13 +292,17 @@ exports.addInteractive = function(menu, options) {
     if (itm.blur) itm.blur(options);
   };
   const focus = (redraw) => {
+    let shown = false;
     if (!options.focus) {
       options.focus=true;
       Bangle.CLKINFO_FOCUS=true;
+      shown = true;
+    }
+    if (redraw) options.redraw();
+    if (shown) {
       const itm = menu[options.menuA].items[options.menuB];
       if (itm.focus) itm.focus(options);
     }
-    if (redraw) options.redraw();
   };
   let touchHandler, lockHandler;
   if (options.x!==undefined && options.y!==undefined && options.w && options.h) {

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -284,38 +284,39 @@ exports.addInteractive = function(menu, options) {
     E.stopEventPropagation&&E.stopEventPropagation();
   }
   Bangle.on("swipe",swipeHandler);
+  const unfocus = () => {
+    options.focus=false;
+    delete Bangle.CLKINFO_FOCUS;
+    options.redraw();
+  };
+  const focus = (redraw) => {
+    options.focus=true;
+    Bangle.CLKINFO_FOCUS=true;
+    if (redraw) options.redraw();
+  };
   let touchHandler, lockHandler;
   if (options.x!==undefined && options.y!==undefined && options.w && options.h) {
     touchHandler = function(_,e) {
       if (e.x<options.x || e.y<options.y ||
           e.x>(options.x+options.w) || e.y>(options.y+options.h)) {
-        if (options.focus) {
-          options.focus=false;
-          delete Bangle.CLKINFO_FOCUS;
-          options.redraw();
-        }
+        if (options.focus)
+          unfocus();
         return; // outside area
       }
       if (!options.focus) {
-        options.focus=true; // if not focussed, set focus
-        Bangle.CLKINFO_FOCUS=true;
-        options.redraw();
+        focus(true);
       } else if (menu[options.menuA].items[options.menuB].run) {
         Bangle.buzz(100, 0.7);
         menu[options.menuA].items[options.menuB].run(); // allow tap on an item to run it (eg home assistant)
       } else {
-        options.focus=true;
-        Bangle.CLKINFO_FOCUS=true;
+        focus();
       }
     };
     Bangle.on("touch",touchHandler);
     if (settings.defocusOnLock) {
       lockHandler = function() {
-        if(options.focus) {
-          options.focus=false;
-          delete Bangle.CLKINFO_FOCUS;
-          options.redraw();
-        }
+        if(options.focus)
+          unfocus();
       };
       Bangle.on("lock", lockHandler);
     }

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -284,12 +284,12 @@ exports.addInteractive = function(menu, options) {
     E.stopEventPropagation&&E.stopEventPropagation();
   }
   Bangle.on("swipe",swipeHandler);
-  const unfocus = () => {
+  const blur = () => {
     options.focus=false;
     delete Bangle.CLKINFO_FOCUS;
     options.redraw();
     const itm = menu[options.menuA].items[options.menuB];
-    if (itm.unfocus) itm.unfocus(options);
+    if (itm.blur) itm.blur(options);
   };
   const focus = (redraw) => {
     if (!options.focus) {
@@ -306,7 +306,7 @@ exports.addInteractive = function(menu, options) {
       if (e.x<options.x || e.y<options.y ||
           e.x>(options.x+options.w) || e.y>(options.y+options.h)) {
         if (options.focus)
-          unfocus();
+          blur();
         return; // outside area
       }
       if (!options.focus) {
@@ -322,7 +322,7 @@ exports.addInteractive = function(menu, options) {
     if (settings.defocusOnLock) {
       lockHandler = function() {
         if(options.focus)
-          unfocus();
+          blur();
       };
       Bangle.on("lock", lockHandler);
     }

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -288,10 +288,16 @@ exports.addInteractive = function(menu, options) {
     options.focus=false;
     delete Bangle.CLKINFO_FOCUS;
     options.redraw();
+    const itm = menu[options.menuA].items[options.menuB];
+    if (itm.unfocus) itm.unfocus(options);
   };
   const focus = (redraw) => {
-    options.focus=true;
-    Bangle.CLKINFO_FOCUS=true;
+    if (!options.focus) {
+      options.focus=true;
+      Bangle.CLKINFO_FOCUS=true;
+      const itm = menu[options.menuA].items[options.menuB];
+      if (itm.focus) itm.focus(options);
+    }
     if (redraw) options.redraw();
   };
   let touchHandler, lockHandler;

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -293,7 +293,8 @@ exports.addInteractive = function(menu, options) {
       redraw = false;
     if (redraw) options.redraw();
   };
-  const focus = (redraw) => {
+  const focus = () => {
+    let redraw = true;
     Bangle.CLKINFO_FOCUS=true;
     if (!options.focus) {
       options.focus=true;
@@ -313,12 +314,10 @@ exports.addInteractive = function(menu, options) {
         return; // outside area
       }
       if (!options.focus) {
-        focus(true);
+        focus();
       } else if (menu[options.menuA].items[options.menuB].run) {
         Bangle.buzz(100, 0.7);
         menu[options.menuA].items[options.menuB].run(options); // allow tap on an item to run it (eg home assistant)
-      } else {
-        focus();
       }
     };
     Bangle.on("touch",touchHandler);

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -234,7 +234,7 @@ exports.addInteractive = function(menu, options) {
     options.redrawHandler = ()=>drawItem(itm);
     itm.on('redraw', options.redrawHandler);
     itm.uses = (0|itm.uses)+1;
-    if (itm.uses==1) itm.show();
+    if (itm.uses==1) itm.show(options);
     itm.emit("redraw");
   }
   function menuHideItem(itm) {
@@ -242,7 +242,7 @@ exports.addInteractive = function(menu, options) {
     delete options.redrawHandler;
     itm.uses--;
     if (!itm.uses)
-      itm.hide();
+      itm.hide(options);
   }
   // handling for swipe between menu items
   function swipeHandler(lr,ud){
@@ -307,7 +307,7 @@ exports.addInteractive = function(menu, options) {
         focus(true);
       } else if (menu[options.menuA].items[options.menuB].run) {
         Bangle.buzz(100, 0.7);
-        menu[options.menuA].items[options.menuB].run(); // allow tap on an item to run it (eg home assistant)
+        menu[options.menuA].items[options.menuB].run(options); // allow tap on an item to run it (eg home assistant)
       } else {
         focus();
       }

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -287,22 +287,21 @@ exports.addInteractive = function(menu, options) {
   const blur = () => {
     options.focus=false;
     delete Bangle.CLKINFO_FOCUS;
-    options.redraw();
     const itm = menu[options.menuA].items[options.menuB];
-    if (itm.blur) itm.blur(options);
+    let redraw = true;
+    if (itm.blur && itm.blur(options) === false)
+      redraw = false;
+    if (redraw) options.redraw();
   };
   const focus = (redraw) => {
-    let shown = false;
     if (!options.focus) {
       options.focus=true;
       Bangle.CLKINFO_FOCUS=true;
-      shown = true;
+      const itm = menu[options.menuA].items[options.menuB];
+      if (itm.focus && itm.focus(options) === false)
+        redraw = false;
     }
     if (redraw) options.redraw();
-    if (shown) {
-      const itm = menu[options.menuA].items[options.menuB];
-      if (itm.focus) itm.focus(options);
-    }
   };
   let touchHandler, lockHandler;
   if (options.x!==undefined && options.y!==undefined && options.w && options.h) {

--- a/apps/clock_info/metadata.json
+++ b/apps/clock_info/metadata.json
@@ -1,7 +1,7 @@
 { "id": "clock_info",
   "name": "Clock Info Module",
   "shortName": "Clock Info",
-  "version":"0.07",
+  "version":"0.08",
   "description": "A library used by clocks to provide extra information on the clock face (Altitude, BPM, etc)",
   "icon": "app.png",
   "type": "module",

--- a/apps/smpltmr/ChangeLog
+++ b/apps/smpltmr/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Ensure Timer supplies an image for clkinfo items
 0.07: Update clock_info to avoid a redraw
 0.08: Timer ClockInfo now updates once a minute
+0.09: Timer ClockInfo resets to timer menu when blurred

--- a/apps/smpltmr/clkinfo.js
+++ b/apps/smpltmr/clkinfo.js
@@ -71,13 +71,19 @@
     ]
   };
 
+  const restoreMainItem = function(clkinfo) {
+    clkinfo.menuB = 0;
+    // clock info redraws after this
+  };
+
   var offsets = [+5,-5];
   offsets.forEach((o, i) => {
     smpltmrItems.items = smpltmrItems.items.concat({
       name: null,
       get: () => ({ text: (o > 0 ? "+" : "") + o + " min.", img: smpltmrItems.img }),
       show: function() { },
-      hide: function () { },
+      hide: function() { },
+      blur: restoreMainItem,
       run: function() {
         if(o > 0) increaseAlarm(o);
         else decreaseAlarm(Math.abs(o));

--- a/apps/smpltmr/metadata.json
+++ b/apps/smpltmr/metadata.json
@@ -2,7 +2,7 @@
   "id": "smpltmr",
   "name": "Simple Timer",
   "shortName": "Simple Timer",
-  "version": "0.08",
+  "version": "0.09",
   "description": "A very simple app to start a timer.",
   "icon": "app.png",
   "tags": "tool,alarm,timer,clkinfo",

--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -11,10 +11,10 @@ declare module ClockInfo {
 
   type MenuItem = {
     name: string,
-    show(): void,
-    hide(): void,
+    show(options: InteractiveOptions): void,
+    hide(options: InteractiveOptions): void,
     on(what: "redraw", cb: () => void): void, // extending from Object
-    run?(): void,
+    run?(options: InteractiveOptions): void,
   } & (
     {
       hasRange: true,

--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -15,8 +15,8 @@ declare module ClockInfo {
     hide(options: InteractiveOptions): void,
     on(what: "redraw", cb: () => void): void, // extending from Object
     run?(options: InteractiveOptions): void,
-    focus?(options: InteractiveOptions): void,
-    blur?(options: InteractiveOptions): void,
+    focus?(options: InteractiveOptions): void | false,
+    blur?(options: InteractiveOptions): void | false,
   } & (
     {
       hasRange: true,

--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -16,7 +16,7 @@ declare module ClockInfo {
     on(what: "redraw", cb: () => void): void, // extending from Object
     run?(options: InteractiveOptions): void,
     focus?(options: InteractiveOptions): void,
-    unfocus?(options: InteractiveOptions): void,
+    blur?(options: InteractiveOptions): void,
   } & (
     {
       hasRange: true,

--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -15,6 +15,8 @@ declare module ClockInfo {
     hide(options: InteractiveOptions): void,
     on(what: "redraw", cb: () => void): void, // extending from Object
     run?(options: InteractiveOptions): void,
+    focus?(options: InteractiveOptions): void,
+    unfocus?(options: InteractiveOptions): void,
   } & (
     {
       hasRange: true,


### PR DESCRIPTION
@gfwilliams @sir-indy I'd like `smpltmr`'s `clkinfo` menu to reset to the "main" menu (showing the time remaining on the timer) after no interaction from the user.
To do this requires shuffling around some clkinfo code to create an API for selecting a given menu. If this seems reasonable to you both, I'll give it a test.

([git's `diff.colormoved`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---color-movedltmodegt) might be useful for seeing which lines have moved but are otherwise unchanged)

- [x] Test
- [x] Update [clock info docs](https://www.espruino.com/Bangle.js+Clock+Info)