### PR TITLE
`fwupdate` Support double zipped firmware files

### DIFF
--- a/apps/fwupdate/custom.html
+++ b/apps/fwupdate/custom.html
@@ -227,8 +227,15 @@ function convertZipFile(binary) {
   Promise.resolve(binary).then(binary => {
     info.binary = binary;
     return JSZip.loadAsync(binary)
-  }).then(function(zipFile) {
-    info.zipFile = zipFile;
+  }).then(async function(zipFile) {
+    const fileArray = Object.values(zipFile.files);
+    // If the contents are zipped twice, extract the contents of the inner zip file
+    if(fileArray.length === 1 && fileArray[0].name?.endsWith(".zip")){
+      const zipBlob = await zipFile.file(fileArray[0].name).async("blob");
+      info.zipFile = await JSZip.loadAsync(zipBlob);
+    }else{
+      info.zipFile = zipFile;
+    }
     return info.zipFile.file("manifest.json").async("string");
   }).then(function(content) {
     info.manifest = JSON.parse(content).manifest;


### PR DESCRIPTION
It is somewhat confusing that the NRF firmware files are double-zipped. I was not able to upload firmware because of this, and I could not find the documentation which noted that you need to manually unzip the file once before uploading it. Now that I know this, it is still a tedious extra step to unzip the file every time I want to test something on my watch.

Therefore I suggest this change, which allows the firmware loader to understand double zipped firmware files. It works by checking if the zip file contains nothing but a single zip file inside it. If yes, the firmware is assumed to be inside the zipped zip file, and so that file is unzipped and used as if that was what the user had uploaded.

I have tested this change with all the firmware files available in the [Firmware Build Action](https://github.com/espruino/Espruino/actions/runs/8426335897), and it now supports all of them without any manual intervention. I doubt that you would ever want to upload a zip file that only contains a single zip file inside it, so I believe this is a safe solution that should work reliably in the future as well.