### PR TITLE
sched: fix snoozing an alarm after the snooze period

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -26,3 +26,4 @@
 0.23: Allow buzzing forever when an alarm fires
 0.24: Emit alarmReload when alarms change (used by widalarm)
 0.25: Fix wrap around when snoozed through midnight
+0.26: Fix hitting snooze on an alarm after when the snooze would've fired

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.25",
+  "version": "0.26",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",
   "type": "scheduler",

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -35,7 +35,9 @@ function showAlarm(alarm) {
       if (alarm.ot === undefined) {
         alarm.ot = alarm.t;
       }
-      alarm.t += settings.defaultSnoozeMillis;
+      let time = new Date();
+      let currentTime = (time.getHours()*3600000)+(time.getMinutes()*60000)+(time.getSeconds()*1000);
+      alarm.t = currentTime + settings.defaultSnoozeMillis;
       alarm.t %= 86400000;
       Bangle.emit("alarmSnooze", alarm);
     } else {


### PR DESCRIPTION
We now set the snooze period from when the user hits snooze, not when the alarm sounded.

For example:
- Snooze period is 10 mins
- Alarm sounds for 11 mins
- User hits snooze
- Alarm is scheduled/snoozed until 23 hours 59 minutes in the future