### PR TITLE
Fix promenu behaviour: scroller & image strings

### DIFF
--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -79,10 +79,11 @@ E.showMenu = function (items) {
                     v = "";
                 }
                 {
-                    if (name.length >= 17 - v.length && typeof item === "object") {
+                    var vplain = v.indexOf("\0") < 0;
+                    if (vplain && name.length >= 17 - v.length && typeof item === "object") {
                         g.drawString(name.substring(0, 12 - v.length) + "...", x + 3.7, iy + 2.7);
                     }
-                    else if (name.length >= 15) {
+                    else if (vplain && name.length >= 15) {
                         g.drawString(name.substring(0, 15) + "...", x + 3.7, iy + 2.7);
                     }
                     else {

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -28,6 +28,9 @@ E.showMenu = function (items) {
         y += 22;
     var lastIdx = 0;
     var selectEdit = undefined;
+    var scroller = {
+        scroll: selected,
+    };
     var l = {
         draw: function (rowmin, rowmax) {
             var rows = 0 | Math.min((y2 - y) / fontHeight, menuItems.length);
@@ -138,9 +141,11 @@ E.showMenu = function (items) {
             else {
                 var lastSelected = selected;
                 selected = (selected + dir + menuItems.length) % menuItems.length;
+                scroller.scroll = selected;
                 l.draw(Math.min(lastSelected, selected), Math.max(lastSelected, selected));
             }
         },
+        scroller: scroller,
     };
     l.draw();
     var back = options.back;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -35,6 +35,10 @@ E.showMenu = (items?: Menu): MenuInstance => {
   let lastIdx = 0;
   let selectEdit: undefined | ActualMenuItem = undefined;
 
+  const scroller = {
+    scroll: selected,
+  };
+
   const l = {
     draw: (rowmin?: number, rowmax?: number) => {
       let rows = 0|Math.min((y2 - y) / fontHeight, menuItems.length);
@@ -156,9 +160,11 @@ E.showMenu = (items?: Menu): MenuInstance => {
       } else {
         const lastSelected = selected;
         selected = (selected + dir + /*keep +ve*/menuItems.length) % menuItems.length;
+        scroller.scroll = selected;
         l.draw(Math.min(lastSelected, selected), Math.max(lastSelected, selected));
       }
     },
+    scroller,
   };
 
   l.draw();

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -87,9 +87,10 @@ E.showMenu = (items?: Menu): MenuInstance => {
         }
 
         /*???*/{
-          if(name.length >= 17 - v.length && typeof item === "object"){
+          const vplain = v.indexOf("\0") < 0;
+          if(vplain && name.length >= 17 - v.length && typeof item === "object"){
             g.drawString(name.substring(0, 12 - v.length) + "...", x + 3.7, iy + 2.7);
-          }else if(name.length >= 15){
+          }else if(vplain && name.length >= 15){
             g.drawString(name.substring(0, 15) + "...", x + 3.7, iy + 2.7);
           }else{
             g.drawString(name, x + 3.7, iy + 2.7);


### PR DESCRIPTION
This fixes promenu to:
- return a `scroller` (permitting it to work with the alarm app)
- avoid calculations on menu items with image strings, assuming the app has figuring this out already