### PR TITLE
Add `ble_advert` module

### DIFF
--- a/apps/bootgattbat/ChangeLog
+++ b/apps/bootgattbat/ChangeLog
@@ -1,2 +1,3 @@
 0.01: Initial release.
 0.02: Handle the case where other apps have set bleAdvert to an array
+0.03: Use the bleAdvert module

--- a/apps/bootgattbat/boot.js
+++ b/apps/bootgattbat/boot.js
@@ -1,26 +1,8 @@
 (() => {
   function advertiseBattery() {
-    if(Array.isArray(Bangle.bleAdvert)){
-      // ensure we're in the cycle
-      var found = false;
-      for(var ad in Bangle.bleAdvert){
-        if(ad[0x180F]){
-          ad[0x180F] = [E.getBattery()];
-          found = true;
-          break;
-        }
-      }
-      if(!found)
-        Bangle.bleAdvert.push({ 0x180F: [E.getBattery()] });
-    }else{
-      // simple object
-      Bangle.bleAdvert[0x180F] = [E.getBattery()];
-    }
-
-    NRF.setAdvertising(Bangle.bleAdvert);
+    require("ble_advert").set(0x180F, [E.getBattery()]);
   }
 
-  if (!Bangle.bleAdvert) Bangle.bleAdvert = {};
   setInterval(advertiseBattery, 60 * 1000);
   advertiseBattery();
 })();

--- a/apps/bootgattbat/metadata.json
+++ b/apps/bootgattbat/metadata.json
@@ -2,7 +2,7 @@
   "id": "bootgattbat",
   "name": "BLE GATT Battery Service",
   "shortName": "BLE Battery Service",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Adds the GATT Battery Service to advertise the percentage of battery currently remaining over Bluetooth.\n",
   "icon": "bluetooth.png",
   "type": "bootloader",

--- a/apps/bootgatthrm/ChangeLog
+++ b/apps/bootgatthrm/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial release.
 0.02: Added compatibility to OpenTracks and added HRM Location
 0.03: Allow setting to keep BLE connected
+0.04: Use the bleAdvert module

--- a/apps/bootgatthrm/boot.js
+++ b/apps/bootgatthrm/boot.js
@@ -4,18 +4,13 @@
      * This function prepares BLE heart rate Advertisement.
      */
 
-    NRF.setAdvertising(
-      {
-        0x180d: undefined
-      },
-      {
-        // We need custom Advertisement settings for Apps like OpenTracks
-        connectable: true,
-        discoverable: true,
-        scannable: true,
-        whenConnected: true,
-      }
-    );
+    require("ble_advert").set(0x180d, undefined, {
+      // We need custom Advertisement settings for Apps like OpenTracks
+      connectable: true,
+      discoverable: true,
+      scannable: true,
+      whenConnected: true,
+    });
 
     NRF.setServices({
       0x180D: { // heart_rate
@@ -28,7 +23,6 @@
         }
       }
     });
-
   }
 
   const keepConnected = (require("Storage").readJSON("gatthrm.settings.json", 1) || {}).keepConnected;

--- a/apps/bootgatthrm/metadata.json
+++ b/apps/bootgatthrm/metadata.json
@@ -2,7 +2,7 @@
   "id": "bootgatthrm",
   "name": "BLE GATT HRM Service",
   "shortName": "BLE HRM Service",
-  "version": "0.03",
+  "version": "0.04",
   "description": "Adds the GATT HRM Service to advertise the measured HRM over Bluetooth.\n",
   "icon": "bluetooth.png",
   "type": "bootloader",

--- a/apps/btadv/ChangeLog
+++ b/apps/btadv/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app!
 0.02: Advertise accelerometer data and sensor location
+0.03: Use the bleAdvert module

--- a/apps/btadv/app.ts
+++ b/apps/btadv/app.ts
@@ -667,6 +667,8 @@ const getBleAdvert = <T>(map: (s: BleServ) => T, all = false) => {
 
 // done via advertise in setServices()
 //const updateBleAdvert = () => {
+//  require("ble_advert").set(...)
+//
 //  let bleAdvert: ReturnType<typeof getBleAdvert<undefined>>;
 //
 //  if (!(bleAdvert = (Bangle as any).bleAdvert)) {

--- a/apps/btadv/metadata.json
+++ b/apps/btadv/metadata.json
@@ -2,7 +2,7 @@
   "id": "btadv",
   "name": "btadv",
   "shortName": "btadv",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Advertise & export live heart rate, accel, pressure, GPS & mag data over bluetooth",
   "icon": "icon.png",
   "tags": "health,tool,sensors,bluetooth",

--- a/apps/bthome/ChangeLog
+++ b/apps/bthome/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Cope with identical duplicate buttons (fix #3260)
       Set 'n' for buttons in Bangle.btHomeData correctly (avoids adding extra buttons on end of advertising)
 0.04: Fix duplicate button on edit->save
+0.05: Use the bleAdvert module

--- a/apps/bthome/boot.js
+++ b/apps/bthome/boot.js
@@ -1,5 +1,3 @@
-// Ensure we have the bleAdvert global (to play well with other stuff)
-if (!Bangle.bleAdvert) Bangle.bleAdvert = {};
 Bangle.btHomeData = [];
 {
   require("BTHome").packetId = 0|(Math.random()*256); // random packet id so new packets show up
@@ -39,20 +37,6 @@ Bangle.btHome = function(extras, options) {
   if (bat) bat.v = E.getBattery();
   var advert = require("BTHome").getAdvertisement(Bangle.btHomeData)[0xFCD2];
   // Add to the list of available advertising
-  if(Array.isArray(Bangle.bleAdvert)){
-    var found = false;
-    for(var ad in Bangle.bleAdvert){
-      if(ad[0xFCD2]){
-        ad[0xFCD2] = advert;
-        found = true;
-        break;
-      }
-    }
-    if(!found)
-      Bangle.bleAdvert.push({ 0xFCD2: advert });
-  } else {
-    Bangle.bleAdvert[0xFCD2] = advert;
-  }
   var advOptions = {};
   var updateTimeout = 10*60*1000; // update every 10 minutes
   if (options.event) { // if it's an event...
@@ -60,7 +44,7 @@ Bangle.btHome = function(extras, options) {
     advOptions.whenConnected = true;
     updateTimeout = 30000; // slow down in 30 seconds
   }
-  NRF.setAdvertising(Bangle.bleAdvert, advOptions);
+  require("ble_advert").set(0xFCD2, advert, advOptions);
   if (Bangle.btHomeTimeout) clearTimeout(Bangle.btHomeTimeout);
   Bangle.btHomeTimeout = setTimeout(function() {
     delete Bangle.btHomeTimeout;

--- a/apps/bthome/metadata.json
+++ b/apps/bthome/metadata.json
@@ -1,7 +1,7 @@
 { "id": "bthome",
   "name": "BTHome",
   "shortName":"BTHome",
-  "version":"0.04",
+  "version":"0.05",
   "description": "Allow your Bangle to advertise with BTHome and send events to Home Assistant via Bluetooth",
   "icon": "icon.png",
   "type": "app",

--- a/apps/openhaystack/ChangeLog
+++ b/apps/openhaystack/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Keep advertising when connected
+0.03: Use ble_advert module to work with other BLE advert apps

--- a/apps/openhaystack/custom.html
+++ b/apps/openhaystack/custom.html
@@ -40,7 +40,7 @@ const key = E.toUint8Array(atob(${JSON.stringify(keyValue)})); // public key
 const mac = [ key[0] | 0b11000000, key[1], key[2], key[3], key[4], key[5] ].map(x => x.toString(16).padStart(2, '0')).join(':'); // mac address
 const adv = [ 0x1e, 0xff, 0x4c, 0x00, 0x12, 0x19, 0x00, key[6], key[7], key[8], key[9], key[10], key[11], key[12], key[13], key[14], key[15], key[16], key[17], key[18], key[19], key[20], key[21], key[22], key[23], key[24], key[25], key[26], key[27], key[0] >> 6, 0x00 ]; // advertising packet
 NRF.setAddress(mac);
-NRF.setAdvertising([adv,{}],{whenConnected: true, interval: 1000}); // advertise AirTag *and* normal device name (to remain connectable)
+require("ble_advert").push(adv, {whenConnected: true, interval: 1000}); // advertise AirTag *and* normal device name (to remain connectable)
 }
 `;
         // send finished app

--- a/apps/openhaystack/metadata.json
+++ b/apps/openhaystack/metadata.json
@@ -1,7 +1,7 @@
 { "id": "openhaystack",
   "name": "OpenHaystack (AirTag)",
   "icon": "icon.png",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Copy a base64 key from https://github.com/seemoo-lab/openhaystack and make your Bangle.js trackable as if it's an AirTag",
   "tags": "openhaystack,bluetooth,ble,tracking,airtag",
   "type": "bootloader",

--- a/modules/ble_advert.js
+++ b/modules/ble_advert.js
@@ -1,0 +1,69 @@
+var advertise = function (options) {
+    var clone = function (obj) {
+        if (Array.isArray(obj)) {
+            return obj.map(clone);
+        }
+        else if (typeof obj === "object") {
+            var r = {};
+            for (var k in obj) {
+                r[k] = clone(obj[k]);
+            }
+            return r;
+        }
+        return obj;
+    };
+    NRF.setAdvertising(clone(Bangle.bleAdvert), options);
+};
+var manyAdv = function (bleAdvert) {
+    return Array.isArray(bleAdvert) && typeof bleAdvert[0] === "object";
+};
+exports.set = function (id, advert, options) {
+    var _a, _b, _c;
+    var bangle = Bangle;
+    if (manyAdv(bangle.bleAdvert)) {
+        var found = false;
+        var obj = void 0;
+        for (var _i = 0, _d = bangle.bleAdvert; _i < _d.length; _i++) {
+            var ad = _d[_i];
+            if (Array.isArray(ad))
+                continue;
+            obj = ad;
+            if (ad[id]) {
+                ad[id] = advert;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            if (obj)
+                obj[id] = advert;
+            else
+                bangle.bleAdvert.push((_a = {}, _a[id] = advert, _a));
+        }
+    }
+    else if (bangle.bleAdvert) {
+        if (Array.isArray(bangle.bleAdvert)) {
+            bangle.bleAdvert = [bangle.bleAdvert, (_b = {}, _b[id] = advert, _b)];
+        }
+        else {
+            bangle.bleAdvert[id] = advert;
+        }
+    }
+    else {
+        bangle.bleAdvert = (_c = {}, _c[id] = advert, _c);
+    }
+    advertise(options);
+};
+exports.push = function (adv, options) {
+    var bangle = Bangle;
+    if (manyAdv(bangle.bleAdvert)) {
+        bangle.bleAdvert.push(adv);
+    }
+    else if (bangle.bleAdvert) {
+        bangle.bleAdvert = [bangle.bleAdvert, adv];
+    }
+    else {
+        bangle.bleAdvert = [adv, {}];
+    }
+    advertise(options);
+};

--- a/modules/ble_advert.ts
+++ b/modules/ble_advert.ts
@@ -1,0 +1,56 @@
+declare let exports: any;
+
+type BleAdvert = { [key: string | number]: number[] };
+type BangleWithAdvert = (typeof Bangle) & { bleAdvert?: BleAdvert | BleAdvert[]; };
+type SetAdvertisingOptions = typeof NRF.setAdvertising extends (data: any, options: infer Opts) => any ? Opts : never;
+
+exports.set = (id: string | number, advert: number[], options?: SetAdvertisingOptions) => {
+	const bangle = Bangle as BangleWithAdvert;
+
+	if(Array.isArray(bangle.bleAdvert)){
+		let found = false;
+		for(let ad of bangle.bleAdvert){
+			if(ad[id]){
+				ad[id] = advert;
+				found = true;
+				break;
+			}
+		}
+		if(!found)
+			bangle.bleAdvert.push({ [id]: advert });
+	}else if(bangle.bleAdvert){
+		bangle.bleAdvert[id] = advert;
+	}else{
+		bangle.bleAdvert = {
+			[id]: advert,
+		};
+	}
+
+	NRF.setAdvertising(bangle.bleAdvert, options);
+};
+
+exports.remove = (id: string | number, options?: SetAdvertisingOptions) => {
+	const bangle = Bangle as BangleWithAdvert;
+
+	if(Array.isArray(bangle.bleAdvert)){
+		let i = 0;
+		for(const ad of bangle.bleAdvert){
+			if(ad[id]){
+				delete ad[id];
+				let empty = true;
+				// eslint-disable-next-line no-unused-vars
+				for(const _ in ad){
+					empty = false;
+					break;
+				}
+				if(empty) bangle.bleAdvert.splice(i, 1);
+				break;
+			}
+			i++;
+		}
+	}else if(bangle.bleAdvert){
+		delete bangle.bleAdvert[id];
+	}
+
+	NRF.setAdvertising(bangle.bleAdvert, options);
+};

--- a/modules/ble_advert.ts
+++ b/modules/ble_advert.ts
@@ -102,6 +102,7 @@ exports.push = (adv: number[], options?: SetAdvertisingOptions) => {
 	advertise(options);
 };
 
+/*
 exports.remove = (id: string | number, options?: SetAdvertisingOptions) => {
 	const bangle = Bangle as BangleWithAdvert;
 
@@ -132,3 +133,4 @@ exports.remove = (id: string | number, options?: SetAdvertisingOptions) => {
 
 	advertise(options);
 };
+*/

--- a/modules/ble_advert.ts
+++ b/modules/ble_advert.ts
@@ -1,4 +1,5 @@
 declare let exports: any;
+declare let BLE_DEBUG: undefined | true;
 
 type BleAdvert = { [key: string | number]: number[] };
 type BangleWithAdvert = (typeof Bangle) & { bleAdvert?: BleAdvert | BleAdvert[]; };
@@ -27,18 +28,30 @@ exports.set = (id: string | number, advert: number[], options?: SetAdvertisingOp
 			if(ad[id]){
 				ad[id] = advert;
 				found = true;
+                if(typeof BLE_DEBUG !== "undefined")
+                    console.log(`bleAdvert is array, found existing entry for ${id}, replaced`)
 				break;
 			}
 		}
-		if(!found)
+		if(!found){
 			bangle.bleAdvert.push({ [id]: advert });
+            if(typeof BLE_DEBUG !== "undefined")
+                console.log(`bleAdvert is array, no entry for ${id}, created`)
+		}
 	}else if(bangle.bleAdvert){
+        if(typeof BLE_DEBUG !== "undefined")
+            console.log(`bleAdvert is object, ${id} entry ${id in bangle.bleAdvert ? "replaced" : "created"}`);
 		bangle.bleAdvert[id] = advert;
 	}else{
+        if(typeof BLE_DEBUG !== "undefined")
+            console.log(`bleAdvert not present, created`);
 		bangle.bleAdvert = {
 			[id]: advert,
 		};
 	}
+
+    if(typeof BLE_DEBUG !== "undefined")
+        console.log(`NRF.setAdvertising({ ${Object.keys(bangle.bleAdvert).join(", ")} }, ${JSON.stringify(options)})`);
 
 	NRF.setAdvertising(clone(bangle.bleAdvert), options);
 	// clone the object, to avoid firmware behaving like so:
@@ -58,6 +71,9 @@ exports.set = (id: string | number, advert: number[], options?: SetAdvertisingOp
 
 exports.remove = (id: string | number, options?: SetAdvertisingOptions) => {
 	const bangle = Bangle as BangleWithAdvert;
+
+    if(typeof BLE_DEBUG !== "undefined")
+        console.log(`ble_advert.remove(${id}, ${JSON.stringify(options)})`);
 
 	if(Array.isArray(bangle.bleAdvert)){
 		let i = 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,7 +61,7 @@
     "*/*/*.ts",
     "apps/*/*.js", // with checkJs: true
     "*/*/*.d.ts",
-    "modules/*.d.ts",
+    "modules/*.ts",
     "typescript/types/*.d.ts"
   ]
 }


### PR DESCRIPTION
This adds a module to coordinate BLE advertising, for apps such as openhaystack, gattbat and gatthrm.


### Problem

Currently the code doesn't work because `NRF.setAdvertising` modifies the passed in object, so we lose track of which entry is for which BLE Service ID

<details>
<summary> Example of NRF type conversion </summary>

```
>ba=require("ble_advert") // old version
=...

>ba.set(0xffff, y={})
Uncaught TypeError: If specifying an object, it must be of the form {data : ..., count : N} or {callback : fn} - got {  }
 at line 24 col 280 in .boot0
...etAdvertising(a.bleAdvert,j)
in function "set" called from line 1 col 20
ba.set(0xffff, y={})

>Bangle.bleAdvert
=[
  new Uint8Array([2, 1, 6, 3, 3,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([30, 255, 76, 0, 18,  ... 80, 230, 104, 3, 0]).buffer,
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer, // { 0xffff: [ ... ] } has been converted to Uint8Array
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,  ...
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([2, 1, 6, 4, 22,  ... 32, 54, 53, 102, 48]).buffer,
  new Uint8Array([2, 1, 6, 3, 22,  ... 32, 54, 53, 102, 48]).buffer
 ]
```

</details>

### Fix

Instead we now clone the object we pass in, to avoid losing track of the service id. We also handle all cases of `Bangle.bleAdvert` (`{ id: advert }`, `number[]`, `[ { id: advert }, { id: advert }, number[], ...]` and `undefined`)

The complexity comes from the advert being an array meaning one of two things - it's `number[]`, so raw data, or it's an array of adverts.

### Example

Running this, I now see the below advertising data, regularly updated by `ble_advert` correctly picking the correct advert to replace:

```
[
  // advert packet 1
  {
    6159: [ 95 ],    // 0x180f, i.e. battery level
    6157: undefined  // 0x180d, i.e. HRM
  },
  // advert packet 2
  [ 30, 255, ... ]  // openhaystack
 ]
```