### PR TITLE
messagesoverlay - Handle prependListener and setWatch callback variable name change

### DIFF
--- a/apps/messagesoverlay/ChangeLog
+++ b/apps/messagesoverlay/ChangeLog
@@ -12,3 +12,5 @@
       Track handler changes done by background code
 0.08: Fix linter warnings
 0.09: Fix scrolling to last line for long text
+0.10: Track Listeners added with prependListener
+      Handle changed internal callback variable name for watches introduced in 2v21.104

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -480,7 +480,7 @@ const backupPrependListener = function(event, handler){
 const origClearWatch = clearWatch;
 const backupClearWatch = function(w) {
   if (w)
-    backup.watches.filter((e)=>e.index != w);
+    backup.watches[w] = null;
   else
     backup.watches = [];
 };
@@ -489,9 +489,10 @@ const origSetWatch = setWatch;
 const backupSetWatch = function(){
   if (!backup.watches)
     backup.watches = [];
-  LOG("backup for watch", arguments);
-  let i = backup.watches.map((e)=>e.index).sort().pop() + 1;
-  backup.watches.push({index:i, args:arguments});
+  LOG("current watches", backup.watches);
+  let i = backup.watches.length + 1;
+  LOG("backup for watch", arguments, "at index", i);
+  backup.watches.push(arguments);
   return i;
 };
 
@@ -531,6 +532,7 @@ const restoreHandlers = function(){
 
     origClearWatch.call(global);
 
+    LOG("Restoring", backup.watches.length, "watches");
     for(let i = 0; i < backup.watches.length; i++){
       let w = backup.watches[i];
       LOG("Restoring watch", w);

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -579,11 +579,12 @@ const backupHandlers = function(){
     LOG("Transform watch", w);
     if (w) {
       w = [
-        w.callback,
+        w.callback ? w.callback : w.cb, // Handle change in name of callback variable to cb in 2v21.104
         w.pin,
         w
       ];
       delete w[2].callback;
+      delete w[2].cb;
       delete w[2].pin;
       w[2].debounce = Math.round(w[2].debounce / 1048.576);
     } else {

--- a/apps/messagesoverlay/lib.js
+++ b/apps/messagesoverlay/lib.js
@@ -467,6 +467,16 @@ const backupOn = function(event, handler){
   else origOn.call(Bangle, event, handler);
 };
 
+const origPrependListener = Bangle.prependListener;
+const backupPrependListener = function(event, handler){
+  if (EVENTS.includes(event)){
+    if (!backup[event])
+      backup[event] = [];
+    backup[event].unshift(handler);
+  }
+  else origPrependListener.call(Bangle, event, handler);
+};
+
 const origClearWatch = clearWatch;
 const backupClearWatch = function(w) {
   if (w)
@@ -541,6 +551,7 @@ const restoreHandlers = function(){
   global.setWatch = origSetWatch;
   global.clearWatch = origClearWatch;
   Bangle.on = origOn;
+  Bangle.prependListener = origPrependListener;
   Bangle.removeListener = origRemove;
   Bangle.removeAllListeners = origRemoveAll;
 
@@ -588,6 +599,7 @@ const backupHandlers = function(){
   global.setWatch = backupSetWatch;
   global.clearWatch = backupClearWatch;
   Bangle.on = backupOn;
+  Bangle.prependListener = backupPrependListener;
   Bangle.removeListener = backupRemove;
   Bangle.removeAllListeners = backupRemoveAll;
 

--- a/apps/messagesoverlay/metadata.json
+++ b/apps/messagesoverlay/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "messagesoverlay",
   "name": "Messages Overlay",
-  "version": "0.09",
+  "version": "0.10",
   "description": "An overlay based implementation of a messages UI (display notifications from iOS and Gadgetbridge/Android)",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
* Listeners added with `prependListener` were not tracked,
* 2v21.104 renamed the internal variable for callbacks stored with setWatch from `callback` to `cb`. This should handle both variants