### PR TITLE
drained: fix not restoring when charge threshold met

### DIFF
--- a/apps/drained/ChangeLog
+++ b/apps/drained/ChangeLog
@@ -5,3 +5,4 @@
 0.04: Enhance menu: enable bluetooth, visit settings & visit recovery
 0.05: Enhance menu: permit toggling bluetooth
 0.06: Display clock in green when charging, with "charging" text
+0.07: Correctly restore full power when the charged threshold is reached

--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -88,7 +88,7 @@ var reload = function () {
 };
 reload();
 Bangle.emit("drained", E.getBattery());
-var _a = require("Storage").readJSON("".concat(app, ".setting.json"), true) || {}, _b = _a.keepStartup, keepStartup = _b === void 0 ? true : _b, _c = _a.restore, restore = _c === void 0 ? 20 : _c, _d = _a.exceptions, exceptions = _d === void 0 ? ["widdst.0"] : _d;
+var _a = require("Storage").readJSON("".concat(app, ".setting.json"), true) || {}, _b = _a.keepStartup, keepStartup = _b === void 0 ? true : _b, _c = _a.restore, restore = _c === void 0 ? 20 : _c, _d = _a.exceptions, exceptions = _d === void 0 ? ["widdst.0"] : _d, _e = _a.interval, interval = _e === void 0 ? 10 : _e;
 function drainedRestore() {
     if (!keepStartup) {
         try {
@@ -101,18 +101,14 @@ function drainedRestore() {
     load();
 }
 var checkCharge = function () {
-    if (E.getBattery() < restore) {
+    if (!Bangle.isCharging() || E.getBattery() < restore) {
         draw();
         return;
     }
     drainedRestore();
 };
-if (Bangle.isCharging())
-    checkCharge();
-Bangle.on("charging", function (charging) {
-    if (charging)
-        checkCharge();
-});
+checkCharge();
+drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
 if (!keepStartup) {
     var storage = require("Storage");
     for (var _i = 0, exceptions_1 = exceptions; _i < exceptions_1.length; _i++) {

--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -101,14 +101,20 @@ function drainedRestore() {
     load();
 }
 var checkCharge = function () {
-    if (!Bangle.isCharging() || E.getBattery() < restore) {
+    if (E.getBattery() < restore) {
         draw();
         return;
     }
     drainedRestore();
 };
-checkCharge();
-drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+if (Bangle.isCharging())
+    checkCharge();
+Bangle.on("charging", function (charging) {
+    if (drainedInterval)
+        drainedInterval = clearInterval(drainedInterval);
+    if (charging)
+        drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+});
 if (!keepStartup) {
     var storage = require("Storage");
     for (var _i = 0, exceptions_1 = exceptions; _i < exceptions_1.length; _i++) {

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -115,7 +115,7 @@ reload();
 Bangle.emit("drained", E.getBattery());
 
 // restore normal boot on charge
-const { keepStartup = true, restore = 20, exceptions = ["widdst.0"] }: DrainedSettings
+const { keepStartup = true, restore = 20, exceptions = ["widdst.0"], interval = 10 }: DrainedSettings
   = require("Storage").readJSON(`${app}.setting.json`, true) || {};
 
 // re-enable normal boot code when we're above a threshold:
@@ -131,19 +131,15 @@ function drainedRestore() { // "public", to allow users to call
 }
 
 const checkCharge = () => {
-  if(E.getBattery() < restore) {
+  if(!Bangle.isCharging() || E.getBattery() < restore) {
     draw();
     return;
   }
   drainedRestore();
 };
 
-if (Bangle.isCharging())
-  checkCharge();
-
-Bangle.on("charging", charging => {
-  if(charging) checkCharge();
-});
+checkCharge();
+drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
 
 if(!keepStartup){
   const storage = require("Storage");

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -131,15 +131,22 @@ function drainedRestore() { // "public", to allow users to call
 }
 
 const checkCharge = () => {
-  if(!Bangle.isCharging() || E.getBattery() < restore) {
+  if(E.getBattery() < restore) {
     draw();
     return;
   }
   drainedRestore();
 };
 
-checkCharge();
-drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+if (Bangle.isCharging())
+  checkCharge();
+
+Bangle.on("charging", charging => {
+  if(drainedInterval)
+    drainedInterval = clearInterval(drainedInterval) as undefined;
+  if(charging)
+    drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+});
 
 if(!keepStartup){
   const storage = require("Storage");

--- a/apps/drained/metadata.json
+++ b/apps/drained/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "drained",
   "name": "Drained",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Switches to displaying a simple clock when the battery percentage is low, and disables some peripherals",
   "readme": "README.md",
   "icon": "icon.png",


### PR DESCRIPTION
previously the assumption was that the `"changing"` event would be fired periodically when charging.

fixes #3625