### PR TITLE
messagegui: stop buzzing for a message when it's removed

### DIFF
--- a/apps/android/lib.js
+++ b/apps/android/lib.js
@@ -44,7 +44,7 @@ exports.gbHandler = (event) => {
     "musicinfo" : function() {
       require("messages").pushMessage(Object.assign(event, {t:"modify",id:"music",title:"Music"}));
     },
-    // {"t":"call","cmd":"incoming/end","name":"Bob","number":"12421312"})
+    // {"t":"call","cmd":"incoming/end/start/outgoing","name":"Bob","number":"12421312"})
     "call" : function() {
       Object.assign(event, {
         t:event.cmd=="incoming"?"add":"remove",

--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -110,3 +110,4 @@
 0.81: Fix issue stopping Music message for being marked as read
       Make sure play button image is transparent
       Add top-right menu to music playback to allow message to be deleted
+0.82: Stop buzzing when a message is removed (e.g. call answered)

--- a/apps/messagegui/lib.js
+++ b/apps/messagegui/lib.js
@@ -18,6 +18,10 @@ exports.listener = function(type, msg) {
     clearTimeout(exports.messageTimeout);
     delete exports.messageTimeout;
   }
+  if (type==="clearAll") {
+    require("messages").stopBuzz();
+    return;
+  }
   if (msg.t==="remove") {
     // we won't open the UI for removed messages, so make sure to delete it from flash
     if (Bangle.MESSAGES) {

--- a/apps/messagegui/lib.js
+++ b/apps/messagegui/lib.js
@@ -25,6 +25,8 @@ exports.listener = function(type, msg) {
       require("messages").apply(msg, Bangle.MESSAGES);
       if (!Bangle.MESSAGES.length) delete Bangle.MESSAGES;
     }
+    if(type!=="music")
+      require("messages").stopBuzz();
     return require("messages").save(msg); // always write removal to flash
   }
 

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.81",
+  "version": "0.82",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
e.g. a call is answered, and the user has `auto-open` disabled. This allows a user to have infinite buzz (`Vibrate timer`) while the phone is ringing, but the buzz will stop when the call is answered (or declined)