### PR TITLE
analogquadclk: fix some fastloading logic

### DIFF
--- a/apps/analogquadclk/ChangeLog
+++ b/apps/analogquadclk/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New Clock!
+0.02: Fix some fastloading logic.

--- a/apps/analogquadclk/app.js
+++ b/apps/analogquadclk/app.js
@@ -32,7 +32,6 @@ const hand_hour_bg = get_hand(HOUR_LEN, HOUR_W, 8, HOUR_BACK);
 const hand_minute = get_hand(MIN_LEN, 4, 3, MIN_BACK);
 const hand_minute_bg = get_hand(MIN_LEN, MIN_W, 6, MIN_BACK);
 
-
 // schedule a draw for the next minute
 function queueDraw() {
   if (drawTimeout) clearTimeout(drawTimeout);
@@ -212,7 +211,6 @@ if (clockInfoItemsBangle) {
       });
   }
 }
-
 
 // Add the 4 clockinfos
 const CLOCKINFOSIZE = 50;

--- a/apps/analogquadclk/app.js
+++ b/apps/analogquadclk/app.js
@@ -236,6 +236,10 @@ Bangle.setUI({
   remove: function() {
     if (drawTimeout) clearTimeout(drawTimeout);
     clockInfoMenuA.remove();
+    clockInfoMenuB.remove();
+    clockInfoMenuC.remove();
+    clockInfoMenuD.remove();
+    require("widget_utils").show(); // re-show widgets
   }
 });
 // Load widgets

--- a/apps/analogquadclk/app.js
+++ b/apps/analogquadclk/app.js
@@ -87,6 +87,21 @@ function draw() {
   lastModified = getHandBounds();
   //g.drawRect(lastModified); // debug
 }
+// Show launcher when middle button pressed
+Bangle.setUI({
+  mode: "clock",
+  remove: function() {
+    if (drawTimeout) clearTimeout(drawTimeout);
+    clockInfoMenuA.remove();
+    clockInfoMenuB.remove();
+    clockInfoMenuC.remove();
+    clockInfoMenuD.remove();
+    require("widget_utils").show(); // re-show widgets
+  }
+});
+// Load widgets
+Bangle.loadWidgets();
+require("widget_utils").hide();
 
 // Clear the screen once, at startup
 background.fillRect(0, 0, W - 1, H - 1);
@@ -229,20 +244,4 @@ let clockInfoMenuD = require("clock_info").addInteractive(clockInfoItems, {
   h: CLOCKINFOSIZE,
   draw: clockInfoDraw
 });
-
-// Show launcher when middle button pressed
-Bangle.setUI({
-  mode: "clock",
-  remove: function() {
-    if (drawTimeout) clearTimeout(drawTimeout);
-    clockInfoMenuA.remove();
-    clockInfoMenuB.remove();
-    clockInfoMenuC.remove();
-    clockInfoMenuD.remove();
-    require("widget_utils").show(); // re-show widgets
-  }
-});
-// Load widgets
-Bangle.loadWidgets();
-require("widget_utils").hide();
 }

--- a/apps/analogquadclk/app.js
+++ b/apps/analogquadclk/app.js
@@ -1,3 +1,4 @@
+{
 const W = g.getWidth();
 const H = g.getHeight();
 const background = require("clockbg"); // image backgrounds
@@ -240,3 +241,4 @@ Bangle.setUI({
 // Load widgets
 Bangle.loadWidgets();
 require("widget_utils").hide();
+}

--- a/apps/analogquadclk/app.js
+++ b/apps/analogquadclk/app.js
@@ -37,7 +37,7 @@ const hand_minute_bg = get_hand(MIN_LEN, MIN_W, 6, MIN_BACK);
 function queueDraw() {
   if (drawTimeout) clearTimeout(drawTimeout);
   drawTimeout = setTimeout(function() {
-    drawTimeout = undefined;
+    //drawTimeout = undefined;
     draw();
   }, 60000 - (Date.now() % 60000));
 }

--- a/apps/analogquadclk/metadata.json
+++ b/apps/analogquadclk/metadata.json
@@ -1,7 +1,7 @@
 { "id": "analogquadclk",
   "name": "Analog Quad Clock",
   "shortName":"Quad Clock",
-  "version":"0.01",
+  "version":"0.02",
   "description": "An analog clock with clockinfos in each of the 4 corners, allowing 4 different data types to be rendered at once",
   "icon": "icon.png",
   "screenshots" : [ { "url":"screenshot.png" }, { "url":"screenshot2.png" } ],


### PR DESCRIPTION
Fixed some hiccups. 

I ran some ram tests and the usage seemed to settle at 3784 when loaded and 2216 after a subsequent `Bangle.setUI()` call on a factory reset watch, fw 2v21.107.

There are still some things I didn't fix/change:
- When the hands are redrawn part of a clock info graphics can be cleared when it shouldn't 
- The tip of the minutes hand are overdrawn at times. Not sure if it's the hidden widget field, clock info or other that's the culprit.
- Just noticed the draw timeout can still survive the unloading also after my attempted (maybe very naive) fix a9c04d3bdcc5da0561be47ffc9dd1f99d359ebe9.