### PR TITLE
dtlaunch: postpone load icons not initially needed

### DIFF
--- a/apps/dtlaunch/ChangeLog
+++ b/apps/dtlaunch/ChangeLog
@@ -30,3 +30,4 @@ when moving pages. Add caching for faster startups.
 0.23: Bangle 1: Fix issue with missing icons, added touch screen interactions
 0.24: Add buzz-on-interaction setting
 0.25: Minor code improvements
+0.26: Bangle 2: Postpone loading icons that are not needed initially.

--- a/apps/dtlaunch/app-b2.js
+++ b/apps/dtlaunch/app-b2.js
@@ -33,10 +33,10 @@
     s.writeJSON("launch.cache.json", launchCache);
   }
   let apps = launchCache.apps;
-  apps.forEach(app=>{
-    if (app.icon)
-      app.icon = s.read(app.icon); // should just be a link to a memory area
-  });
+  for (let i = 0; i < 4; i++) { // Initially only load icons for the current page.
+    if (apps[i].icon)
+      apps[i].icon = s.read(apps[i].icon); // should just be a link to a memory area
+  }
 
   let Napps = apps.length;
   let Npages = Math.ceil(Napps/4);
@@ -100,6 +100,11 @@
   Bangle.drawWidgets(); // To immediately update widget field to follow current theme - remove leftovers if previous app set custom theme.
   Bangle.loadWidgets();
   drawPage(0);
+
+  for (let i = 4; i < apps.length; i++) { // Load the rest of the app icons that were not initially.
+    if (apps[i].icon)
+      apps[i].icon = s.read(apps[i].icon); // should just be a link to a memory area
+  }
 
   let swipeListenerDt = function(dirLeftRight, dirUpDown){
     updateTimeoutToClock();

--- a/apps/dtlaunch/metadata.json
+++ b/apps/dtlaunch/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "dtlaunch",
   "name": "Desktop Launcher",
-  "version": "0.25",
+  "version": "0.26",
   "description": "Desktop style App Launcher with six (four for Bangle 2) apps per page - fast access if you have lots of apps installed.",
   "screenshots": [{"url":"shot1.png"},{"url":"shot2.png"},{"url":"shot3.png"}],
   "icon": "icon.png",


### PR DESCRIPTION
Draw the first screen, then load in the rest of the icons from storage.