### PR TITLE
Support Gadgetbridge Canned Responses

### DIFF
--- a/apps/android/ChangeLog
+++ b/apps/android/ChangeLog
@@ -37,3 +37,4 @@
 0.35: Implement API to enable/disable acceleration data tracking.
 0.36: Move from wrapper function to {} and let - faster execution at boot
       Allow `calendar-` to take an array of items to remove
+0.37: Support Gadgetbridge canned responses

--- a/apps/android/boot.js
+++ b/apps/android/boot.js
@@ -67,6 +67,9 @@
           title:event.name||/*LANG*/"Call", body:/*LANG*/"Incoming call\n"+event.number});
         require("messages").pushMessage(event);
       },
+      "canned_responses_sync" : function() {
+        require("Storage").writeJSON("replies.json", event.d);
+      },
       // {"t":"alarm", "d":[{h:int,m:int,rep:int},... }
       "alarm" : function() {
         //wipe existing GB alarms

--- a/apps/android/metadata.json
+++ b/apps/android/metadata.json
@@ -2,7 +2,7 @@
   "id": "android",
   "name": "Android Integration",
   "shortName": "Android",
-  "version": "0.36",
+  "version": "0.37",
   "description": "Display notifications/music/etc sent from the Gadgetbridge app on Android. This replaces the old 'Gadgetbridge' Bangle.js widget.",
   "icon": "app.png",
   "tags": "tool,system,messages,notifications,gadgetbridge",

--- a/apps/reply/ChangeLog
+++ b/apps/reply/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New Library!
 0.02: Minor bug fixes
+0.03: Support Gadgetbridge canned responses

--- a/apps/reply/lib.js
+++ b/apps/reply/lib.js
@@ -49,13 +49,12 @@ exports.reply = function (options) {
 
     replies.forEach((reply) => {
       var displayString = reply.disp ?? reply.text;
-      var truncatedDisplayString = g.wrapString(displayString, 120);
+      var wrappedDisplayString = g.wrapString(displayString, 120);
       // Generally handles truncating nicely, but falls down in long runs of emoji since they count as one image
-      if (truncatedDisplayString.length > 1) {
-        truncatedDisplayString = truncatedDisplayString.slice(0,1);
-        truncatedDisplayString[truncatedDisplayString.length-1] += "...";
+      if (wrappedDisplayString.length > 1) {
+        displayString = wrappedDisplayString[0]+"...";
       }
-      menu = Object.defineProperty(menu, truncatedDisplayString, {
+      menu = Object.defineProperty(menu, displayString, {
         value: () => constructReply(options.msg ?? {}, reply.text, resolve, reject),
       });
     });

--- a/apps/reply/lib.js
+++ b/apps/reply/lib.js
@@ -46,11 +46,20 @@ exports.reply = function (options) {
         options.fileOverride || "replies.json",
         true
       ) || [];
+
     replies.forEach((reply) => {
-      menu = Object.defineProperty(menu, reply.text, {
+      var displayString = reply.disp ?? reply.text;
+      var truncatedDisplayString = g.wrapString(displayString, 120);
+      // Generally handles truncating nicely, but falls down in long runs of emoji since they count as one image
+      if (truncatedDisplayString.length > 1) {
+        truncatedDisplayString = truncatedDisplayString.slice(0,1);
+        truncatedDisplayString[truncatedDisplayString.length-1] += "...";
+      }
+      menu = Object.defineProperty(menu, truncatedDisplayString, {
         value: () => constructReply(options.msg ?? {}, reply.text, resolve, reject),
       });
     });
+
     if (!keyboard) delete menu[/*LANG*/ "Compose"];
 
     if (replies.length == 0) {

--- a/apps/reply/metadata.json
+++ b/apps/reply/metadata.json
@@ -1,6 +1,6 @@
 { "id": "reply",
   "name": "Reply Library",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A library for replying to text messages via predefined responses or keyboard",
   "icon": "app.png",
   "type": "module",


### PR DESCRIPTION
I realised during development of the "reply" library that Gadgetbridge contains support for setting canned responses/replies directly through the app, which is preferable to customising via ``interface.html`` as it can support emojis/Unicode using text as bitmaps.

This PR consists of 2 main changes:

- Add a "disp(lay)" field to the ``replies.json`` file used by the reply lib. If display is set for a particular canned reply, it will be shown on the menu instead of the default "text" field, which is what is sent to Gadgetbridge as a response. This way, the "disp(lay)" field shown on the watch can contain image representations of emojis and other Unicode characters, while the reply to Gadgetbridge contains the raw Unicode bytes
- Expand the Android integration app to listen for a ``canned_responses_sync`` message, and write the data contained within that message to the ``replies.json`` file used by the reply lib. I'm planning to open an additional PR against Gadgetbridge on CodeBerg to send this message when canned responses are set:

![image](https://github.com/user-attachments/assets/3d8009d1-c75f-4edd-a536-988bd83c99ec)
