### PR TITLE
`health` Remove unused variable

### DIFF
--- a/apps/health/ChangeLog
+++ b/apps/health/ChangeLog
@@ -31,3 +31,4 @@
       Fix daily summaries for 31st of the month
 0.28: Calculate distance from steps if myprofile is installed and stride length is set
 0.29: Minor code improvements
+0.30: Minor code improvements

--- a/apps/health/app.js
+++ b/apps/health/app.js
@@ -176,7 +176,6 @@ function barChart(label, dt) {
   chart_label = label;
   chart_data = dt;
   drawBarChart();
-  swipe_enabled = true;
 }
 
 function drawBarChart() {

--- a/apps/health/metadata.json
+++ b/apps/health/metadata.json
@@ -2,7 +2,7 @@
   "id": "health",
   "name": "Health Tracking",
   "shortName": "Health",
-  "version": "0.29",
+  "version": "0.30",
   "description": "Logs health data and provides an app to view it",
   "icon": "app.png",
   "tags": "tool,system,health",

--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -1086,12 +1086,6 @@ module.exports = {
       "no-undef"
     ]
   },
-  "health/app.js": {
-    "hash": "6d612eed04ee5a844be6ad47c326624cd3e204fecf1c28c99a57ca963b3d7a7b",
-    "rules": [
-      "no-undef"
-    ]
-  },
   "hassio/hassio.app.js": {
     "hash": "b8fbb03cf4a7595299e65a46c4f850394bf57cd4cba879d5524eafbf40ccc32e",
     "rules": [


### PR DESCRIPTION
`health` sets a single variable in the global scope that seems like it can be removed safely. I have tested this change and could not find any issues with it.