### PR TITLE
fix: widbtstates is not clkinfo

### DIFF
--- a/apps/widbtstates/metadata.json
+++ b/apps/widbtstates/metadata.json
@@ -5,7 +5,7 @@
   "description": "If active, shows a white bluetooth icon, if connected, a blue one (nothing if sleeping)",
   "icon": "widget.png",
   "type": "widget",
-  "tags": "widget,bluetooth,clkinfo",
+  "tags": "widget,bluetooth",
   "provides_widgets" : ["bluetooth"],
   "supports": ["BANGLEJS","BANGLEJS2"],
   "storage": [


### PR DESCRIPTION
Change for sorting on apploader.
Not sure if version bump is needed for this. 
