### PR TITLE
boot: fix `throw` stopping clock w/o wdgts loading

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -69,3 +69,6 @@
 0.58: "Make Connectable" temporarily bypasses the whitelist
 0.59: Whitelist: Try to resolve peer addresses using NRF.resolveAddress() - for 2v19 or 2v18 cutting edge builds
 0.60: Minor code improvements
+0.61: Fix `throw` would stop clocks without widgets from being loaded if
+	called by `load(".bootcde")` which is the case when using
+	`Bangle.showClock()`.

--- a/apps/boot/bootloader.js
+++ b/apps/boot/bootloader.js
@@ -3,7 +3,7 @@ var s = require("Storage").readJSON("setting.json",1)||{};
 /* If were being called from JS code in order to load the clock quickly (eg from a launcher)
 and the clock in question doesn't have widgets, force a normal 'load' as this will then
 reset everything and remove the widgets. */
-if (global.__FILE__ && !s.clockHasWidgets) {load();throw "Clock has no widgets, can't fast load";}
+if (global.__FILE__ && !s.clockHasWidgets) {load();setTimeout(()=>{throw "Clock has no widgets, can't fast load";},0);}
 // Otherwise continue to try and load the clock
 var _clkApp = require("Storage").read(s.clock);
 if (!_clkApp) {

--- a/apps/boot/metadata.json
+++ b/apps/boot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boot",
   "name": "Bootloader",
-  "version": "0.60",
+  "version": "0.61",
   "description": "This is needed by Bangle.js to automatically load the clock, menu, widgets and settings",
   "icon": "bootloader.png",
   "type": "bootloader",


### PR DESCRIPTION
This surrounds the `throw` statement with a timeout and is then called only after the clock has loaded. This seems a little weird maybe? But it works. I also tried changing to a `conole.log` instead of the `throw` inside a timeout. That also works, as well as just removing the throw alltogether.

I am not sure this is the best way to solve this. @halemmerich @bobrippling @nxdefiant @gfwilliams do you have other suggestions? Maybe a fix should be somewhere else completely.

E.g. the new [Meridian Clock](https://espruino.github.io/BangleApps/?q=meridian) or [two of them clock](https://espruino.github.io/BangleApps/?q=2ofthemclk) have no widgets.