### PR TITLE
podadrem/spotrem: Fix linter warnings

### DIFF
--- a/apps/podadrem/ChangeLog
+++ b/apps/podadrem/ChangeLog
@@ -8,6 +8,6 @@ Addict.
 0.07: Remove just the specific listeners to not interfere with Quick Launch
 when fastloading.
 0.08: Issue newline before GB commands (solves issue with console.log and ignored commands)
-0.09: Don't send the gadgetbridge wake command twice. Once should do since we
-	issue newline before GB commands.
+0.09: Don't send the gadgetbridge wake command twice. Once should do since we issue newline before GB commands.
 0.10: Minor code improvements
+0.11: Fix a warning from the linter.

--- a/apps/podadrem/app.js
+++ b/apps/podadrem/app.js
@@ -127,7 +127,7 @@ The functions for interacting with Android and the Podcast Addict app
 let pkg = "com.bambuna.podcastaddict";
 let standardCls = pkg + ".receiver.PodcastAddictPlayerReceiver";
 let updateCls = pkg + ".receiver.PodcastAddictBroadcastReceiver";
-let speed = 1.0;
+//let speed = 1.0;
 
 let simpleSearch = "";
 
@@ -269,15 +269,15 @@ let speedMenu = {
                 }
   },
   "Regular Speed": () => {
-    speed = 1.0;
+    //speed = 1.0;
     btMsg("service", standardCls, "player.1xspeed");
   },
   "1.5x Regular Speed": () => {
-    speed = 1.5;
+    //speed = 1.5;
     btMsg("service", standardCls, "player.1.5xspeed");
   },
   "2x Regular Speed": () => {
-    speed = 2.0;
+    //speed = 2.0;
     btMsg("service", standardCls, "player.2xspeed");
   },
   //"Faster" : ()=>{speed+=0.1; speed=((speed>5.0)?5.0:speed); btMsg("service",standardCls,"player.customspeed",{arg1:speed});},

--- a/apps/podadrem/metadata.json
+++ b/apps/podadrem/metadata.json
@@ -2,7 +2,7 @@
   "id": "podadrem",
   "name": "Podcast Addict Remote",
   "shortName": "PA Remote",
-  "version": "0.10",
+  "version": "0.11",
   "description": "Control Podcast Addict on your android device.",
   "readme": "README.md",
   "type": "app",

--- a/apps/spotrem/ChangeLog
+++ b/apps/spotrem/ChangeLog
@@ -7,9 +7,7 @@
 0.07: Remove just the specific listeners to not interfere with Quick Launch
 when fastloading.
 0.08: Issue newline before GB commands (solves issue with console.log and ignored commands)
-0.09: Don't send the gadgetbridge wake command twice. Once should do since we
-	issue newline before GB commands.
+0.09: Don't send the gadgetbridge wake command twice. Once should do since we issue newline before GB commands.
 0.10: Some refactoring to shorten the code.
-0.11: Further refactoring to shorten the code. Fixed search and play that was
-	broken in v0.10.
-
+0.11: Further refactoring to shorten the code. Fixed search and play that was broken in v0.10.
+0.12: Fix some warnings from the linter.

--- a/apps/spotrem/app.js
+++ b/apps/spotrem/app.js
@@ -13,7 +13,7 @@ let dark = g.theme.dark; // bool
 let gfx = function() {
   widgetUtils.hide();
   R = Bangle.appRect;
-  marigin = 8;
+  const MARIGIN = 8;
   // g.drawString(str, x, y, solid)
   g.clearRect(R);
   g.reset();
@@ -21,38 +21,38 @@ let gfx = function() {
   if (dark) {g.setColor(0x07E0);} else {g.setColor(0x03E0);} // Green on dark theme, DarkGreen on light theme.
   g.setFont("4x6:2");
   g.setFontAlign(1, 0, 0);
-  g.drawString("->", R.x2 - marigin, R.y + R.h/2);
+  g.drawString("->", R.x2 - MARIGIN, R.y + R.h/2);
 
   g.setFontAlign(-1, 0, 0);
-  g.drawString("<-", R.x + marigin, R.y + R.h/2);
+  g.drawString("<-", R.x + MARIGIN, R.y + R.h/2);
 
   g.setFontAlign(-1, 0, 1);
-  g.drawString("<-", R.x + R.w/2, R.y + marigin);
+  g.drawString("<-", R.x + R.w/2, R.y + MARIGIN);
 
   g.setFontAlign(1, 0, 1);
-  g.drawString("->", R.x + R.w/2, R.y2 - marigin);
+  g.drawString("->", R.x + R.w/2, R.y2 - MARIGIN);
 
   g.setFontAlign(0, 0, 0);
   g.drawString("Play\nPause", R.x + R.w/2, R.y + R.h/2);
 
   g.setFontAlign(-1, -1, 0);
-  g.drawString("Menu", R.x + 2*marigin, R.y + 2*marigin);
+  g.drawString("Menu", R.x + 2*MARIGIN, R.y + 2*MARIGIN);
 
   g.setFontAlign(-1, 1, 0);
-  g.drawString("Wake", R.x + 2*marigin, R.y + R.h - 2*marigin);
+  g.drawString("Wake", R.x + 2*MARIGIN, R.y + R.h - 2*MARIGIN);
 
   g.setFontAlign(1, -1, 0);
-  g.drawString("Srch", R.x + R.w - 2*marigin, R.y + 2*marigin);
+  g.drawString("Srch", R.x + R.w - 2*MARIGIN, R.y + 2*MARIGIN);
 
   g.setFontAlign(1, 1, 0);
-  g.drawString("Saved", R.x + R.w - 2*marigin, R.y + R.h - 2*marigin);
+  g.drawString("Saved", R.x + R.w - 2*MARIGIN, R.y + R.h - 2*MARIGIN);
 };
 
 // Touch handler for main layout
 let touchHandler = function(_, xy) {
-  x = xy.x;
-  y = xy.y;
-  len = (R.w<R.h+1)?(R.w/3):(R.h/3);
+  let x = xy.x;
+  let y = xy.y;
+  let len = (R.w<R.h+1)?(R.w/3):(R.h/3);
 
   // doing a<b+1 seemed faster than a<=b, also using a>b-1 instead of a>b.
   if ((R.x-1<x && x<R.x+len) && (R.y-1<y && y<R.y+len)) {
@@ -82,7 +82,7 @@ let touchHandler = function(_, xy) {
     spotifyWidget("NEXT");
   } else if ((R.x-1<x && x<R.x2+1) && (R.y-1<y && y<R.y2+1)){
     //play/pause
-    playPause = isPaused?"play":"pause";
+    let playPause = isPaused?"play":"pause";
     Bangle.musicControl(playPause);
     isPaused = !isPaused;
   }

--- a/apps/spotrem/metadata.json
+++ b/apps/spotrem/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "spotrem",
   "name": "Remote for Spotify",
-  "version": "0.11",
+  "version": "0.12",
   "description": "Control spotify on your android device.",
   "readme": "README.md",
   "type": "app",


### PR DESCRIPTION
On `edgewrite` keyboard the top left corner would be overwritten with a
square in solid background colour, the size and position of the red back
button of the previous menu.

Reproducible with with `edgewrite` installed and this code:
```js
E.showMenu({
  "": {title: "hi there", back: ()=>{}},
  "this": ()=>{}
});
//E.showMenu();
require("textinput").input({text:"Top left gets cleard by menu back button removal?"});
```

First brought up on https://github.com/espruino/BangleApps/pull/3632#discussion_r1825290432.