### PR TITLE
alarm: fix uncaught error if no scroller (Bangle 1)

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -51,3 +51,5 @@
 0.46: Show alarm groups if the Show Group setting is ON.  Scroll alarms menu back to previous position when getting back to it.
 0.47: Fix wrap around when snoozed through midnight
 0.48: Use datetimeinput for Events, if available. Scroll back when getting out of group.  Menu date format setting for shorter dates on current year.
+0.49: fix uncaught error if no scroller (Bangle 1). Would happen when trying
+	to select an alarm in the main menu.

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -94,7 +94,7 @@ function showMainMenu(scroll, group, scrollback) {
     if(showAlarm) {
       menu[trimLabel(getLabel(e),40)] = {
         value: e.on ? (e.timer ? iconTimerOn : iconAlarmOn) : (e.timer ? iconTimerOff : iconAlarmOff),
-        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, scroller.scroll, group)
+        onchange: () => setTimeout(e.timer ? showEditTimerMenu : showEditAlarmMenu, 10, e, index, undefined, scroller?scroller.scroll:undefined, group)
       };
     } else if (getGroups) {
       groups[e.group] = undefined;
@@ -102,7 +102,7 @@ function showMainMenu(scroll, group, scrollback) {
   });
 
   if (!group) {
-    Object.keys(groups).sort().forEach(g => menu[g] = () => showMainMenu(null, g, scroller.scroll));
+    Object.keys(groups).sort().forEach(g => menu[g] = () => showMainMenu(null, g, scroller?scroller.scroll:undefined));
     menu[/*LANG*/"Advanced"] = () => showAdvancedMenu();
   }
 

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.48",
+  "version": "0.49",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
This PR seems to fix the following. Tested in the Bangle.js 1 emulator on the Web IDE.

Just tried on emulated Bangle.js 1 and got:

```console
Uncaught Error: Can't read property 'scroll' of undefined
 at line 20 col 1070 in alarm.app.js
...mMenu,10,e,index,undefined,scroller.scroll,group)
                                      ^
in function "onchange" called from line 3 col 106
...onchange)a.onchange(a.value);Bangle.touchHandler==u&&d.draw(...
                              ^
in function "select" called from line 1 col 22
a?d.move(a):d.select()
                     ^
in function "d" called from line 1 col 3
d()
  ^
in function called from system
> 
```

Looking at the git blame it seems to have been around since 2023-11-14.

_Originally posted by @thyttan in https://github.com/espruino/BangleApps/issues/3604#issuecomment-2397608781_
            