### PR TITLE
Allow using either the free OWM API 2.5 or the paid OWM API 3.0

### DIFF
--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Minor code improvements
 0.05: Upgrade OWM to One Call API 3.0. Add pressure to weather.json
 0.06: Fix One Call API 3.0 not returning city names, which are required by the weather app
+0.07: Also allow to use API 2.5 which does not require a paid plan

--- a/apps/owmweather/README.md
+++ b/apps/owmweather/README.md
@@ -8,6 +8,10 @@ Just install and configure the app. This needs an internet-enabled Gadgetbridge 
 Install [My Location](https://banglejs.com/apps/#mylocation) to change the location for the weather requests.
 Install one of the text input libraries to set the API key in the app settings or use the web interface.
 
+You can either use the free API (2.5) or you can use the paid subscription API 3.0.
+The paid API also includes pressure data. You can use the API 3.0 by enabling it in
+the settings.
+
 ## Creator
 
 [halemmerich](https://github.com/halemmerich)

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",

--- a/apps/owmweather/settings.js
+++ b/apps/owmweather/settings.js
@@ -56,7 +56,13 @@
             }
           });
         }
-      }
+      },
+      "OneCall API3.0": {
+        value: !!settings.useOneCall,
+        onchange: v => {
+          writeSettings("useOneCall", v);
+        }
+      },
     };
 
     mainmenu["API key"] = function (){


### PR DESCRIPTION
The previous updates of owmweather broke the app for me, as the open weather map API 3.0 requires a new API key that can only be acquired using a paid subscription plan.

In this patch I make this change optional and allow to either use the free API v2.5 or to use the paid v3.0 API.