### PR TITLE
Update Daisy clock to add battery estimate in hs

### DIFF
--- a/apps/daisy/ChangeLog
+++ b/apps/daisy/ChangeLog
@@ -9,3 +9,4 @@
 0.09: Use 'modules/suncalc.js' to avoid it being copied 8 times for different apps
 0.10: Use widget_utils.
 0.11: Minor code improvements
+0.12: Added setting to change Battery estimate to hours

--- a/apps/daisy/README.md
+++ b/apps/daisy/README.md
@@ -10,7 +10,7 @@ Forum](http://forum.espruino.com/microcosms/1424/)
 
 * Derived from [The Ring](https://banglejs.com/apps/?id=thering) proof of concept and the [Pastel clock](https://banglejs.com/apps/?q=pastel)
 * Includes the [Lazybones](https://banglejs.com/apps/?q=lazybones) Idle warning timer
-* Touch the top right/top left to cycle through the info display (Day, Date, Steps, Sunrise, Sunset, Heart Rate)
+* Touch the top right/top left to cycle through the info display (Day, Date, Steps, Sunrise, Sunset, Heart Rate, Battery Estimate)
 * The heart rate monitor is turned on only when Heart rate is selected and will take a few seconds to settle
 * The heart value is displayed in RED if the confidence value is less than 50%
 * NOTE: The heart rate monitor of Bangle JS 2 is not very accurate when moving about.
@@ -20,6 +20,7 @@ See [#1248](https://github.com/espruino/BangleApps/issues/1248)
 [MyLocation](https://banglejs.com/apps/?id=mylocation)
 * The screen is updated every minute to save battery power
 * Uses the [BloggerSansLight](https://www.1001fonts.com/rounded-fonts.html?page=3) font, which if free for commercial use
+* You need to run >2V22 to show the battery estimate in hours
 
 ## Future Development
 * Use mini icons in the information line rather that text

--- a/apps/daisy/app.js
+++ b/apps/daisy/app.js
@@ -83,6 +83,7 @@ function loadSettings() {
   settings.gy = settings.gy||'#020';
   settings.fg = settings.fg||'#0f0';
   settings.idle_check = (settings.idle_check === undefined ? true : settings.idle_check);
+  settings.batt_hours = (settings.batt_hours === undefined ? true : settings.batt_hours);
   assignPalettes();
 }
 
@@ -112,13 +113,35 @@ function updateSunRiseSunSet(now, lat, lon, line){
   sunSet = extractTime(times.sunset);
 }
 
+function batteryString(){
+  let stringToInsert;
+  if (settings.batt_hours) {
+    var batt_usage = 200000/E.getPowerUsage().total;
+    let rounded;
+    if (batt_usage > 99) {
+      rounded = Math.round(batt_usage);
+    }
+    else if (batt_usage > 9) {
+      rounded = Math.round(200000/E.getPowerUsage().total * 10) / 10;
+    }
+    else {
+      rounded = Math.round(200000/E.getPowerUsage().total * 100) / 100;
+    }
+    stringToInsert = '\n' + rounded + ' ' + ((batt_usage < 2) ? 'h' : 'hs');
+  }
+  else{
+    stringToInsert = ' ' + E.getBattery() + '%';
+  }
+  return 'BATTERY' + stringToInsert;
+}
+
 const infoData = {
   ID_DATE:  { calc: () => {var d = (new Date()).toString().split(" "); return d[2] + ' ' + d[1] + ' ' + d[3];} },
   ID_DAY:   { calc: () => {var d = require("locale").dow(new Date()).toLowerCase(); return d[0].toUpperCase() + d.substring(1);} },
   ID_SR:    { calc: () => 'SUNRISE ' + sunRise },
   ID_SS:    { calc: () => 'SUNSET ' + sunSet },
   ID_STEP:  { calc: () => 'STEPS ' + getSteps() },
-  ID_BATT:  { calc: () => 'BATTERY ' + E.getBattery() + '%' },
+  ID_BATT:  { calc: batteryString},
   ID_HRM:   { calc: () => hrmCurrent }
 };
 

--- a/apps/daisy/app.js
+++ b/apps/daisy/app.js
@@ -118,8 +118,10 @@ function batteryString(){
   if (settings.batt_hours) {
     var batt_usage = 200000/E.getPowerUsage().total;
     let rounded;
-    if (batt_usage > 99) {
-      rounded = Math.round(batt_usage);
+    if (batt_usage > 24) {
+      var days = Math.floor(batt_usage/24);
+      var hours = Math.round((batt_usage/24 - days) * 24);
+      stringToInsert = '\n' + days + ((days < 2) ? 'd' : 'ds') + ' ' + hours + ((hours < 2) ? 'h' : 'hs');
     }
     else if (batt_usage > 9) {
       rounded = Math.round(200000/E.getPowerUsage().total * 10) / 10;
@@ -127,7 +129,9 @@ function batteryString(){
     else {
       rounded = Math.round(200000/E.getPowerUsage().total * 100) / 100;
     }
-    stringToInsert = '\n' + rounded + ' ' + ((batt_usage < 2) ? 'h' : 'hs');
+    if (batt_usage < 24) {
+      stringToInsert = '\n' + rounded + ' ' + ((batt_usage < 2) ? 'h' : 'hs');
+    }
   }
   else{
     stringToInsert = ' ' + E.getBattery() + '%';

--- a/apps/daisy/metadata.json
+++ b/apps/daisy/metadata.json
@@ -1,6 +1,6 @@
 { "id": "daisy",
   "name": "Daisy",
-  "version": "0.11",
+  "version": "0.12",
   "dependencies": {"mylocation":"app"},
   "description": "A beautiful digital clock with large ring guage, idle timer and a cyclic information line that includes, day, date, steps, battery, sunrise and sunset times",
   "icon": "app.png",

--- a/apps/daisy/settings.js
+++ b/apps/daisy/settings.js
@@ -5,7 +5,8 @@
   let s = {'gy' : '#020',
            'fg' : '#0f0',
            'color': 'Green',
-           'check_idle' : true};
+           'check_idle' : true,
+           'batt_hours' : false};
 
   // ...and overwrite them with any saved values
   // This way saved values are preserved if a new version adds more settings
@@ -45,6 +46,14 @@
         s.idle_check = v;
         save();
       },
+    },
+    'Expected Battery Life In Hours': {
+      value: !!s.batt_hours,
+      onchange: v => {
+        s.batt_hours = v;
+        save();
+      },
     }
   });
 })
+


### PR DESCRIPTION
Hi, I saw https://forum.espruino.com/conversations/395838/ and I wanted to implement it on my favorite clock. So I did.

Maybe @hughbarney has a review comment it being your app?

I decided not to check the firmware version when toggling the setting, this could be added if wanted (it being off by default I don't think people enable it if they aren't on the most recent version, or that those people couldn't find out the issue then :D)

Edit: After running around with this I realized that the big hour estimate is really not something I want to convert in my head, so I changed it now that it shows days instead. As soon as we get in the lower region the actual estimate jumps really noticeably, I am unsure if I should "catch" this here and probably just not display them, or if the function should return a more linear estimate. And tbh I personally dont mind the jumping numbers
