### PR TITLE
clkinfocal: remove duplicate day in calendar when format setting is 'dd MMM'

### DIFF
--- a/apps/clkinfocal/ChangeLog
+++ b/apps/clkinfocal/ChangeLog
@@ -2,3 +2,4 @@
 0.02: added settings options to change date format
 0.03: Remove un-needed font requirement, now outputs transparent image
 0.04: Fix image after 0.03 regression
+0.05: Remove duplicated day in calendar when format setting is 'dd MMM'

--- a/apps/clkinfocal/clkinfo.js
+++ b/apps/clkinfocal/clkinfo.js
@@ -5,7 +5,7 @@
   var getDateString = function(dt) {
     switch(settings.fmt) {
     case "dd MMM":
-      return '' + dt.getDate() + ' ' + require("locale").month(dt,1).toUpperCase();
+      return require("locale").month(dt,1).toUpperCase();
     case "DDD dd":
       return require("locale").dow(dt,1).toUpperCase() + ' ' + dt.getDate();
     default: // DDD

--- a/apps/clkinfocal/metadata.json
+++ b/apps/clkinfocal/metadata.json
@@ -1,6 +1,6 @@
 { "id": "clkinfocal",
   "name": "Calendar Clockinfo",
-  "version":"0.04",
+  "version":"0.05",
   "description": "For clocks that display 'clockinfo' (messages that can be cycled through using the clock_info module) this displays the day of the month in the icon, and the weekday. There is also a settings menu to select the format of the text",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
Remove duplicated day in calendar when format setting is 'dd MMM'

![download](https://github.com/espruino/BangleApps/assets/51221635/9e29675f-71d2-4545-9457-a193bf8b717d)

You can test the branch here https://vczb.github.io/BangleApps/?c=clkinfo&q=clkinfocal

Close #3429