### PR TITLE
multitimer: preserve original `uiRemove`

### DIFF
--- a/apps/multitimer/ChangeLog
+++ b/apps/multitimer/ChangeLog
@@ -10,3 +10,4 @@
 0.09: Minor code improvements
 0.10: Handle missing alarm data, e.g. when our reset is fired from
       non-multitimer alarms
+0.11: Preserve setUI removal callbacks, e.g. those of showMenu

--- a/apps/multitimer/app.js
+++ b/apps/multitimer/app.js
@@ -691,10 +691,12 @@ function setUI() {
   // E.showMenu/E.showScroller/E.showAlert call setUI, so we register onDrag() separately
   // and tack on uiRemove after the fact to avoid interfering
   Bangle.on("drag", onDrag);
+  const origRemove = Bangle.uiRemove;
   Bangle.uiRemove = () => {
     Bangle.removeListener("drag", onDrag);
     Object.values(timerInt1).forEach(clearTimeout);
     Object.values(timerInt2).forEach(clearTimeout);
+    if (origRemove) origRemove();
   };
 }
 

--- a/apps/multitimer/metadata.json
+++ b/apps/multitimer/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "multitimer",
   "name": "Multi Timer",
-  "version": "0.10",
+  "version": "0.11",
   "description": "Set timers and chronographs (stopwatches) and watch them count down in real time. Pause, create, edit, and delete timers and chronos, and add custom labels/messages. Also sets alarms.",
   "icon": "app.png",
   "screenshots": [


### PR DESCRIPTION
e.g. a `showMenu()`'s `setUI` call.

Without this, a `showMenu`'s call doesn't get its `remove` callback called.