### PR TITLE
bthrm - Move caching of characteristics into settings

### DIFF
--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -45,4 +45,5 @@
 0.19: Move caching of characteristics into settings app
       Changed default of active scanning to false
       Fix setHRMPower method not returning new state
-      Only buzz  for disconnect after switching on if there already was an actual connection
+      Only buzz for disconnect after switching on if there already was an actual connection
+      Fix recorder not switching BTHRM on and off

--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -45,3 +45,4 @@
 0.19: Move caching of characteristics into settings app
       Changed default of active scanning to false
       Fix setHRMPower method not returning new state
+      Only buzz  for disconnect after switching on if there already was an actual connection

--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -42,4 +42,6 @@
       Add debug option for disabling active scanning
 0.17: New GUI based on layout library
 0.18: Minor code improvements
-0.19: Fix setHRMPower method not returning new state
+0.19: Move caching of characteristics into settings app (needs repairing of the sensor)
+      Changed default of active scanning to false
+      Fix setHRMPower method not returning new state

--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -42,3 +42,4 @@
       Add debug option for disabling active scanning
 0.17: New GUI based on layout library
 0.18: Minor code improvements
+0.19: Fix setHRMPower method not returning new state

--- a/apps/bthrm/ChangeLog
+++ b/apps/bthrm/ChangeLog
@@ -42,6 +42,6 @@
       Add debug option for disabling active scanning
 0.17: New GUI based on layout library
 0.18: Minor code improvements
-0.19: Move caching of characteristics into settings app (needs repairing of the sensor)
+0.19: Move caching of characteristics into settings app
       Changed default of active scanning to false
       Fix setHRMPower method not returning new state

--- a/apps/bthrm/README.md
+++ b/apps/bthrm/README.md
@@ -21,6 +21,10 @@ Once installed you will have to go into this app's settings while your heart rat
 
 **To disable this and return to normal HRM, uninstall the app or change the settings**
 
+The characteristics of your selected sensor are cached in the settings. That means if your sensor changes, e.g. by firmware updates or similar, you will need to re-scan in the settings to update the cache of characteristics. This is done to take some complexity (and time) out of the boot process.
+
+Scanning in the settings will do 10 retries and then give up on adding the sensor. Usually that works fine, if it does not for you just try multiple times. Currently saved sensor information is only replaced on a successful pairing. There are additional options in the Debug entry of the menu that can help with specific sensor oddities. Bonding and active scanning can help with connecting, but can also prevent some sensors from working. The "Grace Periods" just add some additional time at certain steps in the connection process which can help with stability or reconnect speed of some finicky sensors. Defaults should be fine for most.
+
 ### Modes
 
 * Off - Internal HRM is used, no attempt on connecting to BT HRM.
@@ -57,3 +61,7 @@ This replaces `Bangle.setHRMPower` with its own implementation.
 ## Creator
 
 Gordon Williams
+
+## Contributer
+
+[halemmerich](https://github.com/halemmerich)

--- a/apps/bthrm/bthrm.js
+++ b/apps/bthrm/bthrm.js
@@ -106,8 +106,6 @@ function draw(){
     layout.btContact.label = "--";
     layout.btEnergy.label = "--";
   }
-
-  layout.update();
   layout.clear();
   layout.render();
   let first = true;
@@ -128,7 +126,7 @@ global.showStatusInfo = function(txt) {
   g.reset().clearRect(R.x,R.y2-8,R.x2,R.y2).setFont("6x8");
   txt = g.wrapString(txt, R.w)[0];
   g.setFontAlign(0,1).drawString(txt, (R.x+R.x2)/2, R.y2);
-}
+};
 
 function onBtHrm(e) {
   bt = e;

--- a/apps/bthrm/bthrm.js
+++ b/apps/bthrm/bthrm.js
@@ -57,7 +57,7 @@ var layout = new Layout( {
     { type:undefined, height:8 } //dummy to protect debug output
   ]
 }, {
-  lazy:true
+  lazy:false
 });
 
 var int,agg,bt;
@@ -108,6 +108,7 @@ function draw(){
   }
 
   layout.update();
