### PR TITLE
fileman: allow managing files in the app loader

### DIFF
--- a/apps/fileman/ChangeLog
+++ b/apps/fileman/ChangeLog
@@ -1,4 +1,4 @@
 0.01: New app!
 0.02: Improve handling of large amounts of files (fix #579)
 0.03: Update RegExp use (Was using backreference instead of character code)
-0.04: Allow managing files in the app loader
+

--- a/apps/fileman/ChangeLog
+++ b/apps/fileman/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New app!
 0.02: Improve handling of large amounts of files (fix #579)
 0.03: Update RegExp use (Was using backreference instead of character code)
+0.04: Allow managing files in the app loader

--- a/apps/fileman/manage_files.html
+++ b/apps/fileman/manage_files.html
@@ -60,9 +60,10 @@
       },
       deleteFile: function (file) {
         if(confirm(`Really delete ${file}?`)) {
-          Puck.eval(`require("Storage").erase("${file}")`);
-          this.loadFiles();
-          this.getStats();
+          Puck.eval(`require("Storage").erase("${file}")`, () => {
+            this.loadFiles();
+            this.getStats();
+          });
         }
       },
       showFile: function (file) {

--- a/apps/fileman/manage_files.html
+++ b/apps/fileman/manage_files.html
@@ -1,0 +1,77 @@
+<html>
+<head>
+  <link rel="stylesheet" href="../../css/spectre.min.css">
+</head>
+<body>
+<script src="../../core/lib/interface.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
+
+<div id="app">
+  <table class="table">
+    <thead><tr><th>Stats</th><th></th></tr></thead>
+    <tbody><tr v-for="s in stats"><td>{{s[0]}}</td><td>{{s[1]}}</td></tr></tbody>
+  </table>
+  <h3>Files</h3>
+  <div class="form-group">
+    <label class="form-label">Filter</label>
+    <input class="form-input" v-model="fileFilter" type="text" />
+  </div>
+  <table class="table">
+  <thead><tr><th>Filename</th><th>show</th><th>delete</th></tr></thead>
+  <tbody>
+    <tr v-for="file in filteredFiles">
+      <td>{{file}}</td>
+      <td><button v-on:click="showFile(file)" class="btn btn-primary btn-lg mr-2">show</button></td>
+      <td><button v-on:click="deleteFile(file)" class="btn btn-primary btn-lg mr-2">delete</button></td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<script>
+  var app = new Vue({
+    el: '#app',
+    data: {
+      files: ['Click load files to see something'],
+      fileFilter: '',
+      stats: [['No stats', 'loaded']],
+    },
+    computed: {
+      filteredFiles: function () {
+        return this.files.filter((f) => f.includes(this.fileFilter));
+      }
+    },
+    mounted: function () {
+      setTimeout(() => {
+        this.loadFiles();
+        this.getStats();
+      }, 1000);
+    },
+    methods: {
+      loadFiles: function () {
+        Puck.eval('require("Storage").list()', (files) => {
+          this.files = files.filter((f) => !f.startsWith('.')).sort();
+        });
+      },
+      getStats: function () {
+        Puck.eval('require("Storage").getStats()', (stats) => {
+          this.stats = Object.entries(stats);
+        });
+      },
+      deleteFile: function (file) {
+        if(confirm(`Really delete ${file}?`)) {
+          Puck.eval(`require("Storage").erase("${file}")`);
+          this.loadFiles();
+          this.getStats();
+        }
+      },
+      showFile: function (file) {
+        Puck.eval(`require("Storage").read("${file}")`, (contents) => {
+          alert(contents);
+        })
+      }
+    }
+  })
+</script>
+</body>
+</html>

--- a/apps/fileman/metadata.json
+++ b/apps/fileman/metadata.json
@@ -7,6 +7,7 @@
   "icon": "icons8-filing-cabinet-48.png",
   "tags": "tools",
   "supports": ["BANGLEJS","BANGLEJS2"],
+  "interface": "manage_files.html",
   "readme": "README.md",
   "storage": [
     {"name":"fileman.app.js","url":"fileman.app.js"},

--- a/apps/fileman/metadata.json
+++ b/apps/fileman/metadata.json
@@ -2,7 +2,7 @@
   "id": "fileman",
   "name": "File manager",
   "shortName": "FileManager",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Simple file manager, allows user to examine watch storage and display, load or delete individual files",
   "icon": "icons8-filing-cabinet-48.png",
   "tags": "tools",

--- a/apps/fileman/metadata.json
+++ b/apps/fileman/metadata.json
@@ -2,7 +2,7 @@
   "id": "fileman",
   "name": "File manager",
   "shortName": "FileManager",
-  "version": "0.04",
+  "version": "0.03",
   "description": "Simple file manager, allows user to examine watch storage and display, load or delete individual files",
   "icon": "icons8-filing-cabinet-48.png",
   "tags": "tools",


### PR DESCRIPTION
This adds a small interface to the app loader to manage files in the app loader and not just on the watch. You can list, delete and show files in the loader and it shows the storage stats.