### PR TITLE
counter: Support translations

### DIFF
--- a/apps/counter/ChangeLog
+++ b/apps/counter/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Added decrement and touch functions
 0.03: Set color - ensures widgets don't end up coloring the counter's text
 0.04: Adopted for BangleJS 2
+0.05: Support translations

--- a/apps/counter/counter.js
+++ b/apps/counter/counter.js
@@ -95,9 +95,9 @@ if (BANGLEJS2) {
 g.clear(1).setFont("6x8");
 g.setBgColor(g.theme.bg).setColor(g.theme.fg);
 if (BANGLEJS2) { 
- g.drawString('Swipe up to increase\nSwipe down to decrease\nPress button to reset.', x, 100 + y);
+ g.drawString([/*LANG*/"Swipe up to increase", /*LANG*/"Swipe down to decrease", /*LANG*/"Press button to reset"].join("\n"), x, 100 + y);
 } else {
- g.drawString('Tap right or BTN1 to increase\nTap left or BTN3 to decrease\nPress BTN2 to reset.', x, 100 + y);
+ g.drawString([/*LANG*/"Tap right or BTN1 to increase", /*LANG*/"Tap left or BTN3 to decrease", /*LANG*/"Press BTN2 to reset"].join("\n"), x, 100 + y);
 }
 
 Bangle.loadWidgets();

--- a/apps/counter/metadata.json
+++ b/apps/counter/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "counter",
   "name": "Counter",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Simple counter",
   "icon": "counter_icon.png",
   "tags": "tool",


### PR DESCRIPTION
Add support for translations with the `/*LANG*/` comment. I have split the strings into separate sentences to make the translation process a bit nicer, and also make it more likely that translations can be reused across apps.