+  layout.clear();
   layout.render();
   let first = true;
   for (let c of layout.l.c){

--- a/apps/bthrm/bthrm.js
+++ b/apps/bthrm/bthrm.js
@@ -133,16 +133,19 @@ function showStatusInfo(txt) {
 function onBtHrm(e) {
   bt = e;
   bt.time = Date.now();
+  draw();
 }
 
 function onInt(e) {
   int = e;
   int.time = Date.now();
+  draw();
 }
 
 function onAgg(e) {
   agg = e;
   agg.time = Date.now();
+  draw();
 }
 
 var settings = require('Storage').readJSON("bthrm.json", true) || {};
@@ -163,7 +166,6 @@ Bangle.drawWidgets();
 if (Bangle.setBTHRMPower){
   g.reset().setFont("6x8",2).setFontAlign(0,0);
   g.drawString("Please wait...",g.getWidth()/2,g.getHeight()/2);
-  setInterval(draw, 1000);
 } else {
   g.reset().setFont("6x8",2).setFontAlign(0,0);
   g.drawString("BTHRM disabled",g.getWidth()/2,g.getHeight()/2);

--- a/apps/bthrm/bthrm.js
+++ b/apps/bthrm/bthrm.js
@@ -123,7 +123,7 @@ function draw(){
 
 
 // This can get called for the boot code to show what's happening
-function showStatusInfo(txt) {
+global.showStatusInfo = function(txt) {
   var R = Bangle.appRect;
   g.reset().clearRect(R.x,R.y2-8,R.x2,R.y2).setFont("6x8");
   txt = g.wrapString(txt, R.w)[0];

--- a/apps/bthrm/default.json
+++ b/apps/bthrm/default.json
@@ -15,8 +15,7 @@
   "custom_fallbackTimeout": 10,
   "gracePeriodNotification": 0,
   "gracePeriodConnect": 0,
-  "gracePeriodService": 0,
   "gracePeriodRequest": 0,
   "bonding": false,
-  "active": true
+  "active": false
 }

--- a/apps/bthrm/lib.js
+++ b/apps/bthrm/lib.js
@@ -318,20 +318,6 @@ exports.enable = () => {
       return result.then(()=>log("Handled characteristics"));
     };
 
-    let createServicePromise = function(service) {
-      log("Create service promise", service);
-      let result = Promise.resolve();
-      result = result.then(()=>{
-        log("Handling service" + service.uuid);
-        return service.getCharacteristics().then((c)=>createCharacteristicsPromise(c));
-      });
-      return result.then(()=>log("Handled service" + service.uuid));
-    };
-
-    let attachServicePromise = function(promise, service) {
-      return promise.then(()=>createServicePromise(service));
-    };
-
     let initBt = function () {
       log("initBt with blockInit: " + blockInit);
       if (blockInit && !powerdownRequested){

--- a/apps/bthrm/lib.js
+++ b/apps/bthrm/lib.js
@@ -302,22 +302,6 @@ exports.enable = () => {
       });
     };
 
-    let createCharacteristicsPromise = function(newCharacteristics) {
-      log("Create characteristics promis ", newCharacteristics);
-      let result = Promise.resolve();
-      for (let c of newCharacteristics){
-        if (!supportedCharacteristics[c.uuid]) continue;
-        log("Supporting characteristic", c);
-        characteristics.push(c);
-        if (c.properties.notify){
-          addNotificationHandler(c);
-        }
-
-        result = attachCharacteristicPromise(result, c);
-      }
-      return result.then(()=>log("Handled characteristics"));
-    };
-
     let initBt = function () {
       log("initBt with blockInit: " + blockInit);
       if (blockInit && !powerdownRequested){

--- a/apps/bthrm/lib.js
+++ b/apps/bthrm/lib.js
@@ -239,6 +239,7 @@ exports.enable = () => {
       }
     };
 
+    let initialDisconnects = true;
     let buzzing = false;
     let onDisconnect = function(reason) {
       log("Disconnect: " + reason);
@@ -252,7 +253,7 @@ exports.enable = () => {
       supportedCharacteristics["0x2a37"].active = false;
       if (!powerdownRequested) startFallback();
       blockInit = false;
-      if (settings.warnDisconnect && !buzzing){
+      if (settings.warnDisconnect && !buzzing && !initialDisconnects){
         buzzing = true;
         Bangle.buzz(500,0.3).then(()=>waitingPromise(4500)).then(()=>{buzzing = false;});
       }
@@ -415,6 +416,7 @@ exports.enable = () => {
 
       return promise.then(()=>{
         log("Connection established, waiting for notifications");
+        initialDisconnects = false;
         clearRetryTimeout(true);
       }).catch((e) => {
         characteristics = [];
@@ -435,6 +437,7 @@ exports.enable = () => {
       isOn = Bangle._PWR.BTHRM.length;
       // so now we know if we're really on
       if (isOn) {
+        initialDisconnects = true;
         powerdownRequested = false;
         switchFallback();
         if (!Bangle.isBTHRMConnected()) initBt();

--- a/apps/bthrm/lib.js
+++ b/apps/bthrm/lib.js
@@ -16,6 +16,14 @@ exports.enable = () => {
 
   log("Settings: ", settings);
 
+  //this is for compatibility with 0.18 and older
+  let oldCache = require('Storage').readJSON("bthrm.cache.json", true);
+  if(oldCache){
+    settings.cache = oldCache;
+    require('Storage').writeJSON("bthrm.json", settings);
+    require('Storage').erase("bthrm.cache.json");
+  }
+
   if (settings.enabled && settings.cache){
 
     log("Start");

--- a/apps/bthrm/lib.js
+++ b/apps/bthrm/lib.js
@@ -361,9 +361,9 @@ exports.enable = () => {
 
         if (settings.gracePeriodRequest){
           log("Add " + settings.gracePeriodRequest + "ms grace period after request");
-          promise = promise.then(()=>{
+          promise = promise.then((d)=>{
             log("Wait after request");
-            return waitingPromise(settings.gracePeriodRequest);
+            return waitingPromise(settings.gracePeriodRequest).then(()=>Promise.resolve(d));
           });
         }
 

--- a/apps/bthrm/metadata.json
+++ b/apps/bthrm/metadata.json
@@ -2,7 +2,7 @@
   "id": "bthrm",
   "name": "Bluetooth Heart Rate Monitor",
   "shortName": "BT HRM",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Overrides Bangle.js's build in heart rate monitor with an external Bluetooth one.",
   "icon": "app.png",
   "screenshots": [{"url":"screen.png"}],

--- a/apps/bthrm/recorder.js
+++ b/apps/bthrm/recorder.js
@@ -26,11 +26,11 @@
       },
       start : () => {
         Bangle.on('BTHRM', onHRM);
-        if (Bangle.setBTRHMPower) Bangle.setBTHRMPower(1,"recorder");
+        if (Bangle.setBTHRMPower) Bangle.setBTHRMPower(1,"recorder");
       },
       stop : () => {
         Bangle.removeListener('BTHRM', onHRM);
-        if (Bangle.setBTRHMPower) Bangle.setBTHRMPower(0,"recorder");
+        if (Bangle.setBTHRMPower) Bangle.setBTHRMPower(0,"recorder");
       },
       draw : (x,y) => g.setColor((Bangle.isBTHRMActive && Bangle.isBTHRMActive())?"#00f":"#88f").drawImage(atob("DAwBAAAAMMeef+f+f+P8H4DwBgAA"),x,y)
     };

--- a/apps/bthrm/settings.js
+++ b/apps/bthrm/settings.js
@@ -21,8 +21,6 @@
   if (settings.debuglog)
     log = print;
 
-  const bthrm = require("bthrm");
-
   function applyCustomSettings(){
     writeSettings("enabled",true);
     writeSettings("replace",settings.custom_replace);

--- a/apps/bthrm/settings.js
+++ b/apps/bthrm/settings.js
@@ -129,11 +129,9 @@
     "0x2a19", // Battery
   ];
 
-  var characteristicsToCache = function(characteristics, deviceId) {
+  var characteristicsToCache = function(characteristics) {
     log("Cache characteristics");
-    let cache = {
-      id: deviceId
-    };
+    let cache = {};
     if (!cache.characteristics) cache.characteristics = {};
     for (var c of characteristics){
       //"handle_value":16,"handle_decl":15
@@ -240,7 +238,7 @@
 
     return promise.then(()=>{
       log("Connection established, saving cache");
-      characteristicsToCache(characteristics, deviceId);
+      characteristicsToCache(characteristics);
     });
   }
 

--- a/apps/bthrm/settings.js
+++ b/apps/bthrm/settings.js
@@ -262,12 +262,15 @@
           log("Found device", d);
           let shown = (d.name || d.id.substr(0, 17));
           submenu_scan[shown] = function () {
-            E.showPrompt("Set " + shown + "?").then((r) => {
+            E.showPrompt("Connect to\n" + shown + "?", {title: "Pairing"}).then((r) => {
               if (r) {
-                E.showMessage("Connecting...");
+                E.showMessage("Connecting...", {img:require("Storage").read("bthrm.img")});
                 let count = 0;
                 const successHandler = ()=>{
-                  E.showAlert("Success").then(()=>{
+                  E.showPrompt("Success!", {
+                    img:require("Storage").read("bthrm.img"),
+                    buttons: { "OK":true }
+                  }).then(()=>{
                   writeSettings("btid", d.id);
                   // Store the name for displaying later. Will connect by ID
                   if (d.name) {
@@ -280,7 +283,7 @@
                   count++;
                   log("ERROR", e);
                   if (count <= 10){
-                    E.showMessage("Error during caching, Retry " + count + "/10", e);
+                    E.showMessage("Error during caching\nRetry " + count + "/10", e);
                     return cacheDevice(d.id).then(successHandler).catch(errorHandler);
                   } else {
                     E.showAlert("Error during caching", e).then(()=>{

--- a/apps/bthrm/settings.js
+++ b/apps/bthrm/settings.js
@@ -1,6 +1,6 @@
 (function(back) {
   function writeSettings(key, value) {
-    var s = require('Storage').readJSON(FILE, true) || {};
+    let s = require('Storage').readJSON(FILE, true) || {};
     s[key] = value;
     require('Storage').writeJSON(FILE, s);
     readSettings();
@@ -13,9 +13,15 @@
     );
   }
 
-  var FILE="bthrm.json";
-  var settings;
+  let FILE="bthrm.json";
+  let settings;
   readSettings();
+
+  let log = ()=>{};
+  if (settings.debuglog)
+    log = print;
+
+  const bthrm = require("bthrm");
 
   function applyCustomSettings(){
     writeSettings("enabled",true);
@@ -26,7 +32,7 @@
   }
 
   function buildMainMenu(){
-    var mainmenu = {
+    let mainmenu = {
       '': { 'title': 'Bluetooth HRM' },
       '< Back': back,
       'Mode': {
@@ -63,12 +69,13 @@
     };
 
     if (settings.btname || settings.btid){
-      var name = "Clear " + (settings.btname || settings.btid);
+      let name = "Clear " + (settings.btname || settings.btid);
       mainmenu[name] = function() {
       E.showPrompt("Clear current device?").then((r)=>{
           if (r) {
             writeSettings("btname",undefined);
             writeSettings("btid",undefined);
+            writeSettings("cache", undefined);
           }
           E.showMenu(buildMainMenu());
         });
@@ -81,7 +88,7 @@
     return mainmenu;
   }
 
-  var submenu_debug = {
+  let submenu_debug = {
     '' : { title: "Debug"},
     '< Back': function() { E.showMenu(buildMainMenu()); },
     'Alert on disconnect': {
@@ -111,11 +118,137 @@
     'Grace periods': function() { E.showMenu(submenu_grace); }
   };
 
+  let supportedServices = [
+    "0x180d", // Heart Rate
+    "0x180f", // Battery
+  ];
+
+  let supportedCharacteristics = [
+    "0x2a37", // Heart Rate
+    "0x2a38", // Body sensor location
+    "0x2a19", // Battery
+  ];
+
+  var characteristicsToCache = function(characteristics, deviceId) {
+    log("Cache characteristics");
+    let cache = {
+      id: deviceId
+    };
+    if (!cache.characteristics) cache.characteristics = {};
+    for (var c of characteristics){
+      //"handle_value":16,"handle_decl":15
+      log("Saving handle " + c.handle_value + " for characteristic: ", c.uuid);
+      cache.characteristics[c.uuid] = {
+        "handle": c.handle_value,
+        "uuid": c.uuid,
+        "notify": c.properties.notify,
+        "read": c.properties.read
+      };
+    }
+    writeSettings("cache", cache);
+  };
+
+  let createCharacteristicPromise = function(newCharacteristic) {
+    log("Create characteristic promise", newCharacteristic.uuid);
+    return Promise.resolve().then(()=>log("Handled characteristic", newCharacteristic.uuid));
+  };
+
+  let attachCharacteristicPromise = function(promise, characteristic) {
+    return promise.then(()=>{
+      log("Handling characteristic:", characteristic.uuid);
+      return createCharacteristicPromise(characteristic);
+    });
+  };
+
+  let characteristics;
+
+  let createCharacteristicsPromise = function(newCharacteristics) {
+    log("Create characteristics promise ", newCharacteristics.length);
+    let result = Promise.resolve();
+    for (let c of newCharacteristics){
+      if (!supportedCharacteristics.includes(c.uuid)) continue;
+      log("Supporting characteristic", c.uuid);
+      characteristics.push(c);
+
+      result = attachCharacteristicPromise(result, c);
+    }
+    return result.then(()=>log("Handled characteristics"));
+  };
+
+  let createServicePromise = function(service) {
+    log("Create service promise", service.uuid);
+    let result = Promise.resolve();
+    result = result.then(()=>{
+      log("Handling service", service.uuid);
+      return service.getCharacteristics().then((c)=>createCharacteristicsPromise(c));
+    });
+    return result.then(()=>log("Handled service", service.uuid));
+  };
+
+  let attachServicePromise = function(promise, service) {
+    return promise.then(()=>createServicePromise(service));
+  };
+
+  function cacheDevice(deviceId){
+    let promise;
+    let filters;
+    let gatt;
+    characteristics = [];
+    filters = [{ id: deviceId }];
+
+    log("Requesting device with filters", filters);
+    promise = NRF.requestDevice({ filters: filters, active: settings.active });
+
+    promise = promise.then((d)=>{
+      log("Got device", d);
+      gatt = d.gatt;
+      log("Connecting...");
+      return gatt.connect().then(function() {
+        log("Connected.");
+      });
+    });
+
+    if (settings.bonding){
+      promise = promise.then(() => {
+        log(JSON.stringify(gatt.getSecurityStatus()));
+        if (gatt.getSecurityStatus().bonded) {
+          log("Already bonded");
+          return Promise.resolve();
+        } else {
+          log("Start bonding");
+          return gatt.startBonding()
+            .then(() => log("Security status after bonding" + gatt.getSecurityStatus()));
+        }
+      });
+    }
+
+    promise = promise.then(()=>{
+      log("Getting services");
+      return gatt.getPrimaryServices();
+    });
+
+    promise = promise.then((services)=>{
+      log("Got services", services.length);
+      let result = Promise.resolve();
+      for (let service of services){
+        if (!(supportedServices.includes(service.uuid))) continue;
+        log("Supporting service", service.uuid);
+        result = attachServicePromise(result, service);
+      }
+      return result;
+    });
+
+    return promise.then(()=>{
+      log("Connection established, saving cache");
+      characteristicsToCache(characteristics, deviceId);
+    });
+  }
+
   function createMenuFromScan(){
     E.showMenu();
     E.showMessage("Scanning for 4 seconds");
 
-    var submenu_scan = {
+    let submenu_scan = {
       '< Back': function() { E.showMenu(buildMainMenu()); }
     };
     NRF.findDevices(function(devices) {
@@ -126,18 +259,38 @@
         return;
       } else {
         devices.forEach((d) => {
-          print("Found device", d);
-          var shown = (d.name || d.id.substr(0, 17));
+          log("Found device", d);
+          let shown = (d.name || d.id.substr(0, 17));
           submenu_scan[shown] = function () {
             E.showPrompt("Set " + shown + "?").then((r) => {
               if (r) {
-                writeSettings("btid", d.id);
-                // Store the name for displaying later. Will connect by ID
-                if (d.name) {
-                  writeSettings("btname", d.name);
-                }
+                E.showMessage("Connecting...");
+                let count = 0;
+                const successHandler = ()=>{
+                  E.showAlert("Success").then(()=>{
+                  writeSettings("btid", d.id);
+                  // Store the name for displaying later. Will connect by ID
+                  if (d.name) {
+                    writeSettings("btname", d.name);
+                  }
+                    E.showMenu(buildMainMenu());
+                  });
+                };
+                const errorHandler = (e)=>{
+                  count++;
+                  log("ERROR", e);
+                  if (count <= 10){
+                    E.showMessage("Error during caching, Retry " + count + "/10", e);
+                    return cacheDevice(d.id).then(successHandler).catch(errorHandler);
+                  } else {
+                    E.showAlert("Error during caching", e).then(()=>{
+                      E.showMenu(buildMainMenu());
+                    });
+                  }
+                };
+
+                return cacheDevice(d.id).then(successHandler).catch(errorHandler);
               }
-              E.showMenu(buildMainMenu());
             });
           };
         });
@@ -146,7 +299,7 @@
     }, { timeout: 4000, active: true, filters: [{services: [ "180d" ]}]});
   }
 
-  var submenu_custom = {
+  let submenu_custom = {
     '' : { title: "Custom mode"},
     '< Back': function() { E.showMenu(buildMainMenu()); },
     'Replace HRM': {
@@ -183,7 +336,7 @@
     },
   };
 
-  var submenu_grace = {
+  let submenu_grace = {
     '' : { title: "Grace periods"},
     '< Back': function() { E.showMenu(submenu_debug); },
     'Request': {
@@ -214,16 +367,6 @@
       format: v=>v+"ms",
       onchange: v => {
         writeSettings("gracePeriodNotification",v);
-      }
-    },
-    'Service': {
-      value: settings.gracePeriodService,
-      min: 0,
-      max: 3000,
-      step: 100,
-      format: v=>v+"ms",
-      onchange: v => {
-        writeSettings("gracePeriodService",v);
       }
     }
   };


### PR DESCRIPTION
Moves the caching of device characteristics out of the library code and into the settings. Reduces the lib by about 1/6 and potentially saves on flash writes since the connect is now strictly read only. Caching now only happens once during initial pairing with the sensor.