### PR TITLE
hadash: remember scoll positions of menus; "silent" option for service calls

### DIFF
--- a/apps/hadash/ChangeLog
+++ b/apps/hadash/ChangeLog
@@ -1,1 +1,2 @@
 1.00: initial release
+1.01: remember scoll positions of menus; "silent" option for service calls

--- a/apps/hadash/README.md
+++ b/apps/hadash/README.md
@@ -58,8 +58,6 @@ that token in case your watch is stolen or lost.
 ## To-Do
 
 - A better way to configure the menu structure would be useful, something like a custom editor (replacing the jsoneditor).
-- After showing a state or call a service, return to the same point in the menu.
-- Config option for service calls to not show a "successful" prompt
 
 
 ## Author

--- a/apps/hadash/hadash.app.js
+++ b/apps/hadash/hadash.app.js
@@ -28,6 +28,14 @@ var settings = Object.assign({
 }, require('Storage').readJSON(APP_NAME+'.json', true) || {});
 
 
+// wrapper to show a menu (preserving scroll position)
+function showScrollerMenu(menu) {
+  const r = E.showMenu(menu).scroller;
+  scroller = r;
+  return r;
+}
+
+
 // query an entity state
 function queryState(title, id, level) {
   menus[level][''].scroll = scroller.scroll;
@@ -48,10 +56,10 @@ function queryState(title, id, level) {
       if ('unit_of_measurement' in HAresp.attributes)
         msg += HAresp.attributes.unit_of_measurement;
     }
-    E.showPrompt(msg, { title: title4prompt, buttons: {OK: true} }).then((v) => { scroller = E.showMenu(menus[level]).scroller; });
+    E.showPrompt(msg, { title: title4prompt, buttons: {OK: true} }).then((v) => { showScrollerMenu(menus[level]); });
   }).catch( error => {
     console.log(error);
-    E.showPrompt('Error querying state!', { title: title, buttons: {OK: true} }).then((v) => { scroller = E.showMenu(menus[level]).scroller; });
+    E.showPrompt('Error querying state!', { title: title, buttons: {OK: true} }).then((v) => { showScrollerMenu(menus[level]); });
   });
 }
 
@@ -69,14 +77,14 @@ function callService(title, domain, service, data, level, silent) {
     },
   }).then(data => {
     //console.log(data);
-    if (silent) {
-      scroller = E.showMenu(menus[level]).scroller;
-    } else {
-      E.showPrompt('Service called successfully', { title: title, buttons: {OK: true} }).then((v) => { scroller = E.showMenu(menus[level]).scroller; });
+    if (! silent) {
+      return E.showPrompt('Service called successfully', { title: title, buttons: {OK: true} });
     }
+  }).then(() => {
+    showScrollerMenu(menus[level]);
   }).catch( error => {
     console.log(error);
-    E.showPrompt('Error calling service!', { title: title, buttons: {OK: true} }).then((v) => { scroller = E.showMenu(menus[level]).scroller; });
+    E.showPrompt('Error calling service!', { title: title, buttons: {OK: true} }).then((v) => { showScrollerMenu(menus[level]); });
   });
 }
 
@@ -100,7 +108,7 @@ function getServiceInputData(entry, level) {
   let serviceInputMenu = {
     '': {
       'title': entry.title,
-      'back': () => scroller = E.showMenu(menus[level]).scroller
+      'back': () => showScrollerMenu(menus[level])
     },
   };
   let CBs = {};
@@ -211,11 +219,11 @@ function showSubMenu(level, title, entries) {
   menus[level] = {
     '': {
       'title': title,
-      'back': () => scroller = E.showMenu(menus[level - 1]).scroller
+      'back': () => showScrollerMenu(menus[level - 1])
     },
   };
   addMenuEntries(level, entries);
-  scroller = E.showMenu(menus[level]).scroller;
+  showScrollerMenu(menus[level]);
 }
 
 
@@ -232,8 +240,8 @@ addMenuEntries(0, settings.menu);
 
 // check required configuration
 if (! settings.HAbaseUrl || ! settings.HAtoken) {
-  E.showAlert('The app is not yet configured!', 'HA-Dash').then(() => scroller = E.showMenu(menus[0]).scroller);
+  E.showAlert('The app is not yet configured!', 'HA-Dash').then(() => showScrollerMenu(menus[0]));
 } else {
-  scroller = E.showMenu(menus[0]).scroller;
+  showScrollerMenu(menus[0]);
 }
 

--- a/apps/hadash/interface.html
+++ b/apps/hadash/interface.html
@@ -55,6 +55,7 @@
   "title": "Menu entry title",
   "domain": "HA Domain",
   "service": "HA Service",
+  "silent": (true|false),
   "data": {
     "key": "value"
   }
@@ -64,8 +65,10 @@
         under the Developer tools -&gt; Services. Use the "Go to YAML Mode"
         function to see the actual names and values. The domain and service
         parts are the 2 parts of the service name which are separated by a dot.
-        Any (optional) data key/value pairs can be added under the "data"
-        field. For example, here's a service call YAML:
+        If the optional "silent" boolean is set to true (false is default),
+        there will be no message in case of a successful call. Any (optional)
+        data key/value pairs can be added under the "data" field. For example,
+        here's a service call YAML:
         <pre class="code" data-lang="YAML">
 service: persistent_notification.create
 data:
@@ -207,7 +210,7 @@ target:
           { type: 'menu', title: 'Sub-menu', data:
             [
               { type: 'state', title: 'Check for Supervisor updates', id: 'update.home_assistant_supervisor_update' },
-              { type: 'service', title: 'Restart HA', domain: 'homeassistant', service: 'restart', data: {} }
+              { type: 'service', title: 'Restart HA', domain: 'homeassistant', service: 'restart', silent: true, data: {} }
             ]
           },
           { type: 'service', title: 'Custom Notification', domain: 'persistent_notification', service: 'create',

--- a/apps/hadash/metadata.json
+++ b/apps/hadash/metadata.json
@@ -2,7 +2,7 @@
   "id": "hadash",
   "name": "Home-Assistant Dashboard",
   "shortName":"HA-Dash",
-  "version":"1.00",
+  "version":"1.01",
   "description": "Interact with Home-Assistant (query states, call services)",
   "icon": "hadash.png",
   "screenshots": [{ "url": "screenshot.png" }],


### PR DESCRIPTION
This PR implements 2 suggestions by @bobrippling for the HA-Dashboard (hadash):
- return to the same position within the menu (after a HA query/call)
- a "silent" option for service calls