### PR TITLE
antonclk: Handle French time format

### DIFF
--- a/apps/antonclk/ChangeLog
+++ b/apps/antonclk/ChangeLog
@@ -14,3 +14,4 @@
 0.10: Use Bangle.setUI({remove:...}) to allow loading the launcher without a full reset on 2v16
 0.11: Moved enhanced Anton clock to 'Anton Clock Plus' and stripped this clock back down to make it faster for new users (270ms -> 170ms)
       Modified to avoid leaving functions defined when using setUI({remove:...})
+0.12: Clock can understand French time formats

--- a/apps/antonclk/app.js
+++ b/apps/antonclk/app.js
@@ -15,6 +15,7 @@ let draw = function() {
   g.reset().clearRect(Bangle.appRect); // clear whole background (w/o widgets)
   var date = new Date();
   var timeStr = require("locale").time(date, 1); // Hour and minute
+  timeStr = timeStr.replace(/ *h */i, ":"); // Don't use French time format, it is not supported by the Anton font
   g.setFontAlign(0, 0).setFont("Anton").drawString(timeStr, x, y);
   // Show date and day of week
   var dateStr = require("locale").date(date, 0).toUpperCase()+"\n"+

--- a/apps/antonclk/metadata.json
+++ b/apps/antonclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "antonclk",
   "name": "Anton Clock",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A simple clock using the bold Anton font. See `Anton Clock Plus` for an enhanced version",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/antonclkplus/ChangeLog
+++ b/apps/antonclkplus/ChangeLog
@@ -14,3 +14,4 @@
 0.10: Use Bangle.setUI({remove:...}) to allow loading the launcher without a full reset on 2v16
       Modified to avoid leaving functions defined when using setUI({remove:...})
 0.11: Minor code improvements
+0.12: Clock can understand French time formats

--- a/apps/antonclkplus/app.js
+++ b/apps/antonclkplus/app.js
@@ -140,6 +140,7 @@ let draw = function() {
   g.clearRect(0, 24, g.getWidth(), g.getHeight() - 24); // clear whole background (w/o widgets)
   var date = new Date(); // Actually the current date, this one is shown
   var timeStr = require("locale").time(date, 1); // Hour and minute
+  timeStr = timeStr.replace(/ *h */i, ":"); // Don't use French time format, it is not supported by the Anton font
   g.setFontAlign(0, 0).setFont("Anton").drawString(timeStr, x, y); // draw time
   if (secondsScreen) {
     y += 65;

--- a/apps/antonclkplus/metadata.json
+++ b/apps/antonclkplus/metadata.json
@@ -2,7 +2,7 @@
   "id": "antonclkplus",
   "name": "Anton Clock Plus",
   "shortName": "Anton Clock+",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A clock using the bold Anton font, optionally showing seconds and date in ISO-8601 format.",
   "readme":"README.md",
   "icon": "app.png",


### PR DESCRIPTION
Now that custom time formats are allowed, you can expect the French time format to be used. Instead of splitting hours and minutes with `:` it uses `h`, sometimes with spaces around it. 

If you try to use the default Anton Clock with this format, it breaks because the Anton font doesn't include "h". The font size is also too big to support anything wider than `:`  between the numbers.

The French format is niche enough that it is probably not worth the extra work and app size to display it correctly, but it is used enough that I think the default app should be able to handle it. My solution is to detect when the French format is being used and replace it with the standard `:` instead.