### PR TITLE
Battery Widget Themed fix: center widget vertically

### DIFF
--- a/apps/widbata/widbata.wid.js
+++ b/apps/widbata/widbata.wid.js
@@ -8,9 +8,9 @@ WIDGETS["bata"]={area:"tr",sortorder:-10,width:27,draw:function() {
   var x = this.x, y = this.y + 5;
   g.reset();
   g.setColor(g.theme.fg);
-  g.fillRect(x,y+2,x+s-4,y+2+t); // outer
-  g.clearRect(x+2,y+2+2,x+s-4-2,y+2+t-2); // centre
+  g.fillRect(x,y+2-2,x+s-4,y+2+t-2); // outer
+  g.clearRect(x+2,y+2+2-2,x+s-4-2,y+2+t-2-2); // centre
   g.setColor(g.theme.fg);
-  g.fillRect(x+s-3,y+2+(((t - 1)/2)-1),x+s-2,y+2+(((t - 1)/2)-1)+4); // contact
-  g.fillRect(x+3, y+5, x +4 + E.getBattery()*(s-12)/100, y+t-1); // the level
+  g.fillRect(x+s-3,y+2+(((t - 1)/2)-1)-2,x+s-2,y+2+(((t - 1)/2)-1)+4-2); // contact
+  g.fillRect(x+3, y+5-2, x +4 + E.getBattery()*(s-12)/100, y+t-1-2); // the level
 }};

--- a/apps/widbata/widbata.wid.js
+++ b/apps/widbata/widbata.wid.js
@@ -5,12 +5,12 @@ Bangle.on('lcdPower', function(on) {
 WIDGETS["bata"]={area:"tr",sortorder:-10,width:27,draw:function() {
   var s = 26;
   var t = 13; // thickness
-  var x = this.x, y = this.y + 5;
+  var x = this.x, y = this.y + 3;
   g.reset();
   g.setColor(g.theme.fg);
-  g.fillRect(x,y+2-2,x+s-4,y+2+t-2); // outer
-  g.clearRect(x+2,y+2+2-2,x+s-4-2,y+2+t-2-2); // centre
+  g.fillRect(x,y+2,x+s-4,y+2+t); // outer
+  g.clearRect(x+2,y+2+2,x+s-4-2,y+2+t-2); // centre
   g.setColor(g.theme.fg);
-  g.fillRect(x+s-3,y+2+(((t - 1)/2)-1)-2,x+s-2,y+2+(((t - 1)/2)-1)+4-2); // contact
-  g.fillRect(x+3, y+5-2, x +4 + E.getBattery()*(s-12)/100, y+t-1-2); // the level
+  g.fillRect(x+s-3,y+2+(((t - 1)/2)-1),x+s-2,y+2+(((t - 1)/2)-1)+4); // contact
+  g.fillRect(x+3, y+5, x +4 + E.getBattery()*(s-12)/100, y+t-1); // the level
 }};


### PR DESCRIPTION
this just brings the battery icon up by 2 pixels so that is is centered vercially on the 24px widget band