### PR TITLE
calculator: truncate long numbers

### DIFF
--- a/apps/calculator/ChangeLog
+++ b/apps/calculator/ChangeLog
@@ -5,4 +5,4 @@
 0.05: Grid positioning and swipe controls to switch between numbers, operators and special (for Bangle.js 2)
 0.06: Bangle.js 2: Exit with a short press of the physical button
 0.07: Bangle.js 2: Exit by pressing upper left corner of the screen
-0.08: truncate long numbers (and append '-' to displayed value)
+0.08: truncate long numbers (and append '...' to displayed value)

--- a/apps/calculator/ChangeLog
+++ b/apps/calculator/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Grid positioning and swipe controls to switch between numbers, operators and special (for Bangle.js 2)
 0.06: Bangle.js 2: Exit with a short press of the physical button
 0.07: Bangle.js 2: Exit by pressing upper left corner of the screen
+0.08: truncate long numbers (and append '-' to displayed value)

--- a/apps/calculator/app.js
+++ b/apps/calculator/app.js
@@ -10,8 +10,7 @@
 g.clear();
 require("Font7x11Numeric7Seg").add(Graphics);
 
-var DEFAULT_SELECTION_NUMBERS = '5', DEFAULT_SELECTION_OPERATORS = '=', DEFAULT_SELECTION_SPECIALS = 'R';
-var RIGHT_MARGIN = 20;
+var DEFAULT_SELECTION_NUMBERS = '5';
 var RESULT_HEIGHT = 40;
 var RESULT_MAX_LEN = Math.floor((g.getWidth() - 20) / 14);
 var COLORS = {

--- a/apps/calculator/app.js
+++ b/apps/calculator/app.js
@@ -233,7 +233,7 @@ function displayOutput(num) {
     num = num.replace("-","- "); // fix padding for '-'
     g.setFont('7x11Numeric7Seg', 2);
     if (num.length > RESULT_MAX_LEN) {
-      num = num.substr(0, RESULT_MAX_LEN - 1)+'-';
+      num = num.substr(0, RESULT_MAX_LEN - 1)+'...';
     }
   }
   g.setFontAlign(1,0);

--- a/apps/calculator/app.js
+++ b/apps/calculator/app.js
@@ -13,6 +13,7 @@ require("Font7x11Numeric7Seg").add(Graphics);
 var DEFAULT_SELECTION_NUMBERS = '5', DEFAULT_SELECTION_OPERATORS = '=', DEFAULT_SELECTION_SPECIALS = 'R';
 var RIGHT_MARGIN = 20;
 var RESULT_HEIGHT = 40;
+var RESULT_MAX_LEN = Math.floor((g.getWidth() - 20) / 14);
 var COLORS = {
   // [normal, selected]
   DEFAULT: ['#7F8183', '#A6A6A7'],
@@ -261,6 +262,9 @@ function displayOutput(num) {
     num = num.toString();
     num = num.replace("-","- "); // fix padding for '-'
     g.setFont('7x11Numeric7Seg', 2);
+    if (num.length > RESULT_MAX_LEN) {
+      num = num.substr(0, RESULT_MAX_LEN - 1)+'-';
+    }
   }
   g.setFontAlign(1,0);
   g.drawString(num, g.getWidth()-20, RESULT_HEIGHT/2);

--- a/apps/calculator/app.js
+++ b/apps/calculator/app.js
@@ -89,28 +89,11 @@ function prepareScreen(screen, grid, defaultColor) {
 }
 
 function drawKey(name, k, selected) {
-  var rMargin = 0;
-  var bMargin = 0;
   var color = k.color || COLORS.DEFAULT;
   g.setColor(color[selected ? 1 : 0]);
   g.setFont('Vector', 20).setFontAlign(0,0);
   g.fillRect(k.xy[0], k.xy[1], k.xy[2], k.xy[3]);
   g.setColor(-1);
-  // correct margins to center the texts
-  if (name == '0') {
-    rMargin = (RIGHT_MARGIN * 2) - 7;
-  } else if (name === '/') {
-    rMargin = 5;
-  } else if (name === '*') {
-    bMargin = 5;
-    rMargin = 3;
-  } else if (name === '-') {
-    rMargin = 3;
-  } else if (name === 'R' || name === 'N') {
-    rMargin = k.val === 'C' ? 0 : -9;
-  } else if (name === '%') {
-    rMargin = -3;
-  }
   g.drawString(k.val || name, (k.xy[0] + k.xy[2])/2, (k.xy[1] + k.xy[3])/2);
 }
 
@@ -139,29 +122,21 @@ function drawGlobal() {
     screen[k] = specials[k];
   }
   drawKeys();
-  var selected = DEFAULT_SELECTION_NUMBERS;
-  var prevSelected = DEFAULT_SELECTION_NUMBERS;
 }
 function drawNumbers() {
   screen = numbers;
   screenColor = COLORS.DEFAULT;
   drawKeys();
-  var selected = DEFAULT_SELECTION_NUMBERS;
-  var prevSelected = DEFAULT_SELECTION_NUMBERS;
 }
 function drawOperators() {
   screen = operators;
   screenColor =COLORS.OPERATOR;
   drawKeys();
-  var selected = DEFAULT_SELECTION_OPERATORS;
-  var prevSelected = DEFAULT_SELECTION_OPERATORS;
 }
 function drawSpecials() {
   screen = specials;
   screenColor = COLORS.SPECIAL;
   drawKeys();
-  var selected = DEFAULT_SELECTION_SPECIALS;
-  var prevSelected = DEFAULT_SELECTION_SPECIALS;
 }
 
 function getIntWithPrecision(x) {
@@ -219,8 +194,6 @@ function doMath(x, y, operator) {
 }
 
 function displayOutput(num) {
-  var len;
-  var minusMarge = 0;
   g.setBgColor(0).clearRect(0, 0, g.getWidth(), RESULT_HEIGHT-1);
   g.setColor(-1);
   if (num === Infinity || num === -Infinity || isNaN(num)) {
@@ -231,9 +204,7 @@ function displayOutput(num) {
       num = '-INFINITY';
     } else {
       num = 'NOT A NUMBER';
-      minusMarge = -25;
     }
-    len = (num + '').length;
     currNumber = null;
     results = null;
     isDecimal = false;

--- a/apps/calculator/metadata.json
+++ b/apps/calculator/metadata.json
@@ -2,7 +2,7 @@
   "id": "calculator",
   "name": "Calculator",
   "shortName": "Calculator",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Basic calculator reminiscent of MacOs's one. Handy for small calculus.",
   "icon": "calculator.png",
   "screenshots": [{"url":"screenshot_calculator.png"}],


### PR DESCRIPTION
If the resulting number is longer than can be displayed, truncate it so that the (usually) significant part is displayed.
A '-' is append to indicate a truncated number (the font doesn't provide a better character for this than '-').

For example, before this change a simple "5 / 3" resulted in only 6s being displayed - rather than a more useful "1.666666-".