### PR TITLE
promenu: don't show "..." when a string is fully scrolled in

### DIFF
--- a/apps/promenu/ChangeLog
+++ b/apps/promenu/ChangeLog
@@ -10,3 +10,4 @@
 0.06: Fix lower bounding of numeric values
 0.07: Fix bug with alarms app (scroller) and correctly show images
 0.08: Fix bug with modifying menu - allows hadash to save scroll positions
+0.09: Don't show "..." if a string isn't truncated (i.e. scrolled)

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -43,17 +43,21 @@ E.showMenu = function (items) {
             .setColor(hl ? g.theme.fgH : g.theme.fg)
             .setFontAlign(-1, -1);
         var vplain = v.indexOf("\0") < 0;
-        var truncated = true;
-        if (vplain && name.length >= 17 - v.length && typeof item === "object") {
-            g.drawString(name.substring(nameScroll, nameScroll + 12 - v.length) + "...", x + 3.7, y + 2.7);
+        var truncated = false;
+        var drawn = false;
+        if (vplain) {
+            var isFunc = typeof item === "function";
+            var lim = isFunc ? 15 : 17 - v.length;
+            if (name.length >= lim) {
+                var len = isFunc ? 15 : 12 - v.length;
+                var dots = name.length - nameScroll > len ? "..." : "";
+                g.drawString(name.substring(nameScroll, nameScroll + len) + dots, x + 3.7, y + 2.7);
+                drawn = true;
+                truncated = true;
+            }
         }
-        else if (vplain && name.length >= 15) {
-            g.drawString(name.substring(nameScroll, nameScroll + 15) + "...", x + 3.7, y + 2.7);
-        }
-        else {
+        if (!drawn)
             g.drawString(name, x + 3.7, y + 2.7);
-            truncated = false;
-        }
         var xo = x2;
         if (selectEdit && idx === selected) {
             xo -= 24 + 1;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -64,15 +64,27 @@ E.showMenu = (items?: Menu): MenuInstance => {
       .setFontAlign(-1, -1);
 
     const vplain = v.indexOf("\0") < 0;
-    let truncated = true;
-    if(vplain && name.length >= 17 - v.length && typeof item === "object"){
-      g.drawString(name.substring(nameScroll, nameScroll + 12 - v.length) + "...", x + 3.7, y + 2.7);
-    }else if(vplain && name.length >= 15){
-      g.drawString(name.substring(nameScroll, nameScroll + 15) + "...", x + 3.7, y + 2.7);
-    }else{
-      g.drawString(name, x + 3.7, y + 2.7);
-      truncated = false;
+    let truncated = false;
+    let drawn = false;
+    if(vplain){
+      const isFunc = typeof item === "function";
+      const lim = isFunc ? 15 : 17 - v.length;
+
+      if(name.length >= lim){
+        const len = isFunc ? 15 : 12 - v.length;
+        const dots = name.length - nameScroll > len ? "..." : "";
+
+        g.drawString(
+          name.substring(nameScroll, nameScroll + len) + dots,
+          x + 3.7,
+          y + 2.7
+        );
+        drawn = true;
+        truncated = true;
+      }
     }
+    if(!drawn)
+      g.drawString(name, x + 3.7, y + 2.7);
 
     let xo = x2;
     if (selectEdit && idx === selected) {

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -1,5 +1,9 @@
 type ActualMenuItem = Exclude<Menu["..."], MenuOptions | undefined>;
 
+const enum Consts {
+  NAME_SCROLL_PAD = 5,
+}
+
 E.showMenu = (items?: Menu): MenuInstance => {
   const RectRnd = (x1: number, y1: number, x2: number, y2: number, r: number) => {
     const pp = [];
@@ -138,7 +142,7 @@ E.showMenu = (items?: Menu): MenuInstance => {
           ) => {
             drawLine(name, v, item, idx, x, iy, nameScroll);
             nameScroll += 1;
-            if (nameScroll >= name.length - 5) nameScroll = 0;
+            if (nameScroll >= name.length - Consts.NAME_SCROLL_PAD) nameScroll = 0;
           }, 300, name, v, item, idx, x, iy);
         }
 

--- a/apps/promenu/metadata.json
+++ b/apps/promenu/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "promenu",
   "name": "Pro Menu",
-  "version": "0.08",
+  "version": "0.09",
   "description": "Replace the built in menu function. Supports Bangle.js 1 and Bangle.js 2.",
   "icon": "icon.png",
   "type": "bootloader",


### PR DESCRIPTION
Following on from #3570, truncated titles which are scrolled in don't have "..." appended.

```
"Settings for cl..."
"ettings for clo..."
"ttings for cloc..."
"tings for clock   "
"ings for clock    "
"ngs for clock     "
```
