### PR TITLE
Undo change to One Call API 3.0

### DIFF
--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Upgrade OWM to One Call API 3.0. Add pressure to weather.json
 0.06: Fix One Call API 3.0 not returning city names, which are required by the weather app
 0.07: Update weather after reconnecting bluetooth if update is due, refactor code
+0.08: Undo change to One Call API 3.0

--- a/apps/owmweather/lib.js
+++ b/apps/owmweather/lib.js
@@ -1,23 +1,20 @@
 function parseWeather(response) {
   let owmData = JSON.parse(response);
 
-  let isOwmData = false;
-  try {
-    isOwmData = (owmData.lat && owmData.lon) && owmData.current.weather && owmData.current;
-  } catch (_e) {}
+  let isOwmData = owmData.coord && owmData.weather && owmData.main;
 
   if (isOwmData) {
     let json = require("Storage").readJSON('weather.json') || {};
     let weather = {};
     weather.time = Date.now();
-    weather.hum = owmData.current.humidity;
-    weather.temp = owmData.current.temp;
-    weather.code = owmData.current.weather[0].id;
-    weather.wdir = owmData.current.wind_deg;
-    weather.wind = owmData.current.wind_speed;
-    weather.loc = owmData.name || "";
-    weather.txt = owmData.current.weather[0].main;
-    weather.hpa = owmData.current.pressure || 0;
+    weather.hum = owmData.main.humidity;
+    weather.temp = owmData.main.temp;
+    weather.code = owmData.weather[0].id;
+    weather.wdir = owmData.wind.deg;
+    weather.wind = owmData.wind.speed;
+    weather.loc = owmData.name;
+    weather.txt = owmData.weather[0].main;
+    weather.hpa = owmData.main.pressure || 0;
 
     if (weather.wdir != null) {
       let deg = weather.wdir;
@@ -43,7 +40,7 @@ exports.pull = function(completionCallback) {
     "location": "London"
   };
   let settings = require("Storage").readJSON("owmweather.json", 1);
-  let uri = "https://api.openweathermap.org/data/3.0/onecall?lat=" + location.lat.toFixed(2) + "&lon=" + location.lon.toFixed(2) + "&exclude=minutely,hourly,daily,alerts&appid=" + settings.apikey;
+  let uri = "https://api.openweathermap.org/data/2.5/weather?lat=" + location.lat.toFixed(2) + "&lon=" + location.lon.toFixed(2) + "&exclude=hourly,daily&appid=" + settings.apikey;
   if (Bangle.http){
     Bangle.http(uri, {timeout:10000}).then(event => {
       let result = parseWeather(event.resp);

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
After see the issue #3444 and the pull request #3427, I re-read the documentation I referenced in my pull request #3387 and  realize I misinterpreted the information.

The post says they upgraded the __One Call API 2.5__ to __One Call API 3.0__, but this app uses the [__Current weather data API__](https://openweathermap.org/current), which is different and free, and it does not require a payment method.

This pull request undoes that change.

I apologize for any inconvenience caused.