### PR TITLE
runplus: add option to always resume

### DIFF
--- a/apps/runplus/ChangeLog
+++ b/apps/runplus/ChangeLog
@@ -27,3 +27,4 @@ Write to correct settings file, fixing settings not working.
 0.24: Add indicators for lock,gps and pulse to karvonen screen
 0.25: Fix step count bug when runs are resumed after a long time
 0.26: Add ability to zoom in on a single stat by tapping it
+0.27: Allow configuration of time after which the user is prompted to resume

--- a/apps/runplus/ChangeLog
+++ b/apps/runplus/ChangeLog
@@ -27,4 +27,4 @@ Write to correct settings file, fixing settings not working.
 0.24: Add indicators for lock,gps and pulse to karvonen screen
 0.25: Fix step count bug when runs are resumed after a long time
 0.26: Add ability to zoom in on a single stat by tapping it
-0.27: Allow configuration of time after which the user is prompted to resume
+0.27: Allow setting to alway resume an activity

--- a/apps/runplus/app.js
+++ b/apps/runplus/app.js
@@ -26,6 +26,10 @@ let settings = Object.assign({
   B5: "step",
   B6: "caden",
   paceLength: 1000,
+  resume: {
+    promptAfter: 10000,
+    default: false,
+  },
   notify: {
     dist: {
       value: 0,
@@ -64,10 +68,10 @@ function onStartStop() {
   }
 
   var running = !exs.state.active;
-  var shouldResume = false;
+  var shouldResume = settings.resume.default;
   var promise = Promise.resolve();
 
-  if (running && exs.state.duration > 10000) { // if more than 10 seconds of duration, ask if we should resume?
+  if (running && exs.state.duration > settings.resume.promptAfter) { // if more than N seconds of duration, ask if we should resume?
     promise = promise.
       then(() => {
         screen = "menu";

--- a/apps/runplus/metadata.json
+++ b/apps/runplus/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "runplus",
   "name": "Run+",
-  "version": "0.26",
+  "version": "0.27",
   "description": "Displays distance, time, steps, cadence, pace and more for runners. Based on the Run app, but extended with additional screens for heart rate interval training and individual stat focus.",
   "icon": "app.png",
   "tags": "run,running,fitness,outdoors,gps,karvonen,karvonnen",

--- a/apps/runplus/settings.js
+++ b/apps/runplus/settings.js
@@ -17,6 +17,10 @@
     B5: "step",
     B6: "caden",
     paceLength: 1000, // TODO: Default to either 1km or 1mi based on locale
+    resume: {
+      promptAfter: 10000,
+      default: false,
+    },
     notify: {
       dist: {
         increment: 0,
@@ -76,6 +80,23 @@
     '< Back': function() { E.showMenu(menu) },
   }
   menu[/*LANG*/"Notifications"] = function() { E.showMenu(notificationsMenu)};
+  var resumeMenu = {
+    "Prompt after": {
+      value : settings.resume.promptAfter / 1000,
+      onchange : v => {
+        settings.resume.promptAfter = v * 1000;
+        saveSettings();
+      }
+    },
+    "Resume by default": {
+      value : settings.resume.default,
+      onchange : v => {
+        settings.resume.default = v;
+        saveSettings();
+      },
+    },
+  };
+  menu[/*LANG*/"Resume"] = function() { E.showMenu(resumeMenu) };
   ExStats.appendMenuItems(menu, settings, saveSettings);
   ExStats.appendNotifyMenuItems(notificationsMenu, settings, saveSettings);
   var vibPatterns = [/*LANG*/"Off", ".", "-", "--", "-.-", "---"];

--- a/apps/runplus/settings.js
+++ b/apps/runplus/settings.js
@@ -17,10 +17,7 @@
     B5: "step",
     B6: "caden",
     paceLength: 1000, // TODO: Default to either 1km or 1mi based on locale
-    resume: {
-      promptAfter: 10000,
-      default: false,
-    },
+    alwaysResume: false,
     notify: {
       dist: {
         increment: 0,
@@ -76,27 +73,17 @@
         saveSettings();
       }
     };
+  menu[/*LANG*/"Always resume run"] = {
+    value : settings.alwaysResume,
+    onchange : v => {
+      settings.alwaysResume = v;
+      saveSettings();
+    },
+  };
   var notificationsMenu = {
     '< Back': function() { E.showMenu(menu) },
   }
   menu[/*LANG*/"Notifications"] = function() { E.showMenu(notificationsMenu)};
-  var resumeMenu = {
-    "Prompt after": {
-      value : settings.resume.promptAfter / 1000,
-      onchange : v => {
-        settings.resume.promptAfter = v * 1000;
-        saveSettings();
-      }
-    },
-    "Resume by default": {
-      value : settings.resume.default,
-      onchange : v => {
-        settings.resume.default = v;
-        saveSettings();
-      },
-    },
-  };
-  menu[/*LANG*/"Resume"] = function() { E.showMenu(resumeMenu) };
   ExStats.appendMenuItems(menu, settings, saveSettings);
   ExStats.appendNotifyMenuItems(notificationsMenu, settings, saveSettings);
   var vibPatterns = [/*LANG*/"Off", ".", "-", "--", "-.-", "---"];


### PR DESCRIPTION
For example, when doing reps with 1 minute rests, a user can configure runplus so it automatically resumes if started within the minute