### PR TITLE
Temporary fix for minified file lint

### DIFF
--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -1481,5 +1481,11 @@ module.exports = {
       "no-unused-vars",
       "no-cond-assign"
     ]
+  },
+  "kineticscroll/boot.min.js": {
+    "hash": "a5106fa601cdbd2179e32265a8b77e2df62ba44ca0f4b94ce1e594c95a47e20d",
+    "rules": [
+      "no-cond-assign"
+    ]
   }
 };


### PR DESCRIPTION
The minified file `kineticscroll/boot.min.js` includes an optimization that is perfectly fine in minified files, but terrible in source files.

We need to figure out how to deal with minified files while also enforcing good lint rules. I am currently working on a better minifier for the app loader. If that is succesful, we don't need to include minified files here, so the problem would solve itself.

For now, the temporary fix is to exempt the file from the warning.