### PR TITLE
Update reply lib metadata.json to support Bangle JS 1

### DIFF
--- a/apps/reply/metadata.json
+++ b/apps/reply/metadata.json
@@ -6,7 +6,7 @@
   "type": "module",
   "provides_modules" : ["reply"],
   "tags": "",
-  "supports" : ["BANGLEJS2"],  
+  "supports": ["BANGLEJS","BANGLEJS2"],
   "readme": "README.md",
   "interface": "interface.html",
   "storage": [


### PR DESCRIPTION
The reply lib metadata.json file currently does not list Bangle JS 1 support, which then blocks newer versions of the Messages app from installing on Bangle JS 1 devices as the lib can't be found. This adds support for Bangle JS 1, as I've tested in the emulator and there doesn't appear to be anything blocking this running on both devices