### PR TITLE
Daisy Fix: Put default to False for battery display

### DIFF
--- a/apps/daisy/ChangeLog
+++ b/apps/daisy/ChangeLog
@@ -10,3 +10,4 @@
 0.10: Use widget_utils.
 0.11: Minor code improvements
 0.12: Added setting to change Battery estimate to hours
+0.13: Fixed Battery estimate Default to percentage and improved setting string

--- a/apps/daisy/app.js
+++ b/apps/daisy/app.js
@@ -83,7 +83,7 @@ function loadSettings() {
   settings.gy = settings.gy||'#020';
   settings.fg = settings.fg||'#0f0';
   settings.idle_check = (settings.idle_check === undefined ? true : settings.idle_check);
-  settings.batt_hours = (settings.batt_hours === undefined ? true : settings.batt_hours);
+  settings.batt_hours = (settings.batt_hours === undefined ? false : settings.batt_hours);
   assignPalettes();
 }
 

--- a/apps/daisy/metadata.json
+++ b/apps/daisy/metadata.json
@@ -1,6 +1,6 @@
 { "id": "daisy",
   "name": "Daisy",
-  "version": "0.12",
+  "version": "0.13",
   "dependencies": {"mylocation":"app"},
   "description": "A beautiful digital clock with large ring guage, idle timer and a cyclic information line that includes, day, date, steps, battery, sunrise and sunset times",
   "icon": "app.png",

--- a/apps/daisy/settings.js
+++ b/apps/daisy/settings.js
@@ -47,7 +47,7 @@
         save();
       },
     },
-    'Expected Battery Life In Hours': {
+    'Expected Battery Life In Days Not Percentage': {
       value: !!s.batt_hours,
       onchange: v => {
         s.batt_hours = v;


### PR DESCRIPTION
This fixes #3493