### PR TITLE
android: posHandler-> wake + unlock + open associated app screen on android device

### DIFF
--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -315,7 +315,17 @@
   // Message response
   Bangle.messageResponse = (msg,response) => {
     if (msg.id=="call") return gbSend({ t: "call", n:response?"ACCEPT":"REJECT" });
-    if (isFinite(msg.id)) return gbSend({ t: "notify", n:response?"OPEN":"DISMISS", id: msg.id });
+    if (isFinite(msg.id)) {
+      return ()=>{
+        gbSend({ t: "notify", n:response?"OPEN":"DISMISS", id: msg.id });
+        // Wake the android device - if paired as Companion Device it will bypass keyguard and display the associated app screen directly.
+        gbSend({t:"intent", action:"android.intent.action.VIEW",
+          package:"gadgetbridge", class:"nodomain.freeyourgadget.gadgetbridge.activities.WakeActivity",
+          categories:["android.intent.category.DEFAULT"], target:"activity",
+          flags:["FLAG_ACTIVITY_NEW_TASK", "FLAG_ACTIVITY_CLEAR_TASK", "FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS", "FLAG_ACTIVITY_NO_ANIMATION"]
+        });
+      }();
+    }
     // error/warn here?
   };
   Bangle.messageIgnore = msg => {


### PR DESCRIPTION
@gfwilliams @bobrippling 

This is only meant as a proof of concept. What it does is, when I do a right-swipe on a message on the Bangle, the related app screen to display the information on my android device is immediately opened. So I don't have to click the power button on the phone.

The wake + unlock part is the new functionality.

Only works if the Bangle is paired as companion device to Gadgetbridge/Android.

If we want this to go in I'll make the needed additions to the PR.