### PR TITLE
Add fullscreen mode and widgets to line_clock app

### DIFF
--- a/apps/line_clock/ChangeLog
+++ b/apps/line_clock/ChangeLog
@@ -1,1 +1,2 @@
 0.1: init app
+0.2: add ability to display widgets

--- a/apps/line_clock/app.js
+++ b/apps/line_clock/app.js
@@ -10,10 +10,12 @@ const numberOffset = 85;
 const numberSize = 22;
 
 const storage = require('Storage');
+const widget_utils = require("widget_utils");
 
 const SETTINGS_FILE = "line_clock.setting.json";
 
 let initialSettings = {
+  screen: "Full",
   showLock: true,
   showMinute: true,
 };
@@ -22,6 +24,11 @@ let saved_settings = storage.readJSON(SETTINGS_FILE, 1) || initialSettings;
 for (const key in saved_settings) {
   initialSettings[key] = saved_settings[key];
 }
+
+let isFullscreen = function() {
+  const s = initialSettings.screen.toLowerCase();
+  return s === "full";
+};
 
 let gWidth  = g.getWidth(),  gCenterX = gWidth/2;
 let gHeight = g.getHeight(), gCenterY = gHeight/2;
@@ -235,6 +242,14 @@ function lockListenerBw() {
 }
 Bangle.on('lock', lockListenerBw);
 
+function drawWidgets() {
+  if(isFullscreen()){
+    widget_utils.hide();
+  } else {
+    Bangle.drawWidgets();
+  }
+}
+
 Bangle.setUI({
   mode : "clock",
   // TODO implement https://www.espruino.com/Bangle.js+Fast+Load
@@ -267,7 +282,7 @@ function draw() {
   g.setColor(g.theme.bg);
   g.fillRect(0, 0, gWidth, gHeight);
 
-  if(initialSettings.showLock && Bangle.isLocked()){
+  if(initialSettings.showLock && Bangle.isLocked() && isFullscreen()){
     g.setColor(g.theme.fg);
     g.drawImage(imgLock(), gWidth-16, 2);
   }
@@ -282,6 +297,9 @@ function draw() {
   if(initialSettings.showMinute){
     drawNumber(currentMinute);
   }
+  drawWidgets()
 }
+
+Bangle.loadWidgets();
 
 draw();

--- a/apps/line_clock/metadata.json
+++ b/apps/line_clock/metadata.json
@@ -1,7 +1,7 @@
 { "id": "line_clock",
   "name": "Line Clock",
   "shortName":"Line Clock",
-  "version":"0.1",
+  "version":"0.2",
   "description": "a readable analog clock",
   "icon": "app-icon.png",
   "type": "clock",

--- a/apps/line_clock/settings.js
+++ b/apps/line_clock/settings.js
@@ -4,6 +4,7 @@
     // initialize with default settings...
     const storage = require('Storage')
     let settings = {
+      screen: "Full",
       showLock: true,
       showMinute: true,
     };
@@ -16,9 +17,20 @@
       storage.write(SETTINGS_FILE, settings)
     }
 
+  const screenOptions = ["Normal", "Full"];
+
     E.showMenu({
       '': { 'title': 'Line Clock' },
       '< Back': back,
+      'Screen': {
+        value: 0 | screenOptions.indexOf(settings.screen),
+        min: 0, max: 2,
+        format: v => screenOptions[v],
+        onchange: v => {
+          settings.screen = screenOptions[v];
+          save();
+        },
+      },
       'Show Lock': {
         value: settings.showLock,
         onchange: () => {


### PR DESCRIPTION
The line_clock app now has a fullscreen mode configurable through settings. The visible widgets are adjusted according to the screen mode set by the user. A new function 'drawWidgets' has been introduced to facilitate this feature.