### PR TITLE
widdevst: add ability to only redraw when a peripheral changes

### DIFF
--- a/apps/widdevst/ChangeLog
+++ b/apps/widdevst/ChangeLog
@@ -1,3 +1,4 @@
 0.01: First version
 0.02: Support for Bangle.js 2
 0.03: Update storage usage and perform GC every minute
+0.04: Add ability to only redraw when a peripheral state changes

--- a/apps/widdevst/README.md
+++ b/apps/widdevst/README.md
@@ -13,3 +13,7 @@ at fixed positions, and two bars
 - bottom to top: usage of RAM
 
 in green if below 50%, orange if between 50% and 80%, and red if above 80%.
+
+The widget will redraw more frequently when unlocked.
+
+It can be configured to avoid redrawing if all monitored peripherals are off, waiting until it hears from them (meaning you won't see regular RAM/Storage updates, but save battery by avoiding drawing). This can be configured by writing `{"redrawBars":0}` to `widdevst.settings.json`.

--- a/apps/widdevst/metadata.json
+++ b/apps/widdevst/metadata.json
@@ -9,5 +9,8 @@
   "readme": "README.md",
   "storage": [
     {"name": "widdevst.wid.js", "url": "wid.js"}
+  ],
+  "data":[
+    {"name": "widdevst.settings.json"}
   ]
 }

--- a/apps/widdevst/metadata.json
+++ b/apps/widdevst/metadata.json
@@ -1,6 +1,6 @@
 { "id": "widdevst",
   "name": "Device Status Widget",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Shows power status of Bluetooth, Compass, GPS and Heart Rate Monitor as well as storage and memory usage.",
   "icon": "icon.png",
   "type": "widget",

--- a/apps/widdevst/wid.js
+++ b/apps/widdevst/wid.js
@@ -3,7 +3,7 @@
 
   WIDGETS.devst = {area: "tr", width: 22, draw: function() {
     if (WIDGETS.devst._draw) return;
-    var d = new Date();
+    var d = Date.now();
     var t;
     if ((d - stat.date) < 6e4) {
       t = process.memory(false);

--- a/apps/widdevst/wid.js
+++ b/apps/widdevst/wid.js
@@ -1,9 +1,10 @@
 (() => {
   var stat = {date: 0};
+  var d = Date.now();
 
   WIDGETS.devst = {area: "tr", width: 22, draw: function() {
+    d = Date.now();
     if (WIDGETS.devst._draw) return;
-    var d = Date.now();
     var t;
     if ((d - stat.date) < 6e4) {
       t = process.memory(false);
@@ -20,12 +21,15 @@
     g.clearRect(x, y, x + 21, y + 23);
     g.drawRect(x + 2, y + 1, x + 20, y + 21);
     g.setFont('6x8', 1);
-    if (NRF.getSecurityStatus().connected) g.drawString('B', x + 5, y + 3);
-    if (Bangle.isCompassOn()) g.drawString('C', x + 13, y + 3);
-    if (Bangle.isGPSOn()) g.drawString('G', x + 5, y + 12);
-    if (Bangle.isHRMOn()) g.drawString('H', x + 13, y + 12);
+    var again = false;
+    if (NRF.getSecurityStatus().connected) g.drawString('B', x + 5, y + 3), again = true;
+    if (Bangle.isCompassOn()) g.drawString('C', x + 13, y + 3), again = true;
+    if (Bangle.isGPSOn()) g.drawString('G', x + 5, y + 12), again = true;
+    if (Bangle.isHRMOn()) g.drawString('H', x + 13, y + 12), again = true;
     g.setColor(col(stat.sto)); g.drawRect(x + 2, y + 21, x + 2 + stat.sto * 18, y + 22);
     g.setColor(col(t)); g.drawRect(x + 1, y + 21 - t * 20, x + 2, y + 21);
+    // if there's nothing active, don't queue a redraw (rely on Bangle.on(...) below)
+    if (again) setTimeout(draw, drawTime());
   }};
 
   function col(p) {
@@ -33,18 +37,13 @@
   }
 
   var draw = WIDGETS.devst.draw.bind(WIDGETS.devst);
-  var iid = setInterval(draw, Bangle.isLocked() ? 6e4 : 2e3);
 
-  Bangle.on('lcdPower', (on) => {
-    if (on) {
-      draw();
-      if (!iid) iid = setInterval(draw, Bangle.isLocked() ? 6e4 : 2e3);
-    } else if (iid) iid = clearInterval(iid);
-  });
-  Bangle.on('lock', (on) => {
-    if (iid) {
-      clearInterval(iid);
-      iid = setInterval(draw, on ? 6e4 : 2e3);
-    }
-  });
+  var drawTime = () => Bangle.isLocked() ? 6e4 : 2e3;
+  var throttledDraw = () => Date.now() - d > drawTime() && draw();
+
+  Bangle.on("HRM", throttledDraw);
+  Bangle.on("GPS", throttledDraw);
+  Bangle.on("mag", throttledDraw);
+  NRF.on("connect", throttledDraw);
+  draw();
 })();

--- a/apps/widdevst/wid.js
+++ b/apps/widdevst/wid.js
@@ -1,6 +1,9 @@
 (() => {
   var stat = {date: 0};
   var d = Date.now();
+  var settings = require("Storage").readJSON("widdevst.settings.json", 1)||{};
+  var redrawBars = "redrawBars" in settings ? settings.redrawBars : false;
+  delete settings;
 
   WIDGETS.devst = {area: "tr", width: 22, draw: function() {
     d = Date.now();
@@ -29,7 +32,7 @@
     g.setColor(col(stat.sto)); g.drawRect(x + 2, y + 21, x + 2 + stat.sto * 18, y + 22);
     g.setColor(col(t)); g.drawRect(x + 1, y + 21 - t * 20, x + 2, y + 21);
     // if there's nothing active, don't queue a redraw (rely on Bangle.on(...) below)
-    if (again) setTimeout(draw, drawTime());
+    if (redrawBars || again) setTimeout(draw, drawTime());
   }};
 
   function col(p) {


### PR DESCRIPTION
This change tweaks the drawing of `widdevst` to be fired by a change of a peripheral (such as a HRM event), so that:
- if peripherals are on, it'll redraw as regularly as it did before this change
- if periperhals are off, it'll redraw at the same (lower) frequency, or possibly not at all if the next option is enabled (saving draw time & battery)

The setting change allows us to configure the widget to only draw when a peripheral changes, at the cost of not having directly up-to-date bars for storage & memory.

@notEvil what do you think? I'm going to try this out for a little while and see how it compares time-wise to the current implementation