### PR TITLE
alarm: toggle alarms from main menu

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -53,3 +53,5 @@
 0.48: Use datetimeinput for Events, if available. Scroll back when getting out of group.  Menu date format setting for shorter dates on current year.
 0.49: fix uncaught error if no scroller (Bangle 1). Would happen when trying
 	to select an alarm in the main menu.
+0.50: Bangle.js 2: Long touch of alarm in main menu toggle it on/off. Touching the icon on
+	the right will do the same.

--- a/apps/alarm/README.md
+++ b/apps/alarm/README.md
@@ -20,6 +20,8 @@ It uses the [`sched` library](https://github.com/espruino/BangleApps/blob/master
   - `Disable All` &rarr; Disable _all_ enabled alarms & timers
   - `Delete All` &rarr; Delete _all_ alarms & timers
 
+On Bangle.js 2 it's possible to toggle alarms, timers and events from the main menu. This is done by clicking the indicator icons of corresponding entries. Or long pressing anywhere on them.
+
 ## Creator
 
 - [Gordon Williams](https://github.com/gfwilliams)
@@ -29,6 +31,7 @@ It uses the [`sched` library](https://github.com/espruino/BangleApps/blob/master
 - [Alessandro Cocco](https://github.com/alessandrococco) - New UI, full rewrite, new features
 - [Sabin Iacob](https://github.com/m0n5t3r) - Auto snooze support
 - [storm64](https://github.com/storm64) - Fix redrawing in submenus
+- [thyttan](https://github.com/thyttan) - Toggle alarms directly from main menu.
 
 ## Attributions
 

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -88,13 +88,23 @@ function showMainMenu(scroll, group, scrollback) {
   const getGroups = settings.showGroup && !group;
   const groups = getGroups ? {} : undefined;
   var showAlarm;
+  const getIcon = (e)=>{return e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff);};
 
   alarms.forEach((e, index) => {
     showAlarm = !settings.showGroup || (group ? e.group === group : !e.group);
     if(showAlarm) {
-      menu[trimLabel(getLabel(e),40)] = {
-        value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),
-        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, scroller?scroller.scroll:undefined, group)
+      const label = trimLabel(getLabel(e),40);
+      menu[label] = {
+        value: e.on,
+        onchange: (v, touch) => {
+          if (touch && (2==touch.type || 145<touch.x)) { // Long touch or touched icon.
+            e.on = v;
+            saveAndReload();
+          } else {
+            setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, scroller?scroller.scroll:undefined, group);
+          }
+        },
+        format: v=>getIcon(e)
       };
     } else if (getGroups) {
       groups[e.group] = undefined;

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.49",
+  "version": "0.50",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
This will let the user toggle existing alarms, timers and events from the main menu of the app. Either by long touch of the menu entries or by touch on the icon on the right.

This change requires to send the touch event used in showScroller through to `alarm` app. Both `showScroller` and `showMenu` needs changes to make it work. So in this draft state of this PR I add two boot files for modifying those two functions. Have a look at the individual commits to see the diff from firmware version, which I copied over and committed unchanged before tweaking them.

Test it via: https://thyttan.github.io/BangleApps/?id=alarm

The tests fail for the showMenu boot file, but it works on the watch. Enough for testing purpouses.