### PR TITLE
Fix typescript for `Layout`

### DIFF
--- a/apps/rep/app.ts
+++ b/apps/rep/app.ts
@@ -196,7 +196,7 @@ const layout = new L({
 			]
 		}
 	]
-}, {lazy: true});
+} as const, {lazy: true});
 
 class State {
 	paused: boolean = true;
@@ -248,7 +248,7 @@ class State {
 	}
 }
 
-const repToLabel = (i: number, id: string) => {
+const repToLabel = (i: number, id: "cur" | "next") => {
 	const rep = reps[i];
 	if(rep)
 		layout[`${id}_name`]!.label = `${rep.label} / ${msToMinSec(rep.dur)}`;
@@ -256,7 +256,7 @@ const repToLabel = (i: number, id: string) => {
 		emptyLabel(id);
 };
 
-const emptyLabel = (id: string) => {
+const emptyLabel = (id: "cur" | "next") => {
 	layout[`${id}_name`]!.label = "<none> / 0m";
 };
 

--- a/typescript/types/layout.d.ts
+++ b/typescript/types/layout.d.ts
@@ -7,7 +7,7 @@ type ExtractIds<T extends Layout.Hierarchy, Depth extends Prev[number] = 9> =
   [Depth] extends [never]
   ? never
   : (T extends { id?: infer Id extends string }
-    ? { [k in Id]: T }
+    ? { [k in Id]: { -readonly [P in keyof T]: T[P] }  }
     : never)
   |
   (
@@ -34,6 +34,7 @@ declare module Layout {
       setUI(): void;
     };
 
+  // Note: you must use new Layout({...} as const) to have ids inferred
   var Layout: {
     new <T extends Hierarchy>(
       hier: T,

--- a/typescript/types/layout.d.ts
+++ b/typescript/types/layout.d.ts
@@ -1,5 +1,8 @@
 type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+
 type ExtractIds<T extends Layout.Hierarchy, Depth extends Prev[number] = 9> =
   [Depth] extends [never]
   ? never
@@ -15,7 +18,7 @@ type ExtractIds<T extends Layout.Hierarchy, Depth extends Prev[number] = 9> =
 
 declare module Layout {
   type Layouter<T extends Hierarchy> =
-    ExtractIds<T>
+    UnionToIntersection<ExtractIds<T>>
     &
     {
       // these actually change T

--- a/typescript/types/layout.d.ts
+++ b/typescript/types/layout.d.ts
@@ -3,7 +3,7 @@ type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 type ExtractIds<T extends Layout.Hierarchy, Depth extends Prev[number] = 9> =
   [Depth] extends [never]
   ? never
-  : (T extends { id: infer Id extends string }
+  : (T extends { id?: infer Id extends string }
     ? { [k in Id]: T }
     : never)
   |

--- a/typescript/types/layout.d.ts
+++ b/typescript/types/layout.d.ts
@@ -7,7 +7,7 @@ type ExtractIds<T extends Layout.Hierarchy, Depth extends Prev[number] = 9> =
   [Depth] extends [never]
   ? never
   : (T extends { id?: infer Id extends string }
-    ? { [k in Id]: { -readonly [P in keyof T]: T[P] }  }
+    ? { [k in Id]: { -readonly [P in keyof T]: T[P] extends string ? string : T[P] }  }
     : never)
   |
   (


### PR DESCRIPTION
`ExtractIds` wasn't picking out the IDs (`id: ... extends string` rather than `id?: ... extends string`) and the resulting union of objects needed to be merged.

Closes #3251

Confirmed with a demo app and `apps/rep` (no version bump as changes are type-level only -> no `.js` changes)