### PR TITLE
Fix other app's graphics showing on image clock (BANGLEJS 1)

### DIFF
--- a/apps/imgclock/ChangeLog
+++ b/apps/imgclock/ChangeLog
@@ -10,3 +10,4 @@
 0.09: Bangle.js 2 compatibility
 0.10: Tell clock widgets to hide.
 0.11: Allow fullscreen clock faces with hidden widgets
+0.12: Fixed a bug where other app's graphics would not get cleared.

--- a/apps/imgclock/app.js
+++ b/apps/imgclock/app.js
@@ -3,6 +3,7 @@ Draws a fullscreen image from flash memory
 Saves a small image to flash which is just the area where the clock is
 Keeps an offscreen buffer and draws the time to that
 */
+g.clear(); //clears other apps's graphics
 var is12Hour = (require("Storage").readJSON("setting.json",1)||{})["12hour"];
 var inf = require("Storage").readJSON("imgclock.face.json");
 var img = require("Storage").read("imgclock.face.img");

--- a/apps/imgclock/metadata.json
+++ b/apps/imgclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "imgclock",
   "name": "Image background clock",
   "shortName": "Image Clock",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A clock with an image as a background. **Note:** this clock shows seconds, so has higher than average power consumption.",
   "icon": "app.png",
   "type": "clock",


### PR DESCRIPTION
There is an issue, where if you open an app that has graphics on the bottom, and hold down BTN3 to go to the image clock, a small amount of the apps graphics (about 10px) will show on the bottom. This update just adds an initial clear, which clears other app's graphics.

I am using a banglejs v1 (firmware 2v21).