### PR TITLE
fix(astrocalc): handle when moon rise/set don't occur on current day

### DIFF
--- a/apps/astrocalc/ChangeLog
+++ b/apps/astrocalc/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Fix azimuth (bug #2651), only show degrees
 0.07: Minor code improvements
 0.08: Minor code improvements
+0.09: Fix: Handle when the moon rise/set do not occur on the current day

--- a/apps/astrocalc/astrocalc-app.js
+++ b/apps/astrocalc/astrocalc-app.js
@@ -232,8 +232,6 @@ function drawSunShowPage(gps, key, date) {
   return null;
 }
 
-let m;
-
 function sunIndexPageMenu(gps) {
   const sunTimes = SunCalc.getTimes(new Date(), gps.lat, gps.lon);
 
@@ -242,7 +240,7 @@ function sunIndexPageMenu(gps) {
       "title": "-- Sun --",
     },
     "Current Pos": () => {
-      m = E.showMenu();
+      E.showMenu();
       drawSunShowPage(gps, "Current Pos", new Date());
     },
   };
@@ -250,13 +248,13 @@ function sunIndexPageMenu(gps) {
   Object.keys(sunTimes).sort().reduce((menu, key) => {
     const title = titlizeKey(key);
     menu[title] = () => {
-      m = E.showMenu();
+      E.showMenu();
       drawSunShowPage(gps, key, sunTimes[key]);
     };
     return menu;
   }, sunMenu);
 
-  sunMenu["< Back"] = () => m = indexPageMenu(gps);
+  sunMenu["< Back"] = () => indexPageMenu(gps);
 
   return E.showMenu(sunMenu);
 }
@@ -268,18 +266,18 @@ function moonIndexPageMenu(gps) {
       "title": "-- Moon --",
     },
     "Times": () => {
-      m = E.showMenu();
+      E.showMenu();
       drawMoonTimesPage(gps, /*LANG*/"Times");
     },
     "Position": () => {
-      m = E.showMenu();
+      E.showMenu();
       drawMoonPositionPage(gps, /*LANG*/"Position");
     },
     "Illumination": () => {
-      m = E.showMenu();
+      E.showMenu();
       drawMoonIlluminationPage(gps, /*LANG*/"Illumination");
     },
-    "< Back": () => m = indexPageMenu(gps),
+    "< Back": () => indexPageMenu(gps),
   };
 
   return E.showMenu(moonMenu);
@@ -291,10 +289,10 @@ function indexPageMenu(gps) {
       "title": /*LANG*/"Select",
     },
     /*LANG*/"Sun": () => {
-      m = sunIndexPageMenu(gps);
+      sunIndexPageMenu(gps);
     },
     /*LANG*/"Moon": () => {
-      m = moonIndexPageMenu(gps);
+      moonIndexPageMenu(gps);
     },
     "< Back": () => { load(); }
   };

--- a/apps/astrocalc/astrocalc-app.js
+++ b/apps/astrocalc/astrocalc-app.js
@@ -232,6 +232,8 @@ function drawSunShowPage(gps, key, date) {
   return null;
 }
 
+let m;
+
 function sunIndexPageMenu(gps) {
   const sunTimes = SunCalc.getTimes(new Date(), gps.lat, gps.lon);
 
@@ -300,9 +302,9 @@ function indexPageMenu(gps) {
   return E.showMenu(menu);
 }
 
-function getCenterStringX(str) {
-  return (g.getWidth() - g.stringWidth(str)) / 2;
-}
+//function getCenterStringX(str) {
+//  return (g.getWidth() - g.stringWidth(str)) / 2;
+//}
 
 function init() {
   let location = require("Storage").readJSON("mylocation.json",1)||{"lat":51.5072,"lon":0.1276,"location":"London"};
@@ -311,5 +313,4 @@ function init() {
   Bangle.drawWidgets();
 }
 
-let m;
 init();

--- a/apps/astrocalc/astrocalc-app.js
+++ b/apps/astrocalc/astrocalc-app.js
@@ -180,8 +180,8 @@ function drawMoonTimesPage(gps, title) {
   const moonColor = g.theme.dark ? {r: 1, g: 1, b: 1} : {r: 0, g: 0, b: 0};
 
   const pageData = {
-    Rise: dateToTimeString(times.rise),
-    Set: dateToTimeString(times.set),
+    Rise: times.rise ? dateToTimeString(times.rise) : "Not today",
+    Set: times.set ? dateToTimeString(times.set) : "Not today",
   };
 
   drawData(title, pageData, null, g.getHeight()/2 - Object.keys(pageData).length/2*20 + 5);

--- a/apps/astrocalc/metadata.json
+++ b/apps/astrocalc/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "astrocalc",
   "name": "Astrocalc",
-  "version": "0.08",
+  "version": "0.09",
   "description": "Calculates interesting information on the sun like sunset and sunrise and moon cycles for the current day based on your location from MyLocation app",
   "icon": "astrocalc.png",
   "tags": "app,sun,moon,cycles,tool,outdoors",


### PR DESCRIPTION
I noticed a bug in the Moon > Times menu.

My (very basic) understanding is that the `rise` and `set` members of the `times` object returned by the `getMoonTimes` function car actually be `undefined`, depending on if the moon rise or set actually occur on the current day.

This MR handles these cases.