### PR TITLE
Support Nodejs 18

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Use Node.js 20.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 18.x
       - name: Install testing dependencies
         run: npm ci
       - name: Test all apps and widgets

--- a/bin/exempt-lint.mjs
+++ b/bin/exempt-lint.mjs
@@ -16,6 +16,9 @@
 
 import fs from "node:fs/promises";
 
+// Nodejs v18 compatibility (v18 is end-of-life in april 2025)
+if(!("crypto" in globalThis)) globalThis.crypto = (await import("node:crypto")).webcrypto;
+
 const lintRule = process.argv[2];
 if (!lintRule) {
   throw new Error(

--- a/bin/sync-lint-exemptions.mjs
+++ b/bin/sync-lint-exemptions.mjs
@@ -11,6 +11,9 @@
 
 import fs from "node:fs/promises";
 
+// Nodejs v18 compatibility (v18 is end-of-life in april 2025)
+if(!("crypto" in globalThis)) globalThis.crypto = (await import("node:crypto")).webcrypto;
+
 const exemptionsFilePath = "../apps/lint_exemptions.js";
 
 const exemptions = (await import(exemptionsFilePath)).default;


### PR DESCRIPTION
It seems there is still a use case for nodejs 18, so this PR ensures everything runs on v18. I also downgraded the CI to v18 because as you say, it ensures the scripts work for as many people as possible :)