### PR TITLE
recorder: fix accessing WIDGETS

### DIFF
--- a/apps/recorder/ChangeLog
+++ b/apps/recorder/ChangeLog
@@ -52,3 +52,4 @@
 0.41: Fix exit from plots and graphs would easily react twice, going back two
 	levels instead of one.
 0.42: Minor code improvements
+0.43: Fix interaction on clocks without widgets

--- a/apps/recorder/clkinfo.js
+++ b/apps/recorder/clkinfo.js
@@ -11,7 +11,7 @@
 			{
 				name: "Toggle",
 				get: () => {
-					const w = WIDGETS && WIDGETS["recorder"];
+					const w = typeof WIDGETS !== "undefined" && WIDGETS["recorder"];
 
 					return w && w.isRecording() ? {
 						text: "Recording",
@@ -24,7 +24,7 @@
 					};
 				},
 				run: () => {
-					const w = WIDGETS && WIDGETS["recorder"];
+					const w = typeof WIDGETS !== "undefined" && WIDGETS["recorder"];
 					if(w){
 						Bangle.buzz();
 						w.setRecording(!w.isRecording(), { force: "append" });

--- a/apps/recorder/metadata.json
+++ b/apps/recorder/metadata.json
@@ -2,7 +2,7 @@
   "id": "recorder",
   "name": "Recorder",
   "shortName": "Recorder",
-  "version": "0.42",
+  "version": "0.43",
   "description": "Record GPS position, heart rate and more in the background, then download to your PC.",
   "icon": "app.png",
   "tags": "tool,outdoors,gps,widget,clkinfo",


### PR DESCRIPTION
On clocks without `WIDGETS`, the previous code would hit a `TypeError`