### PR TITLE
AGPS: Don't unserialize then immediately serialize

### DIFF
--- a/apps/assistedgps/custom.html
+++ b/apps/assistedgps/custom.html
@@ -131,7 +131,6 @@
 // ===================================================
 
       function jsFromBase64(b64) {
-        var bin = atob(b64);
         var chunkSize = 128;
         var js = "\x10Bangle.setGPSPower(1,'agps');\n"; // turn GPS on
         if (isB1) { // UBLOX
@@ -157,9 +156,9 @@
           // or AGPS.zip uses AID-INI (0x0B 0x01)
         }
 
-        for (var i=0;i<bin.length;i+=chunkSize) {
-          var chunk = bin.substr(i,chunkSize);
-          js += `\x10Serial1.write(atob("${btoa(chunk)}"))\n`;
+        for (var i=0;i<b64.length;i+=chunkSize) {
+          var chunk = b64.substr(i,chunkSize);
+          js += `\x10Serial1.write(atob("${chunk}"))\n`;
         }
         js += "\x10setTimeout(() => Bangle.setGPSPower(0,'agps'), 1000);\n"; // turn GPS off after a delay
         return js;


### PR DESCRIPTION
Right now we're decoding the base64 for no good reason, as it's immediately encoded afterwards, so this removes that.

Note that the chunk size will change - now less data will be sent each time. I wouldn't expect this to be a problem, but I haven't tested it and I might need to change the chunk size.