### PR TITLE
BT States Widget fix: handle colors themes better

### DIFF
--- a/apps/widbtstates/widget.js
+++ b/apps/widbtstates/widget.js
@@ -17,7 +17,7 @@
     };
     var colours = (_a = {},
         _a[1] = {
-            false: "#fff",
+            false: "#000",
             true: "#fff",
         },
         _a[2] = {

--- a/apps/widbtstates/widget.js
+++ b/apps/widbtstates/widget.js
@@ -21,8 +21,8 @@
             true: "#fff",
         },
         _a[2] = {
-            false: "#0ff",
-            true: "#00f",
+            false: "#00f",
+            true: "#0ff",
         },
         _a);
     WIDGETS["bluetooth"] = {

--- a/apps/widbtstates/widget.ts
+++ b/apps/widbtstates/widget.ts
@@ -30,12 +30,12 @@
 		}
 	} = {
 		[State.Active]: {
-			false: "#fff",
+			false: "#000",
 			true: "#fff",
 		},
 		[State.Connected]: {
-			false: "#0ff",
-			true: "#00f",
+			false: "#00f",
+			true: "#0ff",
 		},
 	};
 


### PR DESCRIPTION
I might be wrong but I think there is a mistake here, because cyan is much more readeable on a black background, and same for blue on a white background