### PR TITLE
locale: Release new version

### DIFF
--- a/apps/locale/ChangeLog
+++ b/apps/locale/ChangeLog
@@ -21,3 +21,4 @@
 0.17: Fix regression where long month names were 'undefined' (fix #1641)
 0.18: Fix lint warnings, change anv->janv for fr_BE and fr_CH
 0.19: Deprecate currency information
+0.20: Improve support for meridians

--- a/apps/locale/metadata.json
+++ b/apps/locale/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "locale",
   "name": "Languages",
-  "version": "0.19",
+  "version": "0.20",
   "description": "Translations for different countries",
   "icon": "locale.png",
   "type": "locale",


### PR DESCRIPTION
I forgot to release a new version when updating `locale` in #3535 and #3547