### PR TITLE
fastload - Add warning about automatic reload apploader option

### DIFF
--- a/apps/fastload/README.md
+++ b/apps/fastload/README.md
@@ -1,10 +1,16 @@
+#### ⚠️EXPERIMENTAL⚠️
+
 # Fastload Utils
 
-*EXPERIMENTAL* Use this with caution. When you find something misbehaving please check if the problem actually persists when removing this app.
+Use this with caution. When you find something misbehaving please check if the problem actually persists when removing this app.
 
 This allows fast loading of all apps with two conditions:
 * Loaded app contains `Bangle.loadWidgets`. This is needed to prevent problems with apps not expecting widgets to be already loaded.
 * Current app can be removed completely from RAM.
+
+#### ⚠️ KNOWN ISSUES ⚠️
+
+* Fastload currently does not play nice with the automatic reload option of the apploader. App installs and upgrades are unreliable since the fastload causes code to run after reset and interfere with the upload process.
 
 ## Settings
 


### PR DESCRIPTION
This adds a warning to the fastload README regarding bad behaviour in combination with the new automatic reload of the apploader.