### PR TITLE
owmweather: upgrade to One Call API 3.0

### DIFF
--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Fix updating weather too often
 0.04: Minor code improvements
 0.05: Upgrade OWM to One Call API 3.0. Add pressure to weather.json
+0.06: Fix One Call API 3.0 does not return city name but it is required by weather app

--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -3,4 +3,4 @@
 0.03: Fix updating weather too often
 0.04: Minor code improvements
 0.05: Upgrade OWM to One Call API 3.0. Add pressure to weather.json
-0.06: Fix One Call API 3.0 does not return city name but it is required by weather app
+0.06: Fix One Call API 3.0 not returning city names, which are required by the weather app

--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Do first update request 5s after boot to boot up faster
 0.03: Fix updating weather too often
 0.04: Minor code improvements
+0.05: Upgrade OWM to One Call API 3.0. Add pressure to weather.json

--- a/apps/owmweather/lib.js
+++ b/apps/owmweather/lib.js
@@ -1,7 +1,10 @@
 function parseWeather(response) {
   let owmData = JSON.parse(response);
 
-  let isOwmData = (owmData.lat && owmData.lon) && owmData.current.weather && owmData.current;
+  let isOwmData = false;
+  try {
+    isOwmData = (owmData.lat && owmData.lon) && owmData.current.weather && owmData.current;
+  } catch (_e) {}
 
   if (isOwmData) {
     let json = require("Storage").readJSON('weather.json') || {};
@@ -12,9 +15,9 @@ function parseWeather(response) {
     weather.code = owmData.current.weather[0].id;
     weather.wdir = owmData.current.wind_deg;
     weather.wind = owmData.current.wind_speed;
-    weather.loc = owmData.name ? owmData.name : "";
+    weather.loc = owmData.name || "";
     weather.txt = owmData.current.weather[0].main;
-    weather.hpa = owmData.current.pressure ? owmData.current.pressure : 0;
+    weather.hpa = owmData.current.pressure || 0;
 
     if (weather.wdir != null) {
       let deg = weather.wdir;

--- a/apps/owmweather/lib.js
+++ b/apps/owmweather/lib.js
@@ -1,19 +1,20 @@
 function parseWeather(response) {
   let owmData = JSON.parse(response);
 
-  let isOwmData = owmData.coord && owmData.weather && owmData.main;
+  let isOwmData = (owmData.lat && owmData.lon) && owmData.current.weather && owmData.current;
 
   if (isOwmData) {
     let json = require("Storage").readJSON('weather.json') || {};
     let weather = {};
     weather.time = Date.now();
-    weather.hum = owmData.main.humidity;
-    weather.temp = owmData.main.temp;
-    weather.code = owmData.weather[0].id;
-    weather.wdir = owmData.wind.deg;
-    weather.wind = owmData.wind.speed;
-    weather.loc = owmData.name;
-    weather.txt = owmData.weather[0].main;
+    weather.hum = owmData.current.humidity;
+    weather.temp = owmData.current.temp;
+    weather.code = owmData.current.weather[0].id;
+    weather.wdir = owmData.current.wind_deg;
+    weather.wind = owmData.current.wind_speed;
+    // weather.loc = owmData.name;
+    weather.txt = owmData.current.weather[0].main;
+    weather.hpa = owmData.current.pressure ? owmData.current.pressure : 0;
 
     if (weather.wdir != null) {
       let deg = weather.wdir;
@@ -39,7 +40,7 @@ exports.pull = function(completionCallback) {
     "location": "London"
   };
   let settings = require("Storage").readJSON("owmweather.json", 1);
-  let uri = "https://api.openweathermap.org/data/2.5/weather?lat=" + location.lat.toFixed(2) + "&lon=" + location.lon.toFixed(2) + "&exclude=hourly,daily&appid=" + settings.apikey;
+  let uri = "https://api.openweathermap.org/data/3.0/onecall?lat=" + location.lat.toFixed(2) + "&lon=" + location.lon.toFixed(2) + "&exclude=minutely,hourly,daily,alerts&appid=" + settings.apikey;
   if (Bangle.http){
     Bangle.http(uri, {timeout:10000}).then(event => {
       let result = parseWeather(event.resp);

--- a/apps/owmweather/lib.js
+++ b/apps/owmweather/lib.js
@@ -12,7 +12,7 @@ function parseWeather(response) {
     weather.code = owmData.current.weather[0].id;
     weather.wdir = owmData.current.wind_deg;
     weather.wind = owmData.current.wind_speed;
-    // weather.loc = owmData.name;
+    weather.loc = owmData.name ? owmData.name : "";
     weather.txt = owmData.current.weather[0].main;
     weather.hpa = owmData.current.pressure ? owmData.current.pressure : 0;
 

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
[One Call API 2.5 will be deprecated in June 2024](https://openweathermap.org/api/one-call-api).
Upgrade to One Call API 3.0.
Add pressure to weather.json