### PR TITLE
setuichange: refine when to set button to show launcher

### DIFF
--- a/apps/setuichange/ChangeLog
+++ b/apps/setuichange/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New App!
 0.02: Fix case where we tried to push to Bangle.btnWatches but it wasn't
 	defined.
+0.03: Tweak when to add button clock action.

--- a/apps/setuichange/boot.js
+++ b/apps/setuichange/boot.js
@@ -72,7 +72,7 @@ Bangle.setUI = (function(mode, cb) {
     ];
   } else if (mode=="clock") {
     Bangle.CLOCK=1;
-    Bangle.btnWatches = [
+    if (!(options.btn||options.btnRelease)) Bangle.btnWatches = [
       setWatch(Bangle.showLauncher, BTN1, {repeat:1,edge:"rising"})
     ];
   } else if (mode=="clockupdown") {
@@ -81,11 +81,11 @@ Bangle.setUI = (function(mode, cb) {
       if (e.x < 120) return;
       b();cb((e.y > 88) ? 1 : -1);
     };
-    Bangle.btnWatches = [
+    if (!(options.btn||options.btnRelease)) Bangle.btnWatches = [
       setWatch(Bangle.showLauncher, BTN1, {repeat:1,edge:"rising"})
     ];
   } else if (mode=="custom") {
-    if (options.clock) {
+    if (options.clock && !(options.btn||options.btnRelease)) {
       Bangle.btnWatches = [
         setWatch(Bangle.showLauncher, BTN1, {repeat:1,edge:"rising"})
       ];

--- a/apps/setuichange/metadata.json
+++ b/apps/setuichange/metadata.json
@@ -1,6 +1,6 @@
 { "id": "setuichange",
   "name": "SetUI Proposals preview",
-  "version":"0.02",
+  "version":"0.03",
   "description": "Try out potential future changes to `Bangle.setUI`. Makes hardware button interaction snappier. Makes it possible to set custom event handlers on any type/mode, not just `\"custom\"`. Please provide feedback - see `Read more...` below.",
   "icon": "app.png",
   "tags": "",


### PR DESCRIPTION
Now if some custom btn or btnRelease handler is set the clock button handler won't be added.

@gfwilliams