### PR TITLE
multitimer: handle undefined alarm.data

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -8,3 +8,5 @@
       menu display/fastload removes it
 0.08: Add setting for initial page to display
 0.09: Minor code improvements
+0.10: Handle missing alarm data, e.g. when our reset is fired from
+      non-multitimer alarms

--- a/apps/multitimer/boot.js
+++ b/apps/multitimer/boot.js
@@ -1,6 +1,6 @@
 {
   const resetTimer = alarm => {
-    if (alarm.timer) alarm.timer = alarm.data.ot;
+    if (alarm.timer && "ot" in alarm.data) alarm.timer = alarm.data.ot;
   };
 
   Bangle.on("alarmSnooze", resetTimer);

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.09",
+  "version": "0.10",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
A minor bugfix to prevent exceptions in the multitimer event handler