### PR TITLE
Fix bugs in `ratchet_launcher`

### DIFF
--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -798,12 +798,6 @@ module.exports = {
       "no-undef"
     ]
   },
-  "ratchet_launch/app.js": {
-    "hash": "592d432301d7836aa54e288d465ae8952ecb891d628f824ea9f62479a2a01631",
-    "rules": [
-      "no-undef"
-    ]
-  },
   "rclock/rclock.app.js": {
     "hash": "8e698787730601a1bba71aff03204c2adfaf7eeb77b35dc706534755f63f613b",
     "rules": [

--- a/apps/ratchet_launch/ChangeLog
+++ b/apps/ratchet_launch/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial release
 0.02: Cache the app-launch info
+0.03: Fix bugs that would make the launcher unusable on most watches

--- a/apps/ratchet_launch/app.js
+++ b/apps/ratchet_launch/app.js
@@ -5,13 +5,13 @@ var font = g.getFonts().includes("6x15") ? "6x15" : "6x8:2";
 var largeFont = g.getFonts().includes("12x20") ? "12x20" : "6x8:3";
 var currentApp = 0;
 var overscroll = 0;
-var blankImage = Graphics.createImage(` `);
+var blankImage = Graphics.createImage(`\n \n`);
 var rowHeight = g.getHeight()/3;
 
 // Load apps list
 var apps;
 
-var launchCache = s.readJSON("launch.cache.json", true)||{};
+var launchCache = Storage.readJSON("launch.cache.json", true)||{};
 var launchHash = require("Storage").hash(/\.info/);
 if (launchCache.hash==launchHash) {
   apps = launchCache.apps;
@@ -39,7 +39,7 @@ if (launchCache.hash==launchHash) {
   });
 
   launchCache = { apps, hash: launchHash };
-  s.writeJSON("launch.cache.json", launchCache);
+  Storage.writeJSON("launch.cache.json", launchCache);
 }
 
 // Uncomment for testing in the emulator without apps:

--- a/apps/ratchet_launch/metadata.json
+++ b/apps/ratchet_launch/metadata.json
@@ -2,7 +2,7 @@
   "id": "ratchet_launch",
   "name": "Ratchet Launcher",
   "shortName": "Ratchet",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Launcher with discrete scrolling for quicker app selection",
   "icon": "app.png",
   "type": "launch",


### PR DESCRIPTION
In #2719, the app was updated to access storage via the variable `s` which is not defined. This was flagged by the new linting rules, which is how it caught my attention. Unless you are lucky and something else has defined `s` for you, this means the launcher cannot even open.

It turns out there is also a bug with the default `blankImage`, it is not supported by the `Layout` library. I assume that this worked when the app was designed, but that later revisions of Espruino disallowed images with no height. I have added newlines to give the image a bit of height, which makes it work again.