### PR TITLE
`gpsinfo` Fix memory leaks

### DIFF
--- a/apps/gpsinfo/ChangeLog
+++ b/apps/gpsinfo/ChangeLog
@@ -9,3 +9,4 @@
 0.10: Show satellites "in view" separated by GNS-system
 0.11: Show number of packets received
 0.12: Fix number of packets received
+0.13: Minor code improvements

--- a/apps/gpsinfo/gps-info.js
+++ b/apps/gpsinfo/gps-info.js
@@ -42,21 +42,21 @@ function getMaidenHead(param1,param2){
 
   lon = lon + 180;
   var t = lon/20;
-  fLon = Math.floor(t);
+  const fLon = Math.floor(t);
   t = (t % fLon)*10;
-  sqLon = Math.floor(t);
+  const sqLon = Math.floor(t);
   t = (t-sqLon)*24;
-  subLon = Math.floor(t);
-  extLon = Math.floor((t-subLon)*10);
+  const subLon = Math.floor(t);
+  const extLon = Math.floor((t-subLon)*10);
 
   lat = lat + 90;
   t = lat/10;
-  fLat = Math.floor(t);
+  const fLat = Math.floor(t);
   t = (t % fLat)*10;
-  sqLat = Math.floor(t);
+  const sqLat = Math.floor(t);
   t=(t-sqLat)*24;
-  subLat = Math.floor(t);
-  extLat = Math.floor((t-subLat)*10);
+  const subLat = Math.floor(t);
+  const extLat = Math.floor((t-subLat)*10);
 
   return U[fLon]+U[fLat]+sqLon+sqLat+L[subLon]+L[subLat]+extLon+extLat;
 }

--- a/apps/gpsinfo/metadata.json
+++ b/apps/gpsinfo/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "gpsinfo",
   "name": "GPS Info",
-  "version": "0.12",
+  "version": "0.13",
   "description": "An application that displays information about latitude, longitude, altitude, speed, satellites and time",
   "icon": "gps-info.png",
   "type": "app",

--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -1110,12 +1110,6 @@ module.exports = {
       "no-undef"
     ]
   },
-  "gpsinfo/gps-info.js": {
-    "hash": "1eb77f45d4182613879b8214dc174f84c7333b4a541c2b43cba6014a16f470ee",
-    "rules": [
-      "no-undef"
-    ]
-  },
   "glbasic/glbasic.app.js": {
     "hash": "7d12a030d6f0ef69a0e5a9783229fd49c0a6a06bf751e3ac562145d2ce8350e9",
     "rules": [


### PR DESCRIPTION
`gpsinfo` currently adds a lot of random numbers to the global scope, this should keep the variables local.

I am unfortunately not able to test these changes because my watch refuses to aquire a GPS fix. Maybe some of you can give it a quick check? I am pretty confident that the changes work :)