### PR TITLE
VPW clock: do not remove VGA8 font for fast loading

### DIFF
--- a/apps/vpw_clock/ChangeLog
+++ b/apps/vpw_clock/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Set theme to light, add black as an option for foreground color
 0.04: Handle fast loading
 0.05: Fix theme reset for some themes
+0.06: Minor fix: do not remove VGA8 font

--- a/apps/vpw_clock/app.js
+++ b/apps/vpw_clock/app.js
@@ -167,7 +167,6 @@ Graphics.prototype.setFontMadeSunflower = function () {
       if (drawTimeout) clearTimeout(drawTimeout);
       // remove custom font
       delete Graphics.prototype.setFontMadeSunflower;
-      delete Graphics.prototype.setFontVGA8;
       // revert theme to how it was before
       g.setTheme(originalTheme);
     }

--- a/apps/vpw_clock/metadata.json
+++ b/apps/vpw_clock/metadata.json
@@ -3,7 +3,7 @@
   "name": "Vaporwave Sunset Clock",
   "shortName": "Vaporwave Sunset",
   "type": "clock",
-  "version":"0.05",
+  "version":"0.06",
   "description": "A clock with a vaporwave sunset theme.",
   "tags": "clock",
   "supports": ["BANGLEJS2"],


### PR DESCRIPTION
As per this discussion: https://forum.espruino.com/conversations/395233

Do not remove the VGA8 font as part of the remove `handler`