### PR TITLE
Add a test locale

### DIFF
--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -755,4 +755,27 @@ var locales = {
     day: "ראשון,שני,שלישי,רביעי,חמישי,שישי,שבת",
     trans: { yes: "כן", Yes: "כן", no: "לא", No: "לא", ok: "אישור", on: "פעיל", off: "כבוי" }
   }*/
+ /**
+  * These test strings are designed to be as wide and tall as real locale strings can be.
+  * All apps should be able to display them properly, to ensure that they work with all locales.
+  * To make the strings as long as possible, wide characters like "w" and "m" is used,
+  * and to make them taller, "k" and "g" are used together. 
+  */
+ "test": {
+    lang: "test",
+    icon: "🐛",
+    notes: "Produces the longest possible output. Useful for testing.",
+    decimal_point: ",",
+    thousands_sep: ",",
+    speed: "km/h",
+    distance: { 0: "kmi", 1: "kmi" },
+    temperature: "°C",
+    ampm: { 0: "dop", 1: "odp" },
+    timePattern: { 0: "%HHh%MM:%SS", 1: "%HHh%MM" },
+    datePattern: { 0: "%b, %d, %Y", 1: "%d. %m %Y" },
+    abmonth: Array(12).fill("mgmk").join(","),
+    month: Array(12).fill("megmmaskuum").join(","),
+    abday: Array(7).fill("mgmk").join(","),
+    day: Array(7).fill("megmavammkkom").join(","),
+  },
 };

--- a/apps/locale/sanitycheck.js
+++ b/apps/locale/sanitycheck.js
@@ -91,7 +91,7 @@ function checkLocale(locale, {speedUnits, distanceUnits, codePages, CODEPAGE_CON
 	const speeds = Object.keys(speedUnits);
 	const distances = Object.keys(distanceUnits);
 
-	checkLength("lang", locale.lang, 5, undefined);
+	checkLength("lang", locale.lang, 4, undefined);
 	checkLength("decimal point", locale.decimal_point, 1, 1);
 	checkLength("thousands separator", locale.thousands_sep, 1, 1);
 	checkLength("speed", locale.speed, 2, 4);

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -109,7 +109,9 @@ var KNOWN_WARNINGS = [
   `In locale it_CH, long time format might not work in some apps if it is not "%HH:%MM:%SS"`,
   `In locale it_IT, long time format might not work in some apps if it is not "%HH:%MM:%SS"`,
   `In locale wae_CH, long time format might not work in some apps if it is not "%HH:%MM:%SS"`,
+  `In locale test, long time format might not work in some apps if it is not "%HH:%MM:%SS"`,
   `In locale wae_CH, short time format might not work in some apps if it is not "%HH:%MM"`,
+  `In locale test, short time format might not work in some apps if it is not "%HH:%MM"`,
 ];
 
 var apps = [];


### PR DESCRIPTION
I think it would be useful to have a test locale for when you want to make sure your app can support all locales, even those with very long strings. Right now, you have to guess how much space to give each string, and that is a tedious and error prone method.

The length of each string in the test locale is as long as it is allowed to be, according to these limits:

| String              | Max characters   |
|---------------------|------|
| decimal point   | 1  |
| thousands sep  | 1 |
| speed              | 4     |
| distance          | 3     |
| temperature  | 2     |
| am/pm           | 3     |
| short time      | 5     |
| long time       | 8     |
| short date      | 11   |
| long date       | 14    |
| short month  | 4     |
| long month    | 11  |
| short day       | 4     |
| long day        | 13    |

If @gfwilliams agrees with these limits, I think it could be useful to document them somewhere, and also add some code to verify that they are being followed.

The limits support all existing locales, except a few that have unnecessarily long strings that you cannot expect a small watch to display. I have checked each case, and it is possible to make those strings shorter.

Character count is not the only issue though. The width and height of the characters can also have a big impact on the visual size of the string. I have made sure to use tall and wide characters such that the test strings are at least as big as the biggest real locale strings.

I have tested a bunch of apps with the test locale, and most support it, so I think it is a good middle ground that is not too restrictive on the string lengths, but also doesn't require apps to use too much screen space.