### PR TITLE
clkinfo: make `CLKINFO_FOCUS` a counter

### DIFF
--- a/apps/clock_info/ChangeLog
+++ b/apps/clock_info/ChangeLog
@@ -8,3 +8,4 @@
 0.07: Developer tweak: clkinfo load errors are emitted
 0.08: Pass options to show(), hide() and run(), and add focus() and blur() item methods
 0.09: Save clkinfo settings on kill and remove
+0.10: Fix focus bug when changing focus between two clock infos

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -289,7 +289,7 @@ exports.addInteractive = function(menu, options) {
   Bangle.on("swipe",swipeHandler);
   const blur = () => {
     options.focus=false;
-    delete Bangle.CLKINFO_FOCUS;
+    Bangle.CLKINFO_FOCUS--;
     const itm = menu[options.menuA].items[options.menuB];
     let redraw = true;
     if (itm.blur && itm.blur(options) === false)
@@ -298,7 +298,7 @@ exports.addInteractive = function(menu, options) {
   };
   const focus = () => {
     let redraw = true;
-    Bangle.CLKINFO_FOCUS=true;
+    Bangle.CLKINFO_FOCUS = (Bangle.CLKINFO_FOCUS || 0) + 1;
     if (!options.focus) {
       options.focus=true;
       const itm = menu[options.menuA].items[options.menuB];
@@ -341,7 +341,7 @@ exports.addInteractive = function(menu, options) {
     Bangle.removeListener("swipe",swipeHandler);
     if (touchHandler) Bangle.removeListener("touch",touchHandler);
     if (lockHandler) Bangle.removeListener("lock", lockHandler);
-    delete Bangle.CLKINFO_FOCUS;
+    Bangle.CLKINFO_FOCUS--;
     menuHideItem(menu[options.menuA].items[options.menuB]);
     exports.loadCount--;
     delete exports.clockInfos[options.index];

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -298,7 +298,7 @@ exports.addInteractive = function(menu, options) {
   };
   const focus = () => {
     let redraw = true;
-    Bangle.CLKINFO_FOCUS = (Bangle.CLKINFO_FOCUS || 0) + 1;
+    Bangle.CLKINFO_FOCUS = (0 | Bangle.CLKINFO_FOCUS) + 1;
     if (!options.focus) {
       options.focus=true;
       const itm = menu[options.menuA].items[options.menuB];

--- a/apps/clock_info/metadata.json
+++ b/apps/clock_info/metadata.json
@@ -1,7 +1,7 @@
 { "id": "clock_info",
   "name": "Clock Info Module",
   "shortName": "Clock Info",
-  "version":"0.09",
+  "version":"0.10",
   "description": "A library used by clocks to provide extra information on the clock face (Altitude, BPM, etc)",
   "icon": "app.png",
   "type": "module",

--- a/typescript/types/clock_info.d.ts
+++ b/typescript/types/clock_info.d.ts
@@ -61,5 +61,5 @@ declare module ClockInfo {
 }
 
 interface BangleExt {
-  CLKINFO_FOCUS?: true;
+  CLKINFO_FOCUS?: number;
 }


### PR DESCRIPTION
This avoids issues when we have multiple clkinfos visible. The first clkinfo may want to focus itself, but a second clkinfo may then unfocus, deleting the first's effects (i.e. setting `CLKINFO_FOCUS`).

In detail:

`CLKINFO_FOCUS` will be set (to `true`) by the first handler (left hand clkinfo) and then unset (/ `delete`d) by the second handler (right hand clkinfo).

This is done in [the `touchHandler`](https://github.com/espruino/BangleApps/blob/c2ea454a3bc7bfaefbc39a5b376510bb9d7d4ec8/apps/clock_info/lib.js#L313-L324).

This commit makes `CLKINFO_FOCUS` a count.

- When we have a tap on a previous clkinfo (previous as in, earlier in the event handler list), it'll focus itself, `CLKINFO_FOCUS++`
- The later handler comes along, unfocuses itself, `CLKINFO_FOCUS--`
- `CLKINFO_FOCUS` is now `1`, so clkinfo is registered as being focussed still, meaning quicklaunch will work because of:

> https://github.com/espruino/BangleApps/blob/c2ea454a3bc7bfaefbc39a5b376510bb9d7d4ec8/apps/quicklaunch/boot.js#L36-L36

Fixes #3355