### PR TITLE
openhaystack: work with other advertisements

### DIFF
--- a/apps/openhaystack/ChangeLog
+++ b/apps/openhaystack/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Keep advertising when connected
+0.03: Work with other advertisements

--- a/apps/openhaystack/custom.html
+++ b/apps/openhaystack/custom.html
@@ -40,7 +40,14 @@ const key = E.toUint8Array(atob(${JSON.stringify(keyValue)})); // public key
 const mac = [ key[0] | 0b11000000, key[1], key[2], key[3], key[4], key[5] ].map(x => x.toString(16).padStart(2, '0')).join(':'); // mac address
 const adv = [ 0x1e, 0xff, 0x4c, 0x00, 0x12, 0x19, 0x00, key[6], key[7], key[8], key[9], key[10], key[11], key[12], key[13], key[14], key[15], key[16], key[17], key[18], key[19], key[20], key[21], key[22], key[23], key[24], key[25], key[26], key[27], key[0] >> 6, 0x00 ]; // advertising packet
 NRF.setAddress(mac);
-NRF.setAdvertising([adv,{}],{whenConnected: true, interval: 1000}); // advertise AirTag *and* normal device name (to remain connectable)
+if(Array.isArray(Bangle.bleAdvert)){
+    Bangle.bleAdvert.push(adv);
+}else if(Bangle.bleAdvert){
+    Bangle.bleAdvert = [Bangle.bleAdvert, adv];
+}else{
+    Bangle.bleAdvert = [adv, {}];
+}
+NRF.setAdvertising(Bangle.bleAdvert,{whenConnected: true, interval: 1000}); // advertise AirTag *and* normal device name (to remain connectable)
 }
 `;
         // send finished app

--- a/apps/openhaystack/metadata.json
+++ b/apps/openhaystack/metadata.json
@@ -1,7 +1,7 @@
 { "id": "openhaystack",
   "name": "OpenHaystack (AirTag)",
   "icon": "icon.png",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Copy a base64 key from https://github.com/seemoo-lab/openhaystack and make your Bangle.js trackable as if it's an AirTag",
   "tags": "openhaystack,bluetooth,ble,tracking,airtag",
   "type": "bootloader",


### PR DESCRIPTION
This means if boot code runs before openhaystack's (which uses [`ble_advert`](https://github.com/espruino/BangleApps/blob/master/modules/ble_advert.ts) or stores its advertising data on `Bangle.bleAdvert`), the openhaystack code will add its own advert to the array, rather than overwrite.

@olivierbarriere is this ok by you? I'm currently testing it / waiting for reports to come through