### PR TITLE
New bug in bigdclock.app.js

### DIFF
--- a/apps/bigdclock/ChangeLog
+++ b/apps/bigdclock/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Tell clock widgets to hide.
 0.07: Better battery graphic - now has green, yellow and red sections; battery status reflected in the bar across the middle of the screen; current battery state checked only once every 15 minutes, leading to longer-lasting battery charge
 0.08: Minor code improvements
+0.09: Something was changing the value of the "width" variable, which caused the battery usage feature to malfunction. The "width" variable has been renamed - the cause remains a mystery.

--- a/apps/bigdclock/bigdclock.app.js
+++ b/apps/bigdclock/bigdclock.app.js
@@ -12,7 +12,7 @@ Graphics.prototype.setFontOpenSans = function(scale) {
 
 var drawTimeout;
 var lastBattCheck = 0;
-var width = 0;
+var batteryUsedWidth = 0;
 
 function queueDraw(millis_now) {
     if (drawTimeout) clearTimeout(drawTimeout);
@@ -32,8 +32,8 @@ function draw() {
 
     if ((date.getTime() >= lastBattCheck + 15*60000) || Bangle.isCharging()) {
       lastBattCheck = date.getTime();
-      width = E.getBattery();
-      width += width/2;
+      batteryUsedWidth = E.getBattery();
+      batteryUsedWidth += batteryUsedWidth/2;
     }
 
     g.reset();
@@ -58,7 +58,7 @@ function draw() {
     g.fillRect(167,163,170,167);
     if (Bangle.isCharging()) {
       g.setColor(1,1,0);
-      g.fillRect(12,162,12+width,168);
+      g.fillRect(12,162,12+batteryUsedWidth,168);
     } else {
       g.setColor(1,0,0);
       g.fillRect(12,162,57,168);
@@ -67,16 +67,16 @@ function draw() {
       g.setColor(0,1,0);
       g.fillRect(73,162,162,168);
     }
-    if (width < 150) {
+    if (batteryUsedWidth < 150) {
       g.setColor(g.theme.bg);
-      g.fillRect(12+width+1,162,162,168);
+      g.fillRect(12+batteryUsedWidth+1,162,162,168);
     }
 
     if (Bangle.isCharging()) {
       g.setColor(1,1,0);
-    } else if (width <= 45) {
+    } else if (batteryUsedWidth <= 45) {
       g.setColor(1,0,0);
-    } else if (width <= 60) {
+    } else if (batteryUsedWidth <= 60) {
       g.setColor(1,1,0);
     } else {
       g.setColor(0, 1, 0);

--- a/apps/bigdclock/metadata.json
+++ b/apps/bigdclock/metadata.json
@@ -1,7 +1,7 @@
 { "id": "bigdclock",
   "name": "Big digit clock containing just the essentials",
   "shortName":"Big digit clk",
-  "version": "0.08",
+  "version": "0.09",
   "description": "A clock containing just the essentials, made as easy to read as possible for those of us that need glasses. It contains the time, the day-of-week, the day-of-month, and the current battery state-of-charge.",
   "icon": "bigdclock.png",
   "type": "clock",


### PR DESCRIPTION
The value of "width" was being reset somewhere, which meant that the battery usage feature wasn't working - it was resetting to "battery empty" whenever the clock updated.

So "width" has been renamed to "batteryUsedWidth", which is better anyway, as it is more descriptive of what the variable does.