### PR TITLE
sched interface: handle app-based alarms

### DIFF
--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -173,7 +173,7 @@ function renderAlarm(alarm, exists) {
       };
     }
   }
-  tdType.textContent = type;
+  tdType.textContent = type + (alarm.appid ? `\n(${alarm.appid})` : "");
   if (!exists) {
     const asterisk = document.createElement('sup');
     asterisk.textContent = '*';

--- a/apps/sched/interface.html
+++ b/apps/sched/interface.html
@@ -331,6 +331,10 @@ function getData() {
       alarms.sort((a, b) => {
         let x;
 
+        // move app specific alarms to the bottom
+        x = !!a.appid - !!b.appid;
+        if(x) return x;
+
         x = !!b.date - !!a.date;
         if(x) return x;
 


### PR DESCRIPTION
This displays if an alarm is from an app (`appid`) and sorts it to the bottom if so