### PR TITLE
owmweather: Fix infinite loop when settings.updated is not defined

### DIFF
--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Fix One Call API 3.0 not returning city names, which are required by the weather app
 0.07: Update weather after reconnecting bluetooth if update is due, refactor code
 0.08: Undo change to One Call API 3.0
+0.09: Fix infinite loop when settings.updated is not defined

--- a/apps/owmweather/boot.js
+++ b/apps/owmweather/boot.js
@@ -7,8 +7,8 @@
   );
 
   let refreshMillis = function () {
-    return settings.refresh * 1000 * 60 + 1  // +1 <- leave some slack
-  }
+    return settings.refresh * 1000 * 60 + 1;  // +1 <- leave some slack
+  };
 
   let onCompleted = function () {
     loading = false;
@@ -16,7 +16,7 @@
     require('Storage').writeJSON("owmweather.json", settings);
     if (timeoutRef) clearTimeout(timeoutRef);
     timeoutRef = setTimeout(loadIfDueAndReschedule, refreshMillis());
-  }
+  };
 
   let loadIfDueAndReschedule = function () {
     // also check if the weather.json file has been updated (e.g. force refresh)
@@ -27,18 +27,18 @@
     }
 
     let MillisUntilDue = settings.updated + refreshMillis() - Date.now();
-    if (MillisUntilDue <= 0) {
+    if (!MillisUntilDue || MillisUntilDue <= 0) {
       if (!loading) {
         loading = true;
         require("owmweather").pull(onCompleted);
       }
     } else {
       // called to early, reschedule
-      // console.log('Weather data is not due yet, rescheduling in ' + MillisUntilDue|0 + 'ms');
+      // console.log('Weather data is not due yet, rescheduling in ' + (MillisUntilDue || 0) + 'ms');
       if (timeoutRef) clearTimeout(timeoutRef);
       timeoutRef = setTimeout(loadIfDueAndReschedule, MillisUntilDue + 1);
     }
-  }
+  };
 
   if (settings.enabled) {
     setTimeout(loadIfDueAndReschedule, 5000);  // run 5 seconds after boot

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.08",
+  "version": "0.09",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Fix an infinite loop when settings.updated is not defined. This issue was draining the entire battery within a day.
Fix some missing semicolons.