### PR TITLE
[messagegui] fix: handle the unreadTimeout better

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -105,4 +105,4 @@
 0.76: Swipe up/down on a shown message to show the next newer/older message.
 0.77: Messages can now use international fonts if they are installed
 0.78: Fix: When user taps on a new message, clear the unread timeout
-0.79: Fix: Reset the unread timeout each time a new message is shown
+0.79: Fix: Reset the unread timeout each time a new message is shown. When the message is read from user input, do not set an unread timeout.

--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -105,3 +105,4 @@
 0.76: Swipe up/down on a shown message to show the next newer/older message.
 0.77: Messages can now use international fonts if they are installed
 0.78: Fix: When user taps on a new message, clear the unread timeout
+0.79: Fix: Reset the unread timeout each time a new message is shown

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -87,7 +87,7 @@ var onMessagesModified = function(type,msg) {
   }
   if (msg && msg.id=="nav" && msg.t=="modify" && active!="map")
     return; // don't show an updated nav message if we're just in the menu
-  showMessage(msg&&msg.id);
+  showMessage(msg&&msg.id, false);
 };
 Bangle.on("message", onMessagesModified);
 
@@ -254,16 +254,16 @@ function showMessageScroller(msg) {
       g.setFont(bodyFont).setFontAlign(0,-1).drawString(lines[idx], r.x+r.w/2, r.y);
     }, select : function(idx) {
       if (idx>=lines.length-2)
-        showMessage(msg.id);
+        showMessage(msg.id, true);
     },
-    back : () => showMessage(msg.id)
+    back : () => showMessage(msg.id, true)
   });
 }
 
 function showMessageSettings(msg) {
   active = "settings";
   var menu = {"":{"title":/*LANG*/"Message"},
-    "< Back" : () => showMessage(msg.id),
+    "< Back" : () => showMessage(msg.id, true),
     /*LANG*/"View Message" : () => {
       showMessageScroller(msg);
     },
@@ -304,8 +304,8 @@ function showMessageSettings(msg) {
   E.showMenu(menu);
 }
 
-function showMessage(msgid) {
-  resetReloadTimeout();
+function showMessage(msgid, persist) {
+  if(!persist) resetReloadTimeout();
   let idx = MESSAGES.findIndex(m=>m.id==msgid);
   var msg = MESSAGES[idx];
   if (updateLabelsInterval) {
@@ -410,8 +410,8 @@ function showMessage(msgid) {
   Bangle.swipeHandler = (lr,ud) => {
     if (lr>0 && posHandler) posHandler();
     if (lr<0 && negHandler) negHandler();
-    if (ud>0 && idx<MESSAGES.length-1) showMessage(MESSAGES[idx+1].id);
-    if (ud<0 && idx>0) showMessage(MESSAGES[idx-1].id);
+    if (ud>0 && idx<MESSAGES.length-1) showMessage(MESSAGES[idx+1].id, true);
+    if (ud<0 && idx>0) showMessage(MESSAGES[idx-1].id, true);
   };
   Bangle.on("swipe", Bangle.swipeHandler);
   g.reset().clearRect(Bangle.appRect);
@@ -448,7 +448,7 @@ function checkMessages(options) {
   // If we have a new message, show it
   if (options.showMsgIfUnread && newMessages.length) {
     delete newMessages[0].show; // stop us getting stuck here if we're called a second time
-    showMessage(newMessages[0].id);
+    showMessage(newMessages[0].id, true);
     // buzz after showMessage, so being busy during layout doesn't affect the buzz pattern
     if (global.BUZZ_ON_NEW_MESSAGE) {
       // this is set if we entered the messages app by loading `messagegui.new.js`
@@ -461,7 +461,7 @@ function checkMessages(options) {
   }
   // no new messages: show playing music? Only if we have playing music, or state=="show" (set by messagesmusic)
   if (options.openMusic && MESSAGES.some(m=>m.id=="music" && ((m.track && m.state=="play") || m.state=="show")))
-    return showMessage('music');
+    return showMessage('music', true);
   // no new messages - go to clock?
   if (options.clockIfAllRead && newMessages.length==0)
     return load();
@@ -510,7 +510,7 @@ function checkMessages(options) {
     },
     select : idx => {
       if (idx < MESSAGES.length)
-        showMessage(MESSAGES[idx].id);
+        showMessage(MESSAGES[idx].id, true);
     },
     back : () => load()
   });
@@ -537,7 +537,6 @@ require("messages").toggleWidget(false);
 Bangle.drawWidgets();
 
 setTimeout(() => {
-  resetReloadTimeout();
   // only openMusic on launch if music is new, or state=="show" (set by messagesmusic)
   var musicMsg = MESSAGES.find(m => m.id === "music");
   checkMessages({

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -448,7 +448,7 @@ function checkMessages(options) {
   // If we have a new message, show it
   if (options.showMsgIfUnread && newMessages.length) {
     delete newMessages[0].show; // stop us getting stuck here if we're called a second time
-    showMessage(newMessages[0].id, true);
+    showMessage(newMessages[0].id, false);
     // buzz after showMessage, so being busy during layout doesn't affect the buzz pattern
     if (global.BUZZ_ON_NEW_MESSAGE) {
       // this is set if we entered the messages app by loading `messagegui.new.js`

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -305,6 +305,7 @@ function showMessageSettings(msg) {
 }
 
 function showMessage(msgid) {
+  resetReloadTimeout();
   let idx = MESSAGES.findIndex(m=>m.id==msgid);
   var msg = MESSAGES[idx];
   if (updateLabelsInterval) {
@@ -522,6 +523,13 @@ function cancelReloadTimeout() {
   unreadTimeout = undefined;
 }
 
+function resetReloadTimeout(){
+  cancelReloadTimeout();
+  if (!isFinite(settings.unreadTimeout)) settings.unreadTimeout=60;
+  if (settings.unreadTimeout)
+    unreadTimeout = setTimeout(load, settings.unreadTimeout*1000);
+}
+
 g.clear();
 
 Bangle.loadWidgets();
@@ -529,9 +537,7 @@ require("messages").toggleWidget(false);
 Bangle.drawWidgets();
 
 setTimeout(() => {
-  if (!isFinite(settings.unreadTimeout)) settings.unreadTimeout=60;
-  if (settings.unreadTimeout)
-    unreadTimeout = setTimeout(load, settings.unreadTimeout*1000);
+  resetReloadTimeout();
   // only openMusic on launch if music is new, or state=="show" (set by messagesmusic)
   var musicMsg = MESSAGES.find(m => m.id === "music");
   checkMessages({

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.78",
+  "version": "0.79",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
This MR does two things:

- move the code that sets the `unreadTimeout` to a new function called `resetReloadTimeout`
- each time a new message is received, call `resetReloadTimeout`

This way, if you receive a lot of consecutive messages, you are guaranteed to be able to read the last one, because your timeout starts from its reception and not from the reception of the first one like before.