### PR TITLE
exstats: fix steps being negative

### DIFF
--- a/apps/run/ChangeLog
+++ b/apps/run/ChangeLog
@@ -17,3 +17,4 @@
 0.16: Added ability to resume a run that was stopped previously (fix #1907)
 0.17: Ensure screen redraws after "Resume run?" menu (#3044)
 0.18: Minor code improvements
+0.19: Fix step count bug when runs are resumed after a long time

--- a/apps/run/metadata.json
+++ b/apps/run/metadata.json
@@ -1,6 +1,6 @@
 { "id": "run",
   "name": "Run",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Displays distance, time, steps, cadence, pace and more for runners.",
   "icon": "app.png",
   "tags": "run,running,fitness,outdoors,gps",

--- a/apps/runplus/ChangeLog
+++ b/apps/runplus/ChangeLog
@@ -25,3 +25,4 @@ Write to correct settings file, fixing settings not working.
 0.22: Ensure screen redraws after "Resume run?" menu (#3044)
 0.23: Minor code improvements
 0.24: Add indicators for lock,gps and pulse to karvonen screen
+0.25: Fix step count bug when runs are resumed after a long time

--- a/apps/runplus/metadata.json
+++ b/apps/runplus/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "runplus",
   "name": "Run+",
-  "version": "0.24",
+  "version": "0.25",
   "description": "Displays distance, time, steps, cadence, pace and more for runners. Based on the Run app, but extended with additional screen for heart rate interval training.",
   "icon": "app.png",
   "tags": "run,running,fitness,outdoors,gps,karvonen,karvonnen",

--- a/modules/exstats.js
+++ b/modules/exstats.js
@@ -102,6 +102,7 @@ var stats = {};
 const DATA_FILE = "exstats.json";
 // Load the state from a saved file if there was one
 state = Object.assign(state, require("Storage").readJSON(DATA_FILE,1)||{});
+state.startSteps = Bangle.getStepCount()  - (state.lastSteps - state.startSteps);
 // force step history to a uint8array
 state.stepHistory = new Uint8Array(state.stepHistory);
 // when we exit, write the current state


### PR DESCRIPTION
This is definitely not the correct fix - in my case:
```
>state.startSteps
=336651
>Bangle.getStepCount()
=47487
```

What I expect has happened is that `startSteps` is from a previous run and hasn't been reset overnight, whereas the step count has. I'm not familiar with exstats, @gfwilliams / @GrandVizierOlaf what do you think?