### PR TITLE
drained: restore menu position

### DIFF
--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -58,6 +58,7 @@ var draw = function () {
     }, 60000 - (date.getTime() % 60000));
 };
 var reload = function () {
+    var scroller;
     var showMenu = function () {
         var menu = {
             "Restore to full power": drainedRestore,
@@ -69,9 +70,12 @@ var reload = function () {
         menu["Settings"] = function () { return load("setting.app.js"); };
         menu["Recovery"] = function () { return Bangle.showRecoveryMenu(); };
         menu["Exit menu"] = reload;
+        if (scroller) {
+            menu[""] = { selected: scroller.scroll };
+        }
         if (nextDraw)
             clearTimeout(nextDraw);
-        E.showMenu(menu);
+        (scroller = E.showMenu(menu).scroller);
     };
     Bangle.setUI({
         mode: "custom",

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -78,6 +78,7 @@ const draw = () => {
 };
 
 const reload = () => {
+  let scroller: MenuInstance["scroller"] | undefined;
   const showMenu = () => {
     const menu: Menu = {
       "Restore to full power": drainedRestore,
@@ -92,8 +93,12 @@ const reload = () => {
     menu["Recovery"] = () => Bangle.showRecoveryMenu();
     menu["Exit menu"] = reload;
 
+    if(scroller){
+      menu[""] = { selected: scroller.scroll };
+    }
+
     if(nextDraw) clearTimeout(nextDraw);
-    E.showMenu(menu);
+    ({ scroller } = E.showMenu(menu));
   };
 
   Bangle.setUI({

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -79,7 +79,7 @@ const draw = () => {
 
 const reload = () => {
   const showMenu = () => {
-    const menu: { [k: string]: () => void } = {
+    const menu: Menu = {
       "Restore to full power": drainedRestore,
     };
 

--- a/typescript/types/main.d.ts
+++ b/typescript/types/main.d.ts
@@ -69,6 +69,14 @@ type MenuInstance = {
   draw: () => void;
   move: (n: number) => void;
   select: () => void;
+  scroller?: MenuScroller; // BangleJS 2
+};
+
+/**
+ * Menu scroller.
+ */
+type MenuScroller = {
+  scroll: number;
 };
 
 declare const BTN1: Pin;


### PR DESCRIPTION
To aid in usability when toggling options, such as BLE enabled