### PR TITLE
backswipe: change to prepend swipe listener

### DIFF
--- a/apps/backswipe/ChangeLog
+++ b/apps/backswipe/ChangeLog
@@ -1,6 +1,5 @@
 0.01: New App!
 0.02: Don't fire if the app uses swipes already.
 0.03: Only count defined handlers in the handler array.
-0.04: Fix messages auto opened by `messagegui` could not be blacklisted. Needs
-	a refresh by deselecting and reselecting the "Messages" app throught Back Swipe
-	settings.
+0.04: Fix messages auto opened by `messagegui` could not be blacklisted. Needs a refresh by deselecting and reselecting the "Messages" app throught Back Swipe settings.
+0.05: React on swipes before the active app (for the most part) by using `prependListener`.

--- a/apps/backswipe/boot.js
+++ b/apps/backswipe/boot.js
@@ -38,6 +38,7 @@
       // if we're in an app that has a back button, run the callback for it
       if (global.BACK && countHandlers("swipe")<=settings.standardNumSwipeHandlers && countHandlers("drag")<=settings.standardNumDragHandlers) {
         global.BACK();
+        E.stopEventPropagation();
       }
     }
   }
@@ -56,5 +57,5 @@
   }
 
   // Listen to left to right swipe
-  Bangle.on("swipe", goBack);
+  Bangle.prependListener("swipe", goBack);
 })();

--- a/apps/backswipe/metadata.json
+++ b/apps/backswipe/metadata.json
@@ -1,7 +1,7 @@
 { "id": "backswipe",
   "name": "Back Swipe",
   "shortName":"BackSwipe",
-  "version":"0.04",
+  "version":"0.05",
   "description": "Service that allows you to use an app's back button using left to right swipe gesture",
   "icon": "app.png",
   "tags": "back,gesture,swipe",


### PR DESCRIPTION
Seems to mitigate some conflicts when switching between `edgeclk` (with seconds active) and `dtlaunch`. Sometimes the seconds redraw timeout of `edgeclk` would draw over `dtlaunch`. I don't really understand the conflict but it seems to be resolved by this change..

Can be tried via https://thyttan.github.io/BangleApps/?id=backswipe

- [x] test for ram leaks