### PR TITLE
locale: Remove meridians from time patterns

### DIFF
--- a/apps/locale/locale.html
+++ b/apps/locale/locale.html
@@ -160,8 +160,6 @@ exports = { name : "system", currencySym:"£",
           "%a":  `${js(locale.abday)}.split(',')[d.getDay()]`,
           "%B":  `${js(locale.month)}.split(',')[d.getMonth()]`,
           "%b":  `${js(locale.abmonth)}.split(',')[d.getMonth()]`,
-          "%p":  `d.getHours()<12?${js(locale.ampm[0].toUpperCase())}:${js(locale.ampm[1].toUpperCase())}`,
-          "%P":  `d.getHours()<12?${js(locale.ampm[0].toLowerCase())}:${js(locale.ampm[1].toLowerCase())}`
         };
 
         var timeN = patternToCode(locale.timePattern[0]);

--- a/apps/locale/locales.js
+++ b/apps/locale/locales.js
@@ -61,8 +61,6 @@ timePattern / datePattern:
     %H	hour (00..23)
     %M	minute (00..59)
     %S	second (00..60)
-    %p	locale's equivalent of either AM or PM; blank if not known
-    %P  like %p, but lower case
     
     
 in locales:


### PR DESCRIPTION
Related to #3534

These formatting symbols are not used, and they should not be used because most apps only work with the time string `HH:MM:SS` and they expect the meridian to be accessible from the separate `meridian` function. I suggest removing these symbols.

The removal changes nothing for existing users of the app.