### PR TITLE
vpw_clock - Restore whole theme and unload VGA8 font

### DIFF
--- a/apps/vpw_clock/ChangeLog
+++ b/apps/vpw_clock/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Now using a bigger font for day of week and date for better visibility
 0.03: Set theme to light, add black as an option for foreground color
 0.04: Handle fast loading
+0.05: Fix theme reset for some themes

--- a/apps/vpw_clock/app.js
+++ b/apps/vpw_clock/app.js
@@ -150,7 +150,7 @@ Graphics.prototype.setFontMadeSunflower = function () {
   };
 
   // store the theme before drawing
-  let orignalTheme = g.theme;
+  let originalTheme = g.theme;
 
   // Clear the screen once, at startup
   g.setTheme({ bg: COLOUR_VPW_GREEN, fg: foregroundColor, dark: false }).clear();
@@ -167,8 +167,9 @@ Graphics.prototype.setFontMadeSunflower = function () {
       if (drawTimeout) clearTimeout(drawTimeout);
       // remove custom font
       delete Graphics.prototype.setFontMadeSunflower;
+      delete Graphics.prototype.setFontVGA8;
       // revert theme to how it was before
-      g.setTheme({ bg: orignalTheme.bg, fg: orignalTheme.fb, dark: orignalTheme.dark });
+      g.setTheme(originalTheme);
     }
   });
 

--- a/apps/vpw_clock/metadata.json
+++ b/apps/vpw_clock/metadata.json
@@ -3,7 +3,7 @@
   "name": "Vaporwave Sunset Clock",
   "shortName": "Vaporwave Sunset",
   "type": "clock",
-  "version":"0.04",
+  "version":"0.05",
   "description": "A clock with a vaporwave sunset theme.",
   "tags": "clock",
   "supports": ["BANGLEJS2"],


### PR DESCRIPTION
Fix some issues with colors when using dark themes by setting complete theme. Additionally remove the VGA8 font.