### PR TITLE
promenu: don't modify the menu object

### DIFF
--- a/apps/promenu/ChangeLog
+++ b/apps/promenu/ChangeLog
@@ -9,3 +9,4 @@
       handling of E.showMenu() with no arguments
 0.06: Fix lower bounding of numeric values
 0.07: Fix bug with alarms app (scroller) and correctly show images
+0.08: Fix bug with modifying menu - allows hadash to save scroll positions

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -13,9 +13,7 @@ E.showMenu = function (items) {
         g.setColor(255, 255, 255);
     };
     var options = items && items[""] || {};
-    if (items)
-        delete items[""];
-    var menuItems = Object.keys(items);
+    var menuItems = Object.keys(items).filter(function (x) { return x.length; });
     var fontHeight = options.fontHeight || 25;
     var selected = options.scroll || options.selected || 0;
     var ar = Bangle.appRect;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -15,8 +15,7 @@ E.showMenu = (items?: Menu): MenuInstance => {
     g.setColor(255, 255, 255);
   };
   let options = items && items[""] || {};
-  if (items) delete items[""];
-  const menuItems = Object.keys(items);
+  const menuItems = Object.keys(items).filter(x => x.length);
 
   const fontHeight = options.fontHeight||25;
 

--- a/apps/promenu/metadata.json
+++ b/apps/promenu/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "promenu",
   "name": "Pro Menu",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Replace the built in menu function. Supports Bangle.js 1 and Bangle.js 2.",
   "icon": "icon.png",
   "type": "bootloader",


### PR DESCRIPTION
This fixes `hadash`'s use of `showMenu`, which uses `menu[""]` (previously `delete`'d)