### PR TITLE
`hrm` Fix memory leaks

### DIFF
--- a/apps/hrm/ChangeLog
+++ b/apps/hrm/ChangeLog
@@ -10,3 +10,4 @@
 0.10: Autoscale raw graph to maximum value seen
 0.11: Automatic translation of strings.
 0.12: Minor code improvements
+0.13: Minor code improvements

--- a/apps/hrm/heartrate.js
+++ b/apps/hrm/heartrate.js
@@ -61,7 +61,6 @@ var scale = 2000;
 /* On newer (2v10) firmwares we can subscribe to get
 HRM events as they happen */
 Bangle.on('HRM-raw', function(v) {
-  h=v;
   hrmOffset++;
   if (hrmOffset>g.getWidth()) {
     let thousands = Math.round(rawMax / 1000) * 1000;
@@ -76,7 +75,7 @@ Bangle.on('HRM-raw', function(v) {
   if (rawMax < v.raw) {
     rawMax = v.raw;
   }
-  y = E.clip(btm-(8+v.filt/3000),btm-24,btm);
+  let y = E.clip(btm-(8+v.filt/3000),btm-24,btm);
   g.setColor(1,0,0).fillRect(hrmOffset,btm, hrmOffset, y);
   y = E.clip(btm - (v.raw/scale*84),84,btm);
   g.setColor(g.theme.fg).drawLine(lastHrmPt[0],lastHrmPt[1],hrmOffset, y);
@@ -120,7 +119,7 @@ function readHRM() {
   for (var i=0;i<2;i++) {
     var a = hrmInfo.raw[hrmOffset];
     hrmOffset++;
-    y = E.clip(170 - (a*2),100,230);
+    let y = E.clip(170 - (a*2),100,230);
     g.setColor(g.theme.fg).drawLine(lastHrmPt[0],lastHrmPt[1],hrmOffset, y);
     lastHrmPt = [hrmOffset, y];
   }

--- a/apps/hrm/metadata.json
+++ b/apps/hrm/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "hrm",
   "name": "Heart Rate Monitor",
-  "version": "0.12",
+  "version": "0.13",
   "description": "Measure your heart rate and see live sensor data",
   "icon": "heartrate.png",
   "tags": "health",

--- a/apps/lint_exemptions.js
+++ b/apps/lint_exemptions.js
@@ -1068,12 +1068,6 @@ module.exports = {
       "no-undef"
     ]
   },
-  "hrm/heartrate.js": {
-    "hash": "beb8e433f10d3639b343b060f0d5583ea665445f92b2171daff7612eaf135596",
-    "rules": [
-      "no-undef"
-    ]
-  },
   "hebrew_calendar/app.js": {
     "hash": "3077d581b9fcf73816e265e61105a0692356b89e8ed41a82be51960ae26fc8de",
     "rules": [


### PR DESCRIPTION
`hrm` currently adds two variables to the global scope, this should keep them local.

I have tested these changes and could not find any bugs.