### PR TITLE
lcdclock/lcdclockplus: fix special characters in clockinfo menus

### DIFF
--- a/apps/lcdclock/ChangeLog
+++ b/apps/lcdclock/ChangeLog
@@ -4,3 +4,4 @@
 0.04: clock_info is loaded before widgets to match other clocks
 0.05: fix alignment of clock items caused by 0.04 (fix #2970)
 0.06: Minor code improvements
+0.07: fix special characters in clockinfo menus 

--- a/apps/lcdclock/app.js
+++ b/apps/lcdclock/app.js
@@ -38,7 +38,7 @@ let clockInfoDraw = (itm, info, options) => {
 
   if (info.img) g.drawImage(info.img, options.x+2, options.y+2);
   var title = clockInfoItems[options.menuA].name;
-  var text = info.text.toString().toUpperCase();
+  var text = info.text.toString().toUpperCase().replace(/[^A-Z0-9]/g, "");
   if (title!="Bangle") g.setFontAlign(1,0).drawString(title.toUpperCase(), options.x+options.w-2, options.y+14);
   if (g.setFont("7Seg:2").stringWidth(text)+8>options.w) g.setFont("7Seg");
   g.setFontAlign(0,0).drawString(text, options.x+options.w/2, options.y+40);

--- a/apps/lcdclock/metadata.json
+++ b/apps/lcdclock/metadata.json
@@ -1,6 +1,6 @@
 { "id": "lcdclock",
   "name": "LCD Clock",
-  "version": "0.06",
+  "version": "0.07",
   "description": "A Casio-style clock, with ClockInfo areas at the top and bottom. Tap them and swipe up/down to toggle between different information",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/lcdclockplus/ChangeLog
+++ b/apps/lcdclockplus/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Minor code improvements
+0.03: fix special characters in clockinfo menus

--- a/apps/lcdclockplus/app.js
+++ b/apps/lcdclockplus/app.js
@@ -51,7 +51,7 @@ let clockInfoDraw = (itm, info, options) => {
   if (info.img) {
     g.drawImage(info.img, options.x+1,options.y+2);
   }
-  var text = info.text.toString().toUpperCase();
+  var text = info.text.toString().toUpperCase().replace(/[^A-Z0-9]/g, "");
   if (g.setFont("7Seg:2").stringWidth(text)+24-2>options.w) g.setFont("7Seg");
   g.setFontAlign(0,-1).drawString(text, options.x+options.w/2+13, options.y+6);
 };

--- a/apps/lcdclockplus/metadata.json
+++ b/apps/lcdclockplus/metadata.json
@@ -1,6 +1,6 @@
 { "id": "lcdclockplus",
   "name": "LCD Clock Plus",
-  "version": "0.02",
+  "version": "0.03",
   "description": "A Casio-style clock, with four ClockInfo areas at the top and bottom. Tap them and swipe up/down and left/right to toggle between different information.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"},{"url":"screenshot2.png"}],


### PR DESCRIPTION
When syncing e.g. weather info on the watch, the display/layout for temperature is broken/misplaced/invisible on `lcdclock` and `lcdclockplus` inside the clockinfo menus.
![screenshot_20240927-105228](https://github.com/user-attachments/assets/1310f635-07cf-4829-a3bf-094dfb00397c)
![screenshot_20240927-105021](https://github.com/user-attachments/assets/529e0dbf-7612-481c-a14b-65f7a6d7d761)

This PR fixed that issue by removing special characters from the clockinfo item text that can't be displayed by `7seg` font. The width calculation for the size definition becomes more accurate, which leads to a correct placement of the text.
![screenshot_20240927-102959](https://github.com/user-attachments/assets/0b4da456-fb6e-4247-af76-d91f3de83c43)
![screenshot_20240927-103607](https://github.com/user-attachments/assets/e573eb2c-2ac6-4f95-a707-248b797d3af0)
