### PR TITLE
settings: disable fastload

### DIFF
--- a/apps/setting/ChangeLog
+++ b/apps/setting/ChangeLog
@@ -82,3 +82,4 @@ of 'Select Clock'
 0.71: Minor code improvements
 0.72: Add setting for configuring BLE privacy
 0.73: Fix `const` bug / work with fastload
+0.74: Disable fastload for settings

--- a/apps/setting/metadata.json
+++ b/apps/setting/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "setting",
   "name": "Settings",
-  "version": "0.73",
+  "version": "0.74",
   "description": "A menu for setting up Bangle.js",
   "icon": "settings.png",
   "tags": "tool,system",

--- a/apps/setting/settings.js
+++ b/apps/setting/settings.js
@@ -2,6 +2,13 @@
 Bangle.loadWidgets();
 Bangle.drawWidgets();
 
+// disable fastload to ensure settings are applied when we exit the settings app
+// or if we load into another app from here
+if(global._load){
+  global.load = global._load;
+  delete global._load;
+}
+
 const BANGLEJS2 = process.env.HWVERSION==2;
 const storage = require('Storage');
 let settings;

--- a/apps/widdst/ChangeLog
+++ b/apps/widdst/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Give the boot file the highest priority to ensure it runs before sched (fix #2663)
 0.05: Tweaks to ensure Gadgetbridge can't overwrite timezone on 2v19.106 and later
 0.06: If fastload is present, ensure DST changes are still applied when leaving settings
+0.07: Move fastload logic to settings

--- a/apps/widdst/metadata.json
+++ b/apps/widdst/metadata.json
@@ -1,6 +1,6 @@
 { "id": "widdst",
   "name": "Daylight Saving",
-  "version":"0.06",
+  "version":"0.07",
   "description": "Widget to set daylight saving rules. Requires Espruino 2v15 or later - see the instructions below for more information.",
   "icon": "icon.png",
   "type": "widget",

--- a/apps/widdst/settings.js
+++ b/apps/widdst/settings.js
@@ -33,11 +33,8 @@
     at: 0
   };
 
-  var writtenSettings = false;
-
   function writeSettings() {
     require('Storage').writeJSON("widdst.json", settings);
-    writtenSettings = true;
   }
 
   function writeSubMenuSettings() {
@@ -139,15 +136,7 @@
     "": {
       "Title": /*LANG*/"Daylight Saving"
     },
-    "< Back": () => {
-      if(writtenSettings && global._load){
-        // disable fastload to ensure settings are applied
-        // when we exit the settings app
-        global.load = global._load;
-        delete global._load;
-      }
-      back();
-    },
+    "< Back": back,
     /*LANG*/"Enabled": {
       value: !!settings.has_dst,
       onchange: v => {


### PR DESCRIPTION
This prevents issues with not loading settings on exit, or jumping into other apps such as the recorder, while not unloading settings.

See also https://github.com/espruino/Espruino/issues/2530