### PR TITLE
gbmusic: Upgrade to new translation system

### DIFF
--- a/apps/gbmusic/ChangeLog
+++ b/apps/gbmusic/ChangeLog
@@ -11,3 +11,4 @@
       Remove date+time
 0.11: Use default Bangle formatter for booleans
 0.12: Issue newline before GB commands (solves issue with console.log and ignored commands)
+0.13: Upgrade to new translation system

--- a/apps/gbmusic/metadata.json
+++ b/apps/gbmusic/metadata.json
@@ -2,7 +2,7 @@
   "id": "gbmusic",
   "name": "Gadgetbridge Music Controls",
   "shortName": "Music Controls",
-  "version": "0.12",
+  "version": "0.13",
   "description": "Control the music on your Gadgetbridge-connected phone",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot_v1_d.png"},{"url":"screenshot_v1_l.png"},

--- a/apps/gbmusic/settings.js
+++ b/apps/gbmusic/settings.js
@@ -3,8 +3,7 @@
  */
 (function(back) {
   const SETTINGS_FILE = "gbmusic.json",
-    storage = require("Storage"),
-    translate = require("locale").translate;
+    storage = require("Storage");
 
   // initialize with default settings...
   let s = {
@@ -28,12 +27,12 @@
   let menu = {
     "": {"title": "Music Control"},
   };
-  menu[translate("< Back")] = back;
-  menu[translate("Auto start")] = {
+  menu["< Back"] = back;
+  menu[/*LANG*/"Auto start"] = {
     value: !!s.autoStart,
     onchange: save("autoStart"),
   };
-  menu[translate("Simple button")] = {
+  menu[/*LANG*/"Simple button"] = {
     value: !!s.simpleButton,
     onchange: save("simpleButton"),
   };


### PR DESCRIPTION
This removes the deprecated translation system and adds the new translation system.

I have intentionally removed the translation of the `< Back` string because it will be rendered as a red back button with no text, but if it is translated, the red button disappears and a new entry is added to the menu with the translated version of `< Back`. That is not very nice.