### PR TITLE
[messagegui] Fix: When user taps on a new message, clear unread timeout

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -104,3 +104,4 @@
 0.75: Handle text with images in messages list by just displaying the first line
 0.76: Swipe up/down on a shown message to show the next newer/older message.
 0.77: Messages can now use international fonts if they are installed
+0.78: Fix: When user taps on a new message, clear the unread timeout

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -233,6 +233,7 @@ function showMusicMessage(msg) {
 }
 
 function showMessageScroller(msg) {
+  cancelReloadTimeout();
   active = "scroller";
   var bodyFont = fontBig;
   g.setFont(bodyFont);

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.77",
+  "version": "0.78",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
So that the user can read the long message uninterrupted :)