### PR TITLE
Add BLE privacy setting

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -70,3 +70,4 @@
 0.59: Whitelist: Try to resolve peer addresses using NRF.resolveAddress() - for 2v19 or 2v18 cutting edge builds
 0.60: Minor code improvements
 0.61: Instead of breaking execution with an Exception when updating boot, just use if..else (fix 'Uncaught undefined')
+0.62: Handle setting for configuring BLE privacy

--- a/apps/boot/bootupdate.js
+++ b/apps/boot/bootupdate.js
@@ -78,7 +78,12 @@ if (global.save) boot += `global.save = function() { throw new Error("You can't 
 // Apply any settings-specific stuff
 if (s.options) boot+=`Bangle.setOptions(${E.toJS(s.options)});\n`;
 if (s.brightness && s.brightness!=1) boot+=`Bangle.setLCDBrightness(${s.brightness});\n`;
-if (s.passkey!==undefined && s.passkey.length==6) boot+=`NRF.setSecurity({passkey:${E.toJS(s.passkey.toString())}, mitm:1, display:1});\n`;
+if (s.bleprivacy || (s.passkey!==undefined && s.passkey.length==6)) {
+  let passkey = s.passkey ? `passkey:${E.toJS(s.passkey.toString())},` : "";
+  let privacy = s.bleprivacy ? `privacy:${E.toJS(s.bleprivacy)},` : "";
+  boot+=`NRF.setSecurity({${passkey}${privacy}mitm:1,display:1});\n`;
+}
+if (s.blename === false) boot+=`NRF.setAdvertising({},{showName:false});\n`;
 if (s.whitelist && !s.whitelist_disabled) boot+=`NRF.on('connect', function(addr) { if (!NRF.ignoreWhitelist) { let whitelist = (require('Storage').readJSON('setting.json',1)||{}).whitelist; if (NRF.resolveAddress !== undefined) { let resolvedAddr = NRF.resolveAddress(addr); if (resolvedAddr !== undefined) addr = resolvedAddr + " (resolved)"; } if (!whitelist.includes(addr)) NRF.disconnect(); }});\n`;
 if (s.rotate) boot+=`g.setRotation(${s.rotate&3},${s.rotate>>2});\n` // screen rotation
 // ================================================== FIXING OLDER FIRMWARES

--- a/apps/boot/metadata.json
+++ b/apps/boot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "boot",
   "name": "Bootloader",
-  "version": "0.61",
+  "version": "0.62",
   "description": "This is needed by Bangle.js to automatically load the clock, menu, widgets and settings",
   "icon": "bootloader.png",
   "type": "bootloader",

--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -80,3 +80,4 @@ of 'Select Clock'
 0.69: Add option to wake on double tap
 0.70: Fix load() typo
 0.71: Minor code improvements
+0.72: Add setting for configuring BLE privacy

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.71",
+  "version": "0.72",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -159,6 +159,8 @@ function showAlertsMenu() {
 function showBLEMenu() {
   var hidV = [false, "kbmedia", "kb", "com", "joy"];
   var hidN = [/*LANG*/"Off", /*LANG*/"Kbrd & Media", /*LANG*/"Kbrd", /*LANG*/"Kbrd & Mouse", /*LANG*/"Joystick"];
+  var privacy = [/*LANG*/"Off", /*LANG*/"Show name", /*LANG*/"Hide name"];
+
   E.showMenu({
     '': { 'title': /*LANG*/'Bluetooth' },
     '< Back': ()=>showMainMenu(),
@@ -174,6 +176,32 @@ function showBLEMenu() {
       value: settings.blerepl,
       onchange: () => {
         settings.blerepl = !settings.blerepl;
+        updateSettings();
+      }
+    },
+    /*LANG*/'Privacy': {
+      min: 0, max: privacy.length-1,
+      format: v => privacy[v],
+      value: (() => {
+        // settings.bleprivacy may be some custom object, but we ignore that for now
+        if (settings.bleprivacy && settings.blename === false) return 2;
+        if (settings.bleprivacy) return 1;
+        return 0;
+      })(),
+      onchange: v => {
+        settings.bleprivacy = 0;
+        delete settings.blename;
+        switch (v) {
+          case 0:
+            break;
+          case 1:
+            settings.bleprivacy = 1;
+            break;
+          case 2:
+            settings.bleprivacy = 1;
+            settings.blename = false;
+            break;
+        }
         updateSettings();
       }
     },

--- a/typescript/types/settings.d.ts
+++ b/typescript/types/settings.d.ts
@@ -5,6 +5,8 @@ type Settings = {
 
 	ble: boolean,
 	blerepl: boolean,
+	bleprivacy?: NRFSecurityStatus["privacy"],
+	blename?: boolean,
 	HID?: false | "kbmedia" | "kb" | "com" | "joy",
 
 	passkey?: string,


### PR DESCRIPTION
This follows on from espruino/Espruino#2506, providing an easy way for a user to configure BLE privacy.

Currently the simple modes are supported:
- Off
- On
- On with the device's name hidden

---

This also updates typescript types for the settings object, and brings in typings from espruino (espruino/Espruino#2516)