### PR TITLE
`recorder` Remove unused variable

### DIFF
--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -86,12 +86,6 @@ module.exports = {
       "no-undef"
     ]
   },
-  "recorder/app.js": {
-    "hash": "64c838b63a756a712555ae54d0bae89f0373ce317c289f7b19a583d3f91d473b",
-    "rules": [
-      "no-unused-vars"
-    ]
-  },
   "podadrem/app.js": {
     "hash": "f7392e74974f69553aade2dcc07527b5d3b71a9b84e6dc5e0dd995e78dff8007",
     "rules": [

--- a/apps/recorder/ChangeLog
+++ b/apps/recorder/ChangeLog
@@ -51,3 +51,4 @@
       Fix HRM source never being set in output data
 0.41: Fix exit from plots and graphs would easily react twice, going back two
 	levels instead of one.
+0.42: Minor code improvements

--- a/apps/recorder/app.js
+++ b/apps/recorder/app.js
@@ -330,7 +330,7 @@ function plotGraph(info, style) { "ram"
   if (f===undefined) return;
   var l = f.readLine(f);
   l = f.readLine(f); // skip headers
-  var nl = 0, c, i;
+  var c, i;
   var factor = 1; // multiplier used for values when graphing
   var timeIdx = info.fields.indexOf("Time");
   if (l!==undefined) {
@@ -341,7 +341,7 @@ function plotGraph(info, style) { "ram"
     title = /*LANG*/"Heartrate (bpm)";
     var hrmIdx = info.fields.indexOf("Heartrate");
     while(l!==undefined) {
-      ++nl;c=l.split(",");l = f.readLine(f);
+      c=l.split(",");l = f.readLine(f);
       if (c[hrmIdx]=="") continue;
       i = Math.round(80*(c[timeIdx] - strt)/dur);
       infn[i]+=+c[hrmIdx];
@@ -352,7 +352,7 @@ function plotGraph(info, style) { "ram"
     var altIdx = info.fields.indexOf("Barometer Altitude");
     if (altIdx<0) altIdx = info.fields.indexOf("Altitude");
     while(l!==undefined) {
-      ++nl;c=l.split(",");l = f.readLine(f);
+      c=l.split(",");l = f.readLine(f);
       if (c[altIdx]=="") continue;
       i = Math.round(80*(c[timeIdx] - strt)/dur);
       infn[i]+=+c[altIdx];
@@ -376,7 +376,7 @@ function plotGraph(info, style) { "ram"
     var p,lp = Bangle.project({lat:c[1],lon:c[2]});
     var t,dx,dy,d,lt = c[timeIdx];
     while(l!==undefined) {
-      ++nl;c=l.split(",");
+      c=l.split(",");
       l = f.readLine(f);
       if (c[latIdx] == "") {
         continue;

--- a/apps/recorder/metadata.json
+++ b/apps/recorder/metadata.json
@@ -2,7 +2,7 @@
   "id": "recorder",
   "name": "Recorder",
   "shortName": "Recorder",
-  "version": "0.41",
+  "version": "0.42",
   "description": "Record GPS position, heart rate and more in the background, then download to your PC.",
   "icon": "app.png",
   "tags": "tool,outdoors,gps,widget,clkinfo",


### PR DESCRIPTION
The exemption for this file was broken in #3297 but the warning was not fixed.

The code includes an unused variable that seems safe to remove. I have tested the app and it does not seem to break in any way.

The code seems to be written by @gfwilliams, maybe you can check it to be sure?