### PR TITLE
bootgatthrm: allow option to prevent disconnect

### DIFF
--- a/apps/bootgatthrm/ChangeLog
+++ b/apps/bootgatthrm/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial release.
 0.02: Added compatibility to OpenTracks and added HRM Location
+0.03: Allow setting to keep BLE connected

--- a/apps/bootgatthrm/boot.js
+++ b/apps/bootgatthrm/boot.js
@@ -30,6 +30,9 @@
     });
 
   }
+
+  const keepConnected = (require("Storage").readJSON("gatthrm.settings.json", 1) || {}).keepConnected;
+
   function updateBLEHeartRate(hrm) {
     /*
      * Send updated heart rate measurement via BLE
@@ -52,7 +55,8 @@
         /*
          * BLE has to restart after service setup.  
          */
-        NRF.disconnect();
+        if(!settings.keepConnected)
+          NRF.disconnect();
       }
       else if (error.message.includes("UUID 0x2a37")) {
         /*

--- a/apps/bootgatthrm/boot.js
+++ b/apps/bootgatthrm/boot.js
@@ -70,5 +70,5 @@
   }
 
   setupHRMAdvertising();
-  Bangle.on("HRM", function (hrm) { updateBLEHeartRate(hrm); });
+  Bangle.on("HRM", updateBLEHeartRate);
 })();

--- a/apps/bootgatthrm/boot.js
+++ b/apps/bootgatthrm/boot.js
@@ -53,14 +53,14 @@
     } catch (error) {
       if (error.message.includes("BLE restart")) {
         /*
-         * BLE has to restart after service setup.  
+         * BLE has to restart after service setup.
          */
         if(!settings.keepConnected)
           NRF.disconnect();
       }
       else if (error.message.includes("UUID 0x2a37")) {
         /*
-         * Setup service if it wasn't setup correctly for some reason 
+         * Setup service if it wasn't setup correctly for some reason
          */
         setupHRMAdvertising();
       } else {

--- a/apps/bootgatthrm/metadata.json
+++ b/apps/bootgatthrm/metadata.json
@@ -2,7 +2,7 @@
   "id": "bootgatthrm",
   "name": "BLE GATT HRM Service",
   "shortName": "BLE HRM Service",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Adds the GATT HRM Service to advertise the measured HRM over Bluetooth.\n",
   "icon": "bluetooth.png",
   "type": "bootloader",


### PR DESCRIPTION
This allows a user to (manually) place a config file to keep BLE connected - this prevents bluetooth from disconnecting every time a HRM event fires

@AnotherStranger does this look ok to you?