### PR TITLE
recorder:fix ref error missing `settings` obj

### DIFF
--- a/apps/recorder/ChangeLog
+++ b/apps/recorder/ChangeLog
@@ -47,3 +47,5 @@
 	setInterval.
 0.38: Tweaks to speed up track rendering
 0.39: Minor code improvements
+0.40: Fix reference error from missing `settings` object in widget on 1 sec
+	recordings with gps.

--- a/apps/recorder/metadata.json
+++ b/apps/recorder/metadata.json
@@ -2,7 +2,7 @@
   "id": "recorder",
   "name": "Recorder",
   "shortName": "Recorder",
-  "version": "0.39",
+  "version": "0.40",
   "description": "Record GPS position, heart rate and more in the background, then download to your PC.",
   "icon": "app.png",
   "tags": "tool,outdoors,gps,widget,clkinfo",

--- a/apps/recorder/widget.js
+++ b/apps/recorder/widget.js
@@ -194,6 +194,7 @@
     }
   }
 
+  let settings = loadSettings();
   let writeOnGPS = function() {writeLog(settings.period);};
 
   // Called by the GPS app to reload settings and decide what to do


### PR DESCRIPTION
would get:
```
Uncaught ReferenceError: "settings" is not defined
 at line 198 col 49 in recorder.wid.js
writeLog(settings.period);
                 ^
in function called from system
```

Not sure this is the best way to fix this. Maybe call `loadSettings()` inside `writeOnGps` function instead. But that would lead to many storage interactions.