### PR TITLE
Add support for reply lib to messagegui app

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -106,3 +106,4 @@
 0.77: Messages can now use international fonts if they are installed
 0.78: Fix: When user taps on a new message, clear the unread timeout
 0.79: Fix: Reset the unread timeout each time a new message is shown. When the message is read from user input, do not set an unread timeout.
+0.80: Add ability to reply to messages if a reply library is installed and the message can be replied to

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -323,6 +323,7 @@ function showMessageSettings(msg) {
 }
 
 function showMessage(msgid, persist) {
+  if (replying) { return; }
   if(!persist) resetReloadTimeout();
   let idx = MESSAGES.findIndex(m=>m.id==msgid);
   var msg = MESSAGES[idx];

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.79",
+  "version": "0.80",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -8,7 +8,7 @@
   "type": "app",
   "tags": "tool,system",
   "supports": ["BANGLEJS","BANGLEJS2"],
-  "dependencies" : { "messageicons":"module" },
+  "dependencies" : { "messageicons":"module", "reply": "module" },
   "provides_modules": ["messagegui"],
   "default": true,
   "readme": "README.md",

--- a/apps/reply/ChangeLog
+++ b/apps/reply/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New Library!
+0.02: Minor bug fixes

--- a/apps/reply/lib.js
+++ b/apps/reply/lib.js
@@ -6,7 +6,12 @@ exports.reply = function (options) {
     keyboard = null;
   }
 
-  function constructReply(msg, replyText, resolve) {
+  function constructReply(msg, replyText, resolve, reject) {
+    if (!replyText) { 
+      reject("");
+      return;
+    }
+
     var responseMessage = {msg: replyText};
     if (msg.id) {
       responseMessage = { t: "notify", id: msg.id, n: "REPLY", msg: replyText };
@@ -29,7 +34,10 @@ exports.reply = function (options) {
       }, // options
       /*LANG*/ "Compose": function () {
         keyboard.input().then((result) => {
-          constructReply(options.msg ?? {}, result, resolve);
+          if (result)
+            constructReply(options.msg ?? {}, result, resolve, reject);
+          else
+            E.showMenu(menu);
         });
       },
     };
@@ -40,7 +48,7 @@ exports.reply = function (options) {
       ) || [];
     replies.forEach((reply) => {
       menu = Object.defineProperty(menu, reply.text, {
-        value: () => constructReply(options.msg ?? {}, reply.text, resolve),
+        value: () => constructReply(options.msg ?? {}, reply.text, resolve, reject),
       });
     });
     if (!keyboard) delete menu[/*LANG*/ "Compose"];
@@ -60,10 +68,11 @@ exports.reply = function (options) {
         );
       } else {
         keyboard.input().then((result) => {
-          constructReply(options.msg.id, result, resolve);
+          constructReply(options.msg, result, resolve, reject);
         });
       }
+    } else{
+      E.showMenu(menu);
     }
-    E.showMenu(menu);
   });
 };

--- a/apps/reply/metadata.json
+++ b/apps/reply/metadata.json
@@ -1,6 +1,6 @@
 { "id": "reply",
   "name": "Reply Library",
-  "version": "0.01",
+  "version": "0.02",
   "description": "A library for replying to text messages via predefined responses or keyboard",
   "icon": "app.png",
   "type": "module",


### PR DESCRIPTION
Adds support for the canned responses/reply lib to the default messagegui app.

By clicking on a notification to head to the notification settings, the user will see a "reply" menu item if the message can be replied to, which will trigger the reply library flow