### PR TITLE
slopeclockpp: avoid reusing background colour for clkinfo

### DIFF
--- a/apps/slopeclockpp/ChangeLog
+++ b/apps/slopeclockpp/ChangeLog
@@ -11,3 +11,4 @@
       Stop ClockInfo text drawing outside the allocated area
 0.09: Use clock_info module as an app
 0.10: Option to hide widgets, tweak top widget width to avoid overlap with hour text at 9am
+0.11: Avoid rendering clkinfo in the same colour as the background

--- a/apps/slopeclockpp/app.js
+++ b/apps/slopeclockpp/app.js
@@ -86,6 +86,7 @@ let draw = function() {
 
 let isAnimIn = true;
 let animInterval;
+let minuteX;
 // Draw *just* the minute image
 let drawMinute = function() {
   var yo = slopeBorder + offsy + y - 2*slope*minuteX/R.w;

--- a/apps/slopeclockpp/app.js
+++ b/apps/slopeclockpp/app.js
@@ -128,9 +128,9 @@ let clockInfoDraw = (itm, info, options) => {
   let texty = options.y+41;
   // set a cliprect to stop us drawing outside our box
   g.reset().setClipRect(options.x, options.y, options.x+options.w-1, options.y+options.h-1);
-  g.setFont("6x15").setBgColor(options.bg).setColor(options.fg).clearRect(options.x, texty-15, options.x+options.w-2, texty);
+  g.setFont("6x15").setBgColor(options.bg).clearRect(options.x, texty-15, options.x+options.w-2, texty);
 
-  if (options.focus) g.setColor(options.hl);
+  g.setColor(options.focus ? options.hl : options.fg);
   if (options.x < g.getWidth()/2) { // left align
     let x = options.x+2;
     if (info.img) g.clearRect(x, options.y, x+23, options.y+23).drawImage(info.img, x, options.y);
@@ -150,7 +150,7 @@ let clockInfoMenu = require("clock_info").addInteractive(clockInfoItems, {  // t
 });
 let clockInfoMenu2 = require("clock_info").addInteractive(clockInfoItems, { // bottom left
   app:"slopeclockpp",x:0, y:115, w:50, h:40,
-  draw : clockInfoDraw, bg : bgColor, fg : g.theme.bg, hl : (bgColor=="#000")?"#f00"/*red*/:g.theme.fg
+  draw : clockInfoDraw, bg : bgColor, fg : g.theme.bg, hl : (g.theme.fg===g.toColor(bgColor))?"#f00"/*red*/:g.theme.fg
 });
 
 // Show launcher when middle button pressed

--- a/apps/slopeclockpp/metadata.json
+++ b/apps/slopeclockpp/metadata.json
@@ -1,6 +1,6 @@
 { "id": "slopeclockpp",
   "name": "Slope Clock ++",
-  "version":"0.10",
+  "version":"0.11",
   "description": "A clock where hours and minutes are divided by a sloping line. When the minute changes, the numbers slide off the screen. This is a clone of the original Slope Clock which shows extra information and allows the colors to be selected.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
@eyecreate @myxor @hughbarney what do you think of this? I feel like there might be a better way to ensure the clock info is always visible