### PR TITLE
widdst: ensure DST is applied when leaving settings

### DIFF
--- a/apps/widdst/ChangeLog
+++ b/apps/widdst/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Convert Yes/No On/Off in settings to checkboxes
 0.04: Give the boot file the highest priority to ensure it runs before sched (fix #2663)
 0.05: Tweaks to ensure Gadgetbridge can't overwrite timezone on 2v19.106 and later
+0.06: If fastload is present, ensure DST changes are still applied when leaving settings

--- a/apps/widdst/metadata.json
+++ b/apps/widdst/metadata.json
@@ -1,6 +1,6 @@
 { "id": "widdst",
   "name": "Daylight Saving",
-  "version":"0.05",
+  "version":"0.06",
   "description": "Widget to set daylight saving rules. Requires Espruino 2v15 or later - see the instructions below for more information.",
   "icon": "icon.png",
   "type": "widget",

--- a/apps/widdst/settings.js
+++ b/apps/widdst/settings.js
@@ -33,8 +33,11 @@
     at: 0
   };
 
+  var writtenSettings = false;
+
   function writeSettings() {
     require('Storage').writeJSON("widdst.json", settings);
+    writtenSettings = true;
   }
 
   function writeSubMenuSettings() {
@@ -136,7 +139,15 @@
     "": {
       "Title": /*LANG*/"Daylight Saving"
     },
-    "< Back": () => back(),
+    "< Back": () => {
+      if(writtenSettings && global._load){
+        // disable fastload to ensure settings are applied
+        // when we exit the settings app
+        global.load = global._load;
+        delete global._load;
+      }
+      back();
+    },
     /*LANG*/"Enabled": {
       value: !!settings.has_dst,
       onchange: v => {


### PR DESCRIPTION
... for example, when fastload is installed, so we don't jump back to the clock with the old DST settings.