### PR TITLE
[widclkinfo] Ensure we cancel focus when widget_utils.swipeOn() pushes widget bar off screen

### DIFF
--- a/apps/clock_info/ChangeLog
+++ b/apps/clock_info/ChangeLog
@@ -20,3 +20,5 @@
 0.19: Fix Altitude ClockInfo after BLE added
       Tapping Altitude now updates the reading
 0.20: Altitude ClockInfo now uses the distance units set in locale.
+0.21: Expose ensure_blur function
+

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -348,10 +348,15 @@ exports.addInteractive = function(menu, options) {
     if (redraw) options.redraw();
   };
   let touchHandler, lockHandler;
+// debug touch handler next
   if (options.x!==undefined && options.y!==undefined && options.w && options.h) {
     touchHandler = function(_,e) {
       if (e.x<options.x || e.y<options.y ||
-          e.x>(options.x+options.w) || e.y>(options.y+options.h)) {
+          e.x>(options.x+options.w-1) || e.y>(options.y+options.h-1)) {
+// touch at y=0 focuses when widclkinfo is off screen
+// may have off by one error here
+// options.y is -24
+// options.h is 24
         if (options.focus)
           blur();
         return; // outside area

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -326,12 +326,15 @@ exports.addInteractive = function(menu, options) {
   const blur = () => {
     options.focus=false;
     Bangle.CLKINFO_FOCUS--;
+    // if (Bangle.CLKINFO_FOCUS < 0) Bangle.CLKINFO_FOCUS = 0;
     const itm = menu[options.menuA].items[options.menuB];
     let redraw = true;
     if (itm.blur && itm.blur(options) === false)
       redraw = false;
     if (redraw) options.redraw();
   };
+  // better to only call blur when we know it's focused. Maybe we can rename force_blur to ensure_blur.
+  options.force_blur = blur;
   const focus = () => {
     let redraw = true;
     Bangle.CLKINFO_FOCUS = (0 | Bangle.CLKINFO_FOCUS) + 1;

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -326,15 +326,16 @@ exports.addInteractive = function(menu, options) {
   const blur = () => {
     options.focus=false;
     Bangle.CLKINFO_FOCUS--;
-    // if (Bangle.CLKINFO_FOCUS < 0) Bangle.CLKINFO_FOCUS = 0;
     const itm = menu[options.menuA].items[options.menuB];
     let redraw = true;
     if (itm.blur && itm.blur(options) === false)
       redraw = false;
     if (redraw) options.redraw();
   };
-  // better to only call blur when we know it's focused. Maybe we can rename force_blur to ensure_blur.
-  options.force_blur = blur;
+  // better to only call blur when we know it's focused. Could reuse this logic in this file
+  options.ensure_blur = () => {
+    if (options.focus) blur()
+  }
   const focus = () => {
     let redraw = true;
     Bangle.CLKINFO_FOCUS = (0 | Bangle.CLKINFO_FOCUS) + 1;

--- a/apps/clock_info/metadata.json
+++ b/apps/clock_info/metadata.json
@@ -1,7 +1,7 @@
 { "id": "clock_info",
   "name": "Clock Info Module",
   "shortName": "Clock Info",
-  "version":"0.20",
+  "version":"0.21",
   "description": "A library used by clocks to provide extra information on the clock face (Altitude, BPM, etc)",
   "icon": "app.png",
   "type": "module",

--- a/apps/widclkinfo/ChangeLog
+++ b/apps/widclkinfo/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Now use an app ID (to avoid conflicts with clocks that also use ClockInfo)
 0.03: Fix widget clearing too far down
 0.04: If a small font is needed, use 6x8 but twice as high
+0.05: Defocus the clock_info if widget_utils is used to move widgets off screen

--- a/apps/widclkinfo/metadata.json
+++ b/apps/widclkinfo/metadata.json
@@ -1,6 +1,6 @@
 { "id": "widclkinfo",
   "name": "Clock Info Widget",
-  "version":"0.04",
+  "version":"0.05",
   "description": "Use 'Clock Info' in the Widget bar. Tap on the widget to select, then drag up/down/left/right to choose what information is displayed.",
   "icon": "widget.png",
   "screenshots" : [ { "url":"screenshot.png" }],

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -58,7 +58,7 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     }
   };
 
-  widget_utils.on("hidden", () => {
+  Bangle.on("hidden", () => {
     console.log("hidden");
     clockInfoMenu.y = -24;
     if (clockInfoMenu.focus) {
@@ -67,7 +67,7 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     }
   });
 
-  widget_utils.on("shown", () => {
+  Bangle.on("shown", () => {
     clockInfoMenu.y = 0;
     console.log("shown");
     if (WIDGETS["clkinfo"]) {

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -6,7 +6,7 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     app: "widclkinfo",
     // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
     x: 0,
-    y: 0, // maybe set offset to initial offset
+    y: -24, // TODO how know if offscreen to start?
     w: 72,
     h: 24,
     // You can add other information here you want to be passed into 'options' in 'draw'
@@ -16,13 +16,13 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
       // info: data returned from itm.get() containing text/img/etc
       // options: options passed into addInteractive
       clockInfoInfo = info;
-      if (WIDGETS["clkinfo"]) {
       clockInfoMenu.y = options.y;
+      if (WIDGETS["clkinfo"] && clockInfoMenu.y > -24) {
         WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
-        console.log("Clock Info was updated, thus drawing widget.");
       }
     }
   });
+
   let clockInfoInfo; // when clockInfoMenu.draw is called we set this up
   let draw = function(e) {
     clockInfoMenu.x = e.x;

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -57,6 +57,7 @@
     }
   }.init();
 
+  // We make clock info touch area active on the start of the animation
   Bangle.on("widgets-start-show", () => {
     var wi = WIDGETS["clkinfo"];
     if (wi) {
@@ -76,7 +77,7 @@
   Bangle.on("widgets-start-hide", () => {
     var wi = WIDGETS["clkinfo"];
     if (wi) {
-      if (wi.clockInfoMenu.focus) wi.clockInfoMenu.blur();
+      wi.clockInfoMenu.ensure_blur(); // let user see defocus cue before hiding
       wi.clockInfoMenu.y = -24;
       wi.draw(wi);
     }
@@ -85,7 +86,7 @@
   Bangle.on("widgets-hidden", () => {
     var wi = WIDGETS["clkinfo"];
     if (wi) {
-      if (wi.clockInfoMenu.focus) wi.clockInfoMenu.blur();
+      wi.clockInfoMenu.ensure_blur();
       wi.clockInfoMenu.y = -24;
       wi.draw(wi);
     }

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -61,9 +61,8 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
   widget_utils.on("hidden", () => {
     console.log("hidden");
     clockInfoMenu.y = -24;
-    clockInfoMenu.force_blur(); // needs to be here so it doesn't stay the focused color
     if (clockInfoMenu.focus) {
-      //clockInfoMenu.force_blur();
+      clockInfoMenu.force_blur();
       console.log("Forced blur bc hidden");
     }
   });

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -90,3 +90,4 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
       clockInfoMenu.blur();
     }
   });
+}

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -1,20 +1,30 @@
 if (!require("clock_info").loadCount) { // don't load if a clock_info was already loaded
   // Load the clock infos
-  let clockInfoItems = require("clock_info").load();
-  // Add the
-  let clockInfoMenu = require("clock_info").addInteractive(clockInfoItems, {
-    app : "widclkinfo",
+  let clockInfoItems = clock_info.load();
+
+  // TODO only do checks if widget_utils.swipeOn is being used
+  let wuo = widget_utils.offset;
+
+  let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
+    app: "widclkinfo",
     // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
-    x : 0, y: 0, w: 72, h:24,
+    x: 0,
+    y: 0, // maybe set offset to initial offset
+    w: 72,
+    h: 24,
     // You can add other information here you want to be passed into 'options' in 'draw'
     // This function draws the info
-    draw : (itm, info, options) => {
+    draw: (itm, info, options) => {
       // itm: the item containing name/hasRange/etc
       // info: data returned from itm.get() containing text/img/etc
       // options: options passed into addInteractive
       clockInfoInfo = info;
-      if (WIDGETS["clkinfo"])
+      wuo = 0 | widget_utils.offset;
+      clockInfoMenu.y = options.y + wuo;
+      if (WIDGETS["clkinfo"]) {
         WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+        console.log("Clock Info was updated, thus drawing widget.");
+      }
     }
   });
   let clockInfoInfo; // when clockInfoMenu.draw is called we set this up
@@ -25,12 +35,12 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     width: clockInfoMenu.w,
     draw:function(e) {
       clockInfoMenu.x = e.x;
-      clockInfoMenu.y = e.y;
+      wuo = 0 | widget_utils.offset;
+      clockInfoMenu.y = e.y + wuo;
       var o = clockInfoMenu;
       // Clear the background
       g.reset();
-      // indicate focus - make background reddish
-      //if (clockInfoMenu.focus) g.setBgColor(g.blendColor(g.theme.bg, "#f00", 0.25));
+      // indicate focus
       if (clockInfoMenu.focus) g.setColor("#f00");
       g.clearRect(o.x, o.y, o.x+o.w-1, o.y+o.h-1);
       if (clockInfoInfo) {
@@ -47,4 +57,21 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
       }
     }
   };
-}
+
+  widget_utils.on("hidden", () => {
+    console.log("hidden");
+    clockInfoMenu.y = -24;
+    clockInfoMenu.force_blur(); // needs to be here so it doesn't stay the focused color
+    if (clockInfoMenu.focus) {
+      //clockInfoMenu.force_blur();
+      console.log("Forced blur bc hidden");
+    }
+  });
+
+  widget_utils.on("shown", () => {
+    clockInfoMenu.y = 0;
+    console.log("shown");
+    if (WIDGETS["clkinfo"]) {
+      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+    }
+  });

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -2,9 +2,6 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
   // Load the clock infos
   let clockInfoItems = clock_info.load();
 
-  // TODO only do checks if widget_utils.swipeOn is being used
-  let wuo = widget_utils.offset;
-
   let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
     app: "widclkinfo",
     // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
@@ -19,9 +16,8 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
       // info: data returned from itm.get() containing text/img/etc
       // options: options passed into addInteractive
       clockInfoInfo = info;
-      wuo = 0 | widget_utils.offset;
-      clockInfoMenu.y = options.y + wuo;
       if (WIDGETS["clkinfo"]) {
+      clockInfoMenu.y = options.y;
         WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
         console.log("Clock Info was updated, thus drawing widget.");
       }
@@ -35,8 +31,7 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     width: clockInfoMenu.w,
     draw:function(e) {
       clockInfoMenu.x = e.x;
-      wuo = 0 | widget_utils.offset;
-      clockInfoMenu.y = e.y + wuo;
+      clockInfoMenu.y = e.y;
       var o = clockInfoMenu;
       // Clear the background
       g.reset();

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -1,93 +1,101 @@
-if (!require("clock_info").loadCount) { // don't load if a clock_info was already loaded
-  // Load the clock infos
-  let clockInfoItems = clock_info.load();
+(() => {
+  if (!require("clock_info").loadCount) { // don't load if a clock_info was already loaded
+  //WIDGETS = {};
+  const clock_info = require("clock_info");
 
-  let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
-    app: "widclkinfo",
-    // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
-    x: 0,
-    y: -24, // TODO how know if offscreen to start?
-    w: 72,
-    h: 24,
-    // You can add other information here you want to be passed into 'options' in 'draw'
-    // This function draws the info
-    draw: (itm, info, options) => {
-      // itm: the item containing name/hasRange/etc
-      // info: data returned from itm.get() containing text/img/etc
-      // options: options passed into addInteractive
-      clockInfoInfo = info;
-      clockInfoMenu.y = options.y;
-      if (WIDGETS["clkinfo"] && clockInfoMenu.y > -24) {
-        WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+  WIDGETS["clkinfo"] = {
+    area: "tl",
+    width: 0, //this.clockInfoMenu.w,
+    init: function() {
+      this.width = this.clockInfoMenu.w;
+      delete this.init;
+      return this;
+    },
+    clockInfoInfo: undefined, // defined during clockInfoMenu.draw()
+    clockInfoMenu: clock_info.addInteractive(clock_info.load(), {
+      app: "widclkinfo",
+      // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
+      x: 0,
+      y: 0, // TODO how know if offscreen to start?
+      w: 72,
+      h: 24,
+      // You can add other information here you want to be passed into 'options' in 'draw'
+      // This function draws the info
+      draw: (itm, info, options) => {
+        // itm: the item containing name/hasRange/etc
+        // info: data returned from itm.get() containing text/img/etc
+        // options: options passed into addInteractive
+        var wi = WIDGETS["clkinfo"];
+        wi.clockInfoInfo = info;
+        wi.clockInfoMenu.y = options.y;
+        if (WIDGETS["clkinfo"] && wi.clockInfoMenu.y > -24) {
+          WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+        }
       }
+    }),
+    draw: function(e) {
+      this.clockInfoMenu.x = e.x;
+      var o = this.clockInfoMenu;
+      g.reset();
+      // indicate focus
+      if (this.clockInfoMenu.focus) {
+        g.setColor("#f00");
+      }
+      g.clearRect(o.x, o.y, o.x + o.w - 1, o.y + o.h - 1);
+      if (this.clockInfoInfo) {
+        var x = o.x;
+        if (this.clockInfoInfo.img) {
+          g.drawImage(this.clockInfoInfo.img, x, o.y); // draw the image
+          x += 24;
+        }
+        var availableWidth = o.x + this.clockInfoMenu.w - (x + 2);
+        g.setFont("6x8:2").setFontAlign(-1, 0);
+        if (g.stringWidth(this.clockInfoInfo.text) > availableWidth)
+          g.setFont("6x8:1x2");
+        g.drawString(this.clockInfoInfo.text, x + 2, o.y + 12); // draw the text
+      }
+    }
+  }.init();
+
+  Bangle.on("widgets-start-show", () => {
+    var wi = WIDGETS["clkinfo"];
+    if (wi) {
+      wi.clockInfoMenu.y = 0;
+      wi.draw(wi);
     }
   });
 
-  let clockInfoInfo; // when clockInfoMenu.draw is called we set this up
-  let draw = function(e) {
-    clockInfoMenu.x = e.x;
-    var o = clockInfoMenu;
-    // Clear the background
-    g.reset();
-    // indicate focus
-    if (clockInfoMenu.focus) {
-      g.setColor("#f00");
-    }
-    g.clearRect(o.x, o.y, o.x + o.w - 1, o.y + o.h - 1);
-
-    if (clockInfoInfo) {
-      var x = o.x;
-      if (clockInfoInfo.img) {
-        g.drawImage(clockInfoInfo.img, x, o.y); // draw the image
-        x += 24;
-      }
-      var availableWidth = o.x + clockInfoMenu.w - (x + 2);
-      g.setFont("6x8:2").setFontAlign(-1, 0);
-      if (g.stringWidth(clockInfoInfo.text) > availableWidth)
-        g.setFont("6x8:1x2");
-      g.drawString(clockInfoInfo.text, x + 2, o.y + 12); // draw the text
-    }
-  };
-
-  // The actual widget we're displaying
-  WIDGETS["clkinfo"] = {
-    area: "tl",
-    width: clockInfoMenu.w,
-    draw: draw
-  };
-
-  Bangle.on("widgets-start-show", () => {
-    clockInfoMenu.y = 0;
-    if (WIDGETS["clkinfo"]) {
-      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
-    }
-  })
-
   Bangle.on("widgets-shown", () => {
-    clockInfoMenu.y = 0;
-    if (WIDGETS["clkinfo"]) {
-      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+    var wi = WIDGETS["clkinfo"];
+    if (wi) {
+      wi.clockInfoMenu.y = 0;
+      wi.draw(wi);
     }
   });
 
   Bangle.on("widgets-start-hide", () => {
-    clockInfoMenu.y = -24;
-    if (WIDGETS["clkinfo"]) {
-      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
-    }
-    if (clockInfoMenu.focus) {
-      clockInfoMenu.blur();
+    var wi = WIDGETS["clkinfo"];
+    if (wi) {
+      if (wi.clockInfoMenu.focus) wi.clockInfoMenu.blur();
+      wi.clockInfoMenu.y = -24;
+      wi.draw(wi);
     }
   });
 
   Bangle.on("widgets-hidden", () => {
-    clockInfoMenu.y = -24;
-    if (WIDGETS["clkinfo"]) {
-      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
-    }
-    // check here too in case widget_utils.hide() is called
-    if (clockInfoMenu.focus) {
-      clockInfoMenu.blur();
+    var wi = WIDGETS["clkinfo"];
+    if (wi) {
+      if (wi.clockInfoMenu.focus) wi.clockInfoMenu.blur();
+      wi.clockInfoMenu.y = -24;
+      wi.draw(wi);
     }
   });
-}
+}})()
+
+/*
+const widget_utils = require("widget_utils");
+g.clear();
+Bangle.loadWidgets();
+widget_utils.swipeOn();
+Bangle.drawWidgets();
+*/

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -24,33 +24,36 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     }
   });
   let clockInfoInfo; // when clockInfoMenu.draw is called we set this up
+  let draw = function(e) {
+    clockInfoMenu.x = e.x;
+    var o = clockInfoMenu;
+    // Clear the background
+    g.reset();
+    // indicate focus
+    if (clockInfoMenu.focus) {
+      g.setColor("#f00");
+    }
+    g.clearRect(o.x, o.y, o.x + o.w - 1, o.y + o.h - 1);
+
+    if (clockInfoInfo) {
+      var x = o.x;
+      if (clockInfoInfo.img) {
+        g.drawImage(clockInfoInfo.img, x, o.y); // draw the image
+        x += 24;
+      }
+      var availableWidth = o.x + clockInfoMenu.w - (x + 2);
+      g.setFont("6x8:2").setFontAlign(-1, 0);
+      if (g.stringWidth(clockInfoInfo.text) > availableWidth)
+        g.setFont("6x8:1x2");
+      g.drawString(clockInfoInfo.text, x + 2, o.y + 12); // draw the text
+    }
+  };
 
   // The actual widget we're displaying
   WIDGETS["clkinfo"] = {
-    area:"tl",
+    area: "tl",
     width: clockInfoMenu.w,
-    draw:function(e) {
-      clockInfoMenu.x = e.x;
-      clockInfoMenu.y = e.y;
-      var o = clockInfoMenu;
-      // Clear the background
-      g.reset();
-      // indicate focus
-      if (clockInfoMenu.focus) g.setColor("#f00");
-      g.clearRect(o.x, o.y, o.x+o.w-1, o.y+o.h-1);
-      if (clockInfoInfo) {
-        var x = o.x;
-        if (clockInfoInfo.img) {
-          g.drawImage(clockInfoInfo.img, x,o.y); // draw the image
-          x+=24;
-        }
-        var availableWidth = o.x+clockInfoMenu.w - (x+2);
-        g.setFont("6x8:2").setFontAlign(-1,0);
-        if (g.stringWidth(clockInfoInfo.text) > availableWidth)
-          g.setFont("6x8:1x2");
-        g.drawString(clockInfoInfo.text, x+2,o.y+12); // draw the text
-      }
-    }
+    draw: draw
   };
 
   Bangle.on("widgets-start-show", () => {

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -53,19 +53,37 @@ if (!require("clock_info").loadCount) { // don't load if a clock_info was alread
     }
   };
 
-  Bangle.on("hidden", () => {
-    console.log("hidden");
-    clockInfoMenu.y = -24;
-    if (clockInfoMenu.focus) {
-      clockInfoMenu.force_blur();
-      console.log("Forced blur bc hidden");
+  Bangle.on("widgets-start-show", () => {
+    clockInfoMenu.y = 0;
+    if (WIDGETS["clkinfo"]) {
+      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+    }
+  })
+
+  Bangle.on("widgets-shown", () => {
+    clockInfoMenu.y = 0;
+    if (WIDGETS["clkinfo"]) {
+      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
     }
   });
 
-  Bangle.on("shown", () => {
-    clockInfoMenu.y = 0;
-    console.log("shown");
+  Bangle.on("widgets-start-hide", () => {
+    clockInfoMenu.y = -24;
     if (WIDGETS["clkinfo"]) {
       WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+    }
+    if (clockInfoMenu.focus) {
+      clockInfoMenu.blur();
+    }
+  });
+
+  Bangle.on("widgets-hidden", () => {
+    clockInfoMenu.y = -24;
+    if (WIDGETS["clkinfo"]) {
+      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
+    }
+    // check here too in case widget_utils.hide() is called
+    if (clockInfoMenu.focus) {
+      clockInfoMenu.blur();
     }
   });

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -92,11 +92,3 @@
     }
   });
 }})()
-
-/*
-const widget_utils = require("widget_utils");
-g.clear();
-Bangle.loadWidgets();
-widget_utils.swipeOn();
-Bangle.drawWidgets();
-*/

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -18,7 +18,7 @@
       x: 0,
       y: 0, // TODO how know if offscreen to start?
       w: 72,
-      h: 24,
+      h: 23, // workaround off by one error in clock_info
       // You can add other information here you want to be passed into 'options' in 'draw'
       // This function draws the info
       draw: (itm, info, options) => {

--- a/apps/widclkinfo/widget.js
+++ b/apps/widclkinfo/widget.js
@@ -1,6 +1,5 @@
 (() => {
   if (!require("clock_info").loadCount) { // don't load if a clock_info was already loaded
-  //WIDGETS = {};
   const clock_info = require("clock_info");
 
   WIDGETS["clkinfo"] = {

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -11,7 +11,7 @@ exports.hide = function() {
     w.area = "";
     if (w.x!=undefined) g.clearRect(w.x,w.y,w.x+w.width-1,w.y+23);
   }
-  // TODO: do we need to emit event here too?
+  Bangle.emit("widgets-hidden");
 };
 
 /// Show any hidden widgets
@@ -26,6 +26,7 @@ exports.show = function() {
     delete w._area;
     w.draw(w);
   }
+  Bangle.emit("widgets-shown");
 };
 
 /// Remove anything not needed if the overlay was removed

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -132,34 +132,33 @@ exports.swipeOn = function(autohide) {
     if (exports.animInterval) clearInterval(exports.animInterval);
     exports.animInterval = setInterval(function() {
       exports.offset += dir;
-        let stop = false;
-// exports.offset >=0              <0                     <-23
-//     dir >0     shown, so stop.  in process of showing  start show
-//         <0     start hide       in process of hiding   hidden, so stop
-        if (dir > 0) {
-            if (exports.offset >= 0) {
-                stop = true;
-                exports.offset = 0;
-                Bangle.emit("widgets-shown");
-            } else if (exports.offset <= -23) {
-                Bangle.emit("widgets-start-show");
-            } else {
-                Bangle.emit("widget-anim-step");
-            }
-        } else if (dir < 0) {
-            if (exports.offset>=0) {
-                Bangle.emit("widget-start-hide");
-            } else if (exports.offset <= -23) {
-                stop = true;
-                exports.offset = -24;
-                Bangle.emit("widgets-hidden");
-            } else {
-                Bangle.emit("widget-anim-step");
-            }
+      let stop = false;
+      // exports.offset >=0              <0                     <-23
+      //     dir >0     shown, so stop.  in process of showing  start show
+      //         <0     start hide       in process of hiding   hidden, so stop
+      if (dir > 0) {
+        if (exports.offset >= 0) {
+          stop = true;
+          exports.offset = 0;
+          Bangle.emit("widgets-shown");
+        } else if (exports.offset <= -23) {
+          Bangle.emit("widgets-start-show");
+        } else {
+          Bangle.emit("widget-anim-step");
         }
-        else {
-            // dir == 0??
+      } else if (dir < 0) {
+        if (exports.offset >= 0) {
+          Bangle.emit("widget-start-hide");
+        } else if (exports.offset <= -23) {
+          stop = true;
+          exports.offset = -24;
+          Bangle.emit("widgets-hidden");
+        } else {
+          Bangle.emit("widget-anim-step");
         }
+      } else {
+        // dir == 0??
+      }
       if (stop) {
         clearInterval(exports.animInterval);
         delete exports.animInterval;

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -157,6 +157,7 @@ exports.swipeOn = function(autohide) {
         } else {
           Bangle.emit("widgets-anim-step");
         }
+      }
       if (stop) {
         clearInterval(exports.animInterval);
         delete exports.animInterval;

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -158,6 +158,7 @@ exports.swipeOn = function(autohide) {
     let cb;
     if (exports.autohide > 0) cb = function() {
       exports.hideTimeout = setTimeout(function() {
+        Bangle.emit("widgets-start-hide");
         anim(-4);
       }, exports.autohide);
     };

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -11,6 +11,7 @@ exports.hide = function() {
     w.area = "";
     if (w.x!=undefined) g.clearRect(w.x,w.y,w.x+w.width-1,w.y+23);
   }
+  // TODO: do we need to emit event here too?
 };
 
 /// Show any hidden widgets
@@ -134,11 +135,11 @@ exports.swipeOn = function(autohide) {
       if (dir>0 && exports.offset>=0) { // fully down
         stop = true;
         exports.offset = 0;
-        exports.emit("shown");
+        Bangle.emit("widgets-shown");
       } else if (dir<0 && exports.offset<-23) { // fully up
         stop = true;
         exports.offset = -24;
-        exports.emit("hidden");
+        Bangle.emit("widgets-hidden");
       }
       if (stop) {
         clearInterval(exports.animInterval);
@@ -160,8 +161,14 @@ exports.swipeOn = function(autohide) {
         anim(-4);
       }, exports.autohide);
     };
-    if (ud>0 && exports.offset<0) anim(4, cb);
-    if (ud<0 && exports.offset>-24) anim(-4);
+    if (ud>0 && exports.offset<0) {
+      Bangle.emit("widgets-start-show");
+      anim(4, cb);
+    }
+    if (ud<0 && exports.offset>-24) {
+      Bangle.emit("widgets-start-hide");
+      anim(-4);
+    }
   };
   Bangle.on("swipe", exports.swipeHandler);
   Bangle.drawWidgets();

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -134,9 +134,11 @@ exports.swipeOn = function(autohide) {
       if (dir>0 && exports.offset>=0) { // fully down
         stop = true;
         exports.offset = 0;
+        exports.emit("shown");
       } else if (dir<0 && exports.offset<-23) { // fully up
         stop = true;
         exports.offset = -24;
+        exports.emit("hidden");
       }
       if (stop) {
         clearInterval(exports.animInterval);

--- a/modules/widget_utils.js
+++ b/modules/widget_utils.js
@@ -161,9 +161,10 @@ exports.swipeOn = function(autohide) {
       if (stop) {
         clearInterval(exports.animInterval);
         delete exports.animInterval;
-        if (callback) callback();
-      }
-      else {
+        if (callback) {
+          callback();
+        }
+      } else {
         exports.offset += dir;
       }
       queueDraw();


### PR DESCRIPTION
Fixes bug with widclkinfo interacting with widget_utils.

Expose a ensure_blur in clock_info that widclkinfo can call. Handles animation with events.

The relevant versions are in my app loader: https://cbkerr.github.io/BangleApps/

I've been testing with the watchface Andark.

## Symptoms

Load widget_utils and widclkinfo.

1. The Clock Info of `widclkinfo` stays focused after the widgets autohide, so the selected clock info (`options.menuA`, `options.menuB`) changes when swiping the screen (like when using menus).
2. When the widgets are hidden, tapping in the top left corner focuses the clock info inside widclkinfo.
3. Swiping up to hide the widget bar also changes the selected Clock Info, and if the hidden `widclkinfo` is focused, swiping down to show widgets also changes the selected clock info.

### Minimal reproduction of bug
With useful debug info printed

```js
// development
WIDGETS = [];
widget_utils = require("widget_utils");

//(() => { // don't load if a clock_info was already loaded
// Load the clock infos
let clockInfoItems = require("clock_info").load();
// Add the
let clockInfoMenu = require("clock_info").addInteractive(clockInfoItems, {
  app: "widclkinfo",
  // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
  x: 0,
  y: 0,
  w: 72,
  h: 24,
  // You can add other information here you want to be passed into 'options' in 'draw'
  // This function draws the info
  draw: (itm, info, options) => {
    // itm: the item containing name/hasRange/etc
    // info: data returned from itm.get() containing text/img/etc
    // options: options passed into addInteractive
    clockInfoInfo = info;
    if (WIDGETS["clkinfo"])
      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
  }
});
let clockInfoInfo; // when clockInfoMenu.draw is called we set this up

// The actual widget we're displaying
WIDGETS["clkinfo"] = {
  area: "tl",
  width: clockInfoMenu.w,
  draw: function(e) {
    clockInfoMenu.x = e.x;
    clockInfoMenu.y = e.y;
    var o = clockInfoMenu;
    // Clear the background
    g.reset();
    // indicate focus - make background reddish
    //if (clockInfoMenu.focus) g.setBgColor(g.blendColor(g.theme.bg, "#f00", 0.25));
    if (clockInfoMenu.focus) g.setColor("#f00");
    g.clearRect(o.x, o.y, o.x + o.w - 1, o.y + o.h - 1);
    if (clockInfoInfo) {
      var x = o.x;
      if (clockInfoInfo.img) {
        g.drawImage(clockInfoInfo.img, x, o.y); // draw the image
        x += 24;
      }
      var availableWidth = o.x + clockInfoMenu.w - (x + 2);
      g.setFont("6x8:2").setFontAlign(-1, 0);
      if (g.stringWidth(clockInfoInfo.text) > availableWidth)
        g.setFont("6x8:1x2");
      g.drawString(clockInfoInfo.text, x + 2, o.y + 12); // draw the text
    }
  }
};
//})();

Bangle.setUI('clock');
g.clear();
Bangle.loadWidgets();
require("widget_utils").swipeOn();

setInterval(() => {
  g.clear(Bangle.appRect);
  g.setFont("6x8");

  g.drawString("widget_utils.offset: " + widget_utils.offset, 4, 40);
  g.drawString("Bangle.CLKINFO_FOCUS: " + Bangle.CLKINFO_FOCUS, 4, 50);
  g.drawString("clockInfoMenu.y: " + clockInfoMenu.y, 4, 70);
  g.drawString("clockInfoMenu.focus: " + clockInfoMenu.focus, 4, 60);
  g.drawString("menuA: " + clockInfoMenu.menuA, 4, 80);
  g.drawString("menuB: " + clockInfoMenu.menuB, 4, 90);
  //g.drawString(clock_info.clockInfos, 4, 90);
  // g.drawString("cIM.x: " + clockInfoMenu.x, 4, 100);
  //g.drawString("items: " + clockInfoItems, 4, 90)
}, 500);
```



## Expected behavior
When widgets autohide, the Clock Info in `widclkinfo` blurs itself just like tapping outside of its region.
Tapping only selects the Clock Info in `widclkinfo` if it is visible. (when `widget_utils.offset == 0`)


## To test these fixes
1. Upload to storage the slightly tweaked clock_info to `clock_info`
2. Run this from web IDE:
 
<details>
<summary>Code to upload to RAM from Web IDE that writes custom widget_utils to storage</summary>

```js
const clock_info = require("clock_info"); // only slight modification to expose force_blur

require("Storage").write("mywidut", `
exports.offset = 0;
exports.hide = function() {
  exports.cleanup();
  if (!global.WIDGETS) return;
  g.reset(); // reset colors
  for (var w of global.WIDGETS) {
    if (w._draw) return; // already hidden
    w._draw = w.draw;
    w.draw = () => {};
    w._area = w.area;
    w.area = "";
    if (w.x!=undefined) g.clearRect(w.x,w.y,w.x+w.width-1,w.y+23);
  }
};

/// Show any hidden widgets
exports.show = function() {
  exports.cleanup();
  if (!global.WIDGETS) return;
  for (var w of global.WIDGETS) {
    if (!w._draw) return; // not hidden
    w.draw = w._draw;
    w.area = w._area;
    delete w._draw;
    delete w._area;
    w.draw(w);
  }
};

/// Remove anything not needed if the overlay was removed
exports.cleanupOverlay = function() {
  exports.offset = -24;
  Bangle.setLCDOverlay(undefined, {id: "widget_utils"});
  delete exports.autohide;
  delete Bangle.appRect;
  if (exports.animInterval) {
    clearInterval(exports.animInterval);
    delete exports.animInterval;
  }
  if (exports.hideTimeout) {
    clearTimeout(exports.hideTimeout);
    delete exports.hideTimeout;
  }
};

/// Remove any intervals/handlers/etc that we might have added. Does NOT re-show widgets that were hidden
exports.cleanup = function() {
  exports.cleanupOverlay();
  delete exports.offset;
  if (exports.swipeHandler) {
    Bangle.removeListener("swipe", exports.swipeHandler);
    delete exports.swipeHandler;
  }
  if (exports.origDraw) {
    Bangle.drawWidgets = exports.origDraw;
    delete exports.origDraw;
  }
};

/** Put widgets offscreen, and allow them to be swiped
back onscreen with a downwards swipe. Use .show to undo.
First parameter controls automatic hiding time, 0 equals not hiding at all.
Default value is 2000ms until hiding.
Bangle.js 2 only at the moment. On Bangle.js 1 widgets will be hidden permanently.

Note: On Bangle.js 1 is is possible to draw widgets in an offscreen area of the LCD
and use Bangle.setLCDOffset. However we can't detect a downward swipe so how to
actually make this work needs some thought.
*/
exports.swipeOn = function(autohide) {
  if (process.env.HWVERSION!==2) return exports.hide();
  exports.cleanup();
  if (!global.WIDGETS) return;
  exports.autohide=autohide===undefined?2000:autohide;
  /* TODO: maybe when widgets are offscreen we don't even
  store them in an offscreen buffer? */

  // force app rect to be fullscreen
  Bangle.appRect = { x: 0, y: 0, w: g.getWidth(), h: g.getHeight(), x2: g.getWidth()-1, y2: g.getHeight()-1 };
  // setup offscreen graphics for widgets
  let og = Graphics.createArrayBuffer(g.getWidth(),26,16,{msb:true});
  og.theme = g.theme;
  og._reset = og.reset;
  og.reset = function() {
    return this._reset().setColor(g.theme.fg).setBgColor(g.theme.bg);
  };
  og.reset().clearRect(0,0,og.getWidth(),23).fillRect(0,24,og.getWidth(),25);
  let _g = g;
  exports.offset = -24; // where on the screen are we? -24=hidden, 0=full visible

  function queueDraw() {
    const o = exports.offset;
    Bangle.appRect.y = o+24;
    Bangle.appRect.h = 1 + Bangle.appRect.y2 - Bangle.appRect.y;
    if (o>-24) {
      Bangle.setLCDOverlay(og, 0, o, {
        id:"widget_utils",
        remove:()=>{
          require("widget_utils").cleanupOverlay();
        }
      });
    } else {
      Bangle.setLCDOverlay(undefined, {id: "widget_utils"});
    }
  }

  for (var w of global.WIDGETS) if (!w._draw) { // already hidden
    w._draw = w.draw;
    w.draw = function() {
      g=og;
      this._draw(this);
      g=_g;
      if (exports.offset>-24) queueDraw();
    };
    w._area = w.area;
    if (w.area.startsWith("b"))
      w.area = "t"+w.area.substr(1);
  }

  exports.origDraw = Bangle.drawWidgets;
  Bangle.drawWidgets = ()=>{
    g=og;
    exports.origDraw();
    g=_g;
  };

  function anim(dir, callback) {
    if (exports.animInterval) clearInterval(exports.animInterval);
    exports.animInterval = setInterval(function() {
      exports.offset += dir;
      let stop = false;
      if (dir>0 && exports.offset>=0) { // fully down
        stop = true;
        exports.offset = 0;
        exports.emit("shown");
      } else if (dir<0 && exports.offset<-23) { // fully up
        stop = true;
        exports.offset = -24;
        exports.emit("hidden");
      }
      if (stop) {
        clearInterval(exports.animInterval);
        delete exports.animInterval;
        if (callback) callback();
      }
      queueDraw();
    }, 50);
  }
  // On swipe down, animate to show widgets
  exports.swipeHandler = function(lr,ud) {
    if (exports.hideTimeout) {
      clearTimeout(exports.hideTimeout);
      delete exports.hideTimeout;
    }
    let cb;
    if (exports.autohide > 0) cb = function() {
      exports.hideTimeout = setTimeout(function() {
        anim(-4);
      }, exports.autohide);
    };
    if (ud>0 && exports.offset<0) anim(4, cb);
    if (ud<0 && exports.offset>-24) anim(-4);
  };
  Bangle.on("swipe", exports.swipeHandler);
  Bangle.drawWidgets();
};
`);

const widget_utils = require("mywidut"); // only 8 chars allowed in name

// development
WIDGETS = [];


// code from widclkinfo for debugging

//(() => { // don't load if a clock_info was already loaded
  // Load the clock infos
  let clockInfoItems = clock_info.load();

  let wuo = widget_utils.offset;

  let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
    app: "widclkinfo",
    // Add the dimensions we're rendering to here - these are used to detect taps on the clock info area
    x: 0,
    y: 0, // set offset to initial offset
    w: 72,
    h: 24,
    // You can add other information here you want to be passed into 'options' in 'draw'
    // This function draws the info
    draw: (itm, info, options) => {
      // itm: the item containing name/hasRange/etc
      // info: data returned from itm.get() containing text/img/etc
      // options: options passed into addInteractive
      clockInfoInfo = info;
      //wuo = 0 | widget_utils.offset;
      clockInfoMenu.y = options.y + wuo;
      if (WIDGETS["clkinfo"]) {
        WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
        console.log("Clock Info was updated, thus drawing widget.");
      }
    }
  });

  let clockInfoInfo; // when clockInfoMenu.draw is called we set this up

  // The actual widget we're displaying
  WIDGETS["clkinfo"] = {
    area: "tl",
    width: clockInfoMenu.w,
    draw: function(e) {
      clockInfoMenu.x = e.x;
      wuo = 0 | widget_utils.offset;
      clockInfoMenu.y = e.y + wuo;
      var o = clockInfoMenu;
      // Clear the background
      g.reset();
      // indicate focus
      if (clockInfoMenu.focus) g.setColor("#f00");
      g.clearRect(o.x, o.y, o.x + o.w - 1, o.y + o.h - 1);

      if (clockInfoInfo) {
        var x = o.x;
        if (clockInfoInfo.img) {
          g.drawImage(clockInfoInfo.img, x, o.y); // draw the image
          x += 24;
        }
        var availableWidth = o.x + clockInfoMenu.w - (x + 2);
        g.setFont("6x8:2").setFontAlign(-1, 0);
        if (g.stringWidth(clockInfoInfo.text) > availableWidth)
          g.setFont("6x8:1x2");
        g.drawString(clockInfoInfo.text, x + 2, o.y + 12); // draw the text
      }
    }
  };

  widget_utils.on("hidden", () => {
    console.log("hidden");
    clockInfoMenu.y = -24;
    clockInfoMenu.force_blur(); // needs to be here so it doesn't stay the focused color
    if (clockInfoMenu.focus) {
      //clockInfoMenu.force_blur();
      console.log("Forced blur bc hidden");
    }
  });

  widget_utils.on("shown", () => {
    clockInfoMenu.y = 0;
    console.log("shown");
    if (WIDGETS["clkinfo"]) {
      WIDGETS["clkinfo"].draw(WIDGETS["clkinfo"]);
    }
  });

  // for debug:
//})();



Bangle.setUI('clock');
g.clear();
Bangle.loadWidgets();
widget_utils.swipeOn();


// debug info:
setInterval(() => {
  g.clear(Bangle.appRect);
  g.setFont("6x8");

  g.drawString("widget_utils.offset: " + widget_utils.offset, 4, 40);
  g.drawString("Bangle.CLKINFO_FOCUS: " + Bangle.CLKINFO_FOCUS, 4, 50);
  g.drawString("clockInfoMenu.y: " + clockInfoMenu.y, 4, 70);
  g.drawString("clockInfoMenu.focus: " + clockInfoMenu.focus, 4, 60);
  g.drawString("menuA: " + clockInfoMenu.menuA, 4, 80);
  g.drawString("menuB: " + clockInfoMenu.menuB, 4, 90);
  //g.drawString(clock_info.clockInfos, 4, 90);
  // g.drawString("cIM.x: " + clockInfoMenu.x, 4, 100);
  //g.drawString("items: " + clockInfoItems, 4, 90)
}, 500);

// these work:
//global.clockInfoMenu
//clockInfoMenu.focus

// get list of all added infos:
//clock_info.clockInfos

// Added a function clockInfoMenu.force_blur()
```

</details>