### PR TITLE
swiperclocklaunch: fix detection of clock

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -81,3 +81,4 @@ of 'Select Clock'
 0.70: Fix load() typo
 0.71: Minor code improvements
 0.72: Add setting for configuring BLE privacy
+0.73: Fix `const` bug / work with fastload

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.72",
+  "version": "0.73",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -1,3 +1,4 @@
+{
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
@@ -984,3 +985,4 @@ function showTouchscreenCalibration() {
 }
 
 showMainMenu();
+}

--- a/apps/swiperclocklaunch/ChangeLog
+++ b/apps/swiperclocklaunch/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Update to work with new 'fast switch' clock->launcher functionality
 0.05: Keep track of event listeners we "overwrite", and remove them at the start of setUI
 0.06: Handle apps that call setUI({}) to reset
+0.07: Use a more reliable method of detecting a clock

--- a/apps/swiperclocklaunch/boot.js
+++ b/apps/swiperclocklaunch/boot.js
@@ -8,19 +8,14 @@
     sui(mode,cb);
     oldSwipe = Bangle.swipeHandler;
 
-    if ("object"==typeof mode) mode = mode.mode;
-    if (!mode) return;
-
-    if (mode.startsWith("clock")) {
+    if (Bangle.CLOCK) {
       // clock -> launcher
       Bangle.swipeHandler = dir => { if (dir<0) Bangle.showLauncher(); };
       Bangle.on("swipe", Bangle.swipeHandler);
-    } else {
-      if (global.__FILE__ && __FILE__.endsWith(".app.js") && (require("Storage").readJSON(__FILE__.slice(0,-6)+"info",1)||{}).type=="launch") {
-        // launcher -> clock
-        Bangle.swipeHandler = dir => { if (dir>0) load(); };
-        Bangle.on("swipe", Bangle.swipeHandler);
-      }
+    } else if (global.__FILE__ && __FILE__.endsWith(".app.js") && (require("Storage").readJSON(__FILE__.slice(0,-6)+"info",1)||{}).type==="launch") {
+      // launcher -> clock
+      Bangle.swipeHandler = dir => { if (dir>0) load(); };
+      Bangle.on("swipe", Bangle.swipeHandler);
     }
   };
 })();

--- a/apps/swiperclocklaunch/boot.js
+++ b/apps/swiperclocklaunch/boot.js
@@ -3,19 +3,21 @@
   var oldSwipe;
 
   Bangle.setUI = function(mode, cb) {
-    if (oldSwipe && oldSwipe !== Bangle.swipeHandler)
+    if (oldSwipe) {
       Bangle.removeListener("swipe", oldSwipe);
+      oldSwipe = undefined;
+    }
+
     sui(mode,cb);
-    oldSwipe = Bangle.swipeHandler;
 
     if (Bangle.CLOCK) {
       // clock -> launcher
-      Bangle.swipeHandler = dir => { if (dir<0) Bangle.showLauncher(); };
-      Bangle.on("swipe", Bangle.swipeHandler);
+      oldSwipe = dir => { if (dir<0) Bangle.showLauncher(); };
+      Bangle.on("swipe", oldSwipe);
     } else if (global.__FILE__ && __FILE__.endsWith(".app.js") && (require("Storage").readJSON(__FILE__.slice(0,-6)+"info",1)||{}).type==="launch") {
       // launcher -> clock
-      Bangle.swipeHandler = dir => { if (dir>0) load(); };
-      Bangle.on("swipe", Bangle.swipeHandler);
+      oldSwipe = dir => { if (dir>0) load(); };
+      Bangle.on("swipe", oldSwipe);
     }
   };
 })();

--- a/apps/swiperclocklaunch/metadata.json
+++ b/apps/swiperclocklaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "swiperclocklaunch",
   "name": "Swiper Clock Launch",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Navigate between clock and launcher with Swipe action",
   "icon": "swiperclocklaunch.png",
   "type": "bootloader",


### PR DESCRIPTION
swiperclocklaunch now reliably detects a clock, using existing logic in `setUI` instead of inspecting arguments