### PR TITLE
Correct interface.js path in interface.html example

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ in an iframe.
     <link rel="stylesheet" href="../../css/spectre.min.css">
   </head>
   <body>
-    <script src="../../lib/interface.js"></script>
+    <script src="../../core/lib/interface.js"></script>
     <div id="t">Loading...</div>
     <script>
       function onInit() {


### PR DESCRIPTION
I used the example code for interface.html and couldn't get it to work until I made this change (which I had seen in all the other public source code). So I'm assuming this was an error or an outdated example that should be updated.