### PR TITLE
EdgeWrite: Draw initial text after setUI in case it removes a back button

### DIFF
--- a/apps/kbedgewrite/ChangeLog
+++ b/apps/kbedgewrite/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Accents and extended mode characters
+0.03: Bugfix - draw initial text after the back button has been removed

--- a/apps/kbedgewrite/lib.js
+++ b/apps/kbedgewrite/lib.js
@@ -352,11 +352,6 @@ exports.input = function(options) {
     }
   };
 
-  // Draw initial string
-  require("widget_utils").hide();
-  g.setBgColor(g.theme.bg);
-  wrapText();
-  draw();
 
   return new Promise((resolve,reject) => {
     Bangle.setUI({
@@ -385,6 +380,13 @@ exports.input = function(options) {
         }
       }
     });
+
+    // Draw initial string
+    require("widget_utils").hide();
+    g.setBgColor(g.theme.bg);
+    wrapText();
+    draw();
+
   });
 
 

--- a/apps/kbedgewrite/metadata.json
+++ b/apps/kbedgewrite/metadata.json
@@ -1,6 +1,6 @@
 { "id": "kbedgewrite",
   "name": "EdgeWrite keyboard",
-  "version":"0.02",
+  "version":"0.03",
   "description": "A library for text input via EdgeWrite swipe gestures",
   "icon": "app.png",
   "type":"textinput",


### PR DESCRIPTION
As discussed in https://github.com/espruino/BangleApps/pull/3633 setUI removes the back button by clearing a rectangle, even if the widget bar is hidden, so this PR moves hiding the widget bar and the draw of any initial text until after this has happened.