### PR TITLE
messagegui: refactor the messages scroller and use it more (WIP)

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -114,4 +114,5 @@
 0.83: Add option to not open the first unread message
 0.84: Fix: Assign show message entry to the settings menu and not the message itself.
 0.85: Use new Rebble fonts if available
-      Remove workaround for 2v10 (>3 years ago) - assume everyone is on never firmware now
+0.86: Refactor to display a scroller with all messages loaded. 
+      Initial scroll position is at the chosen message.

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -340,6 +340,9 @@ function showMessagesScroller(msg) {
           setColor("#f00").drawImage(footerImgNeg,r.x+5+3,r.y).
           setColor("#0f0").drawImage(footerImgPos,r.w-64-5,r.y);
       }
+      if (0===scrollIdx) {
+        g.setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="), r.x, r.y);
+      }
       if (scrollIdx<shownScrollIdxFirst) {shownScrollIdxFirst = scrollIdx;}
       if (scrollIdx>shownScrollIdxLast) {shownScrollIdxLast = scrollIdx;}
     },

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -383,16 +383,17 @@ function showMessagesScroller(msg) {
     }
   });
 
-  // helper function for message selection
-  let findSelectedMsg = function(scrollIdx) {
-    for (let i = firstTitleLinePerMsg.length - 1; i >= 0; i--) {
-      if (scrollIdx >= firstTitleLinePerMsg[i]) {
-        return MESSAGES[i];
-      }
-    }
-  }
+  //// Additional input handling to extend that of E.showScroller ////
+
+  // Input handling for positive and negative response via swipes.
+  // Emits a touch event that in turn triggers the select function of E.showScroller above.
+  Bangle.swipeHandler = (lr) => {
+    if (lr) {Bangle.emit("touch", 1, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:{swipeLR:lr}});}
+  };
+  Bangle.on("swipe", Bangle.swipeHandler);
 
   // Add an external back touch handler.
+  // Emits a new touch event that in turn triggers the select function of E.showScroller above.
   let touchHandler = (button, xy)=>{
     // if ((left side of Banlge 1 screen) || (top left corner of Bangle 2 screen))
     if ((!xy && 1===button) || (xy && xy.type===0 && xy.x<30 && xy.y<30)) {
@@ -409,6 +410,18 @@ function showMessagesScroller(msg) {
   };
   Bangle.prependListener("touch", touchHandler);
 
+  //// Helper functions ////
+
+  // helper function for message selection
+  let findSelectedMsg = function(scrollIdx) {
+    for (let i = firstTitleLinePerMsg.length - 1; i >= 0; i--) {
+      if (scrollIdx >= firstTitleLinePerMsg[i]) {
+        return MESSAGES[i];
+      }
+    }
+  }
+
+  // Helper function to update new status of messages
   function updateReadMessages() {
     let shownMsgIdxFirst, shownMsgIdxLast;
     const LINES_PER_SCREEN = APP_RECT.h/FONT_HEIGHT;
@@ -446,6 +459,8 @@ function showMessagesScroller(msg) {
     }
     //print(MESSAGES)
   }
+
+  // Helper functions to handle positive and negative responses to messages
   var negHandler,posHandler = [ ];
   if (msg.negative) {
     negHandler = (msg)=>{
@@ -486,10 +501,6 @@ function showMessagesScroller(msg) {
     };
     //footer.push({type:"img",src:atob("QRABAAAAAAAAAAOAAAAABgAAA8AAAAADgAAD4AAAAAHgAAPgAAAAAPgAA+AAAAAAfgAD4///////gAPh///////gA+D///////AD4H//////8cPgAAAAAAPw8+AAAAAAAfB/4AAAAAAA8B/gAAAAAABwB+AAAAAAADAB4AAAAAAAAABgAA=="),col:"#0f0",cb:posHandler});
   }
-  Bangle.swipeHandler = (lr) => {
-    if (lr) {Bangle.emit("touch", 1, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:{swipeLR:lr}});}
-  };
-  Bangle.on("swipe", Bangle.swipeHandler);
 }
 
 function showMessageSettings(msg) {

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -369,8 +369,9 @@ function showMessagesScroller(msg) {
         },0);
       }
       //print(touch)
-      if (touch && touch.type.swipeLR) {
+      if (touch && touch.type.swipeLR!=0) {
         //print("select swipe")
+        updateReadMessages();
         if (touch.type.swipeLR>0 && posHandler) {posHandler(MSG_SELECTED);}
         if (touch.type.swipeLR<0 && negHandler) {negHandler(MSG_SELECTED);}
       }
@@ -378,6 +379,8 @@ function showMessagesScroller(msg) {
     back: function () {
       if (!persist) { return load(); }
       Bangle.removeListener("touch", touchHandler);
+      updateReadMessages();
+      WU&&WU.show();
       returnToMain();
     }
   });

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -118,6 +118,7 @@ function showMessageRouter(msg, persist, explicitDestnation) {
     if ("list"===active) {return returnToMain();}
     if ("settings"===active || "overview"===active) {return;}
   }
+  return showMessagesScroller(msg);
   //if (false) {showMessageSettings(msg);}
 }
 

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -377,6 +377,11 @@ function showMessagesScroller(msg) {
           break;
         }
       }
+    },
+    back: function () {
+      if (!persist) { return load(); }
+      Bangle.removeListener("touch", touchHandler);
+      Bangle.emit("touch", 1, { x: Math.floor(APP_RECT.x2 / 2), y: Math.floor(APP_RECT.y2 / 2), type: { back: true } });
     }
   });
 
@@ -389,31 +394,13 @@ function showMessagesScroller(msg) {
       returnToMain();
       E.stopEventPropagation();
       Bangle.removeListener("touch", touchHandler);
-      if (btnWatch) {clearWatch(btnWatch); btnWatch = undefined;}
     } else if (xy && xy.type===0 && xy.x>175-30 && xy.y<30) {
       Bangle.emit("touch", 2, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:0});
       E.stopEventPropagation();
-      if (btnWatch) {clearWatch(btnWatch); btnWatch = undefined;}
       Bangle.removeListener("touch", touchHandler);
     }
   };
   Bangle.prependListener("touch", touchHandler);
-
-  // If Bangle.js 2 add an external back hw button handler.
-  let btnWatch;
-  if (2===process.env.HWVERSION) {
-    btnWatch = setWatch(()=>{
-      if ("scroller"!==active) {return;}
-      Bangle.emit("drag", {dy:0}); // Compatibility with `kineticscroll`, stopping the scroller so it doesn't continue scrolling when the `showMessageOverview` screen is loaded.
-      // Zero ms timeout as to not move on before the scroller has registered the emitted drag event.
-      setTimeout(()=>{
-        if (!persist) {return load();}
-        Bangle.removeListener("touch", touchHandler);
-        Bangle.emit("touch",1, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:{back:true}});
-      },0);
-    }, BTN);
-  }
-
 
   function updateReadMessages() {
     let shownMsgIdxFirst, shownMsgIdxLast;

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -599,8 +599,14 @@ setTimeout(() => {
 }, 10); // if checkMessages wants to 'load', do that
 
 /* If the Bangle is unlocked by the user, treat that
-as a queue to stop repeated buzzing */
+as a queue to stop repeated buzzing.
+Also suspend the reload timeout while the watch is unlocked. */
 Bangle.on('lock',locked => {
-  if (!locked)
+  if (!locked) {
     require("messages").stopBuzz();
+    cancelReloadTimeout();
+  }
+  if (locked) {
+    if (!persist) {resetReloadTimeout();}
+  }
 });

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -731,9 +731,6 @@ function checkMessages(options) {
     }
     return;
   }
-  // no new messages: show playing music? Only if we have playing music, or state=="show" (set by messagesmusic)
-  if (options.openMusic && MESSAGES.some(m=>m.id=="music" && ((m.track && m.state=="play") || m.state=="show")))
-    return showMessageOverview('music');
   // no new messages - go to clock?
   if (options.clockIfAllRead && newMessages.length==0)
     return load();

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -78,7 +78,7 @@ var onMessagesModified = function(type,msg) {
   }
   if (msg && msg.id=="nav" && msg.t=="modify" && active!="map")
     return; // don't show an updated nav message if we're just in the menu
-  showMessageOverview(msg&&msg.id, false);
+  showMessageRouter(msg, persist, "dependsOnActive");
 };
 Bangle.on("message", onMessagesModified);
 
@@ -455,9 +455,8 @@ function showMessageSettings(msg) {
   E.showMenu(menu);
 }
 
-function showMessageOverview(msgid, persist) {
+function showMessageOverview(msgid) {
   if (replying) { return; }
-  if(!persist) resetReloadTimeout();
   let idx = MESSAGES.findIndex(m=>m.id==msgid);
   var msg = MESSAGES[idx];
   if (updateLabelsInterval) {
@@ -465,14 +464,6 @@ function showMessageOverview(msgid, persist) {
     updateLabelsInterval=undefined;
   }
   if (!msg) return returnToClockIfEmpty(); // go home if no message found
-  if (msg.id=="music") {
-    cancelReloadTimeout(); // don't auto-reload to clock now
-    return showMusicMessage(msg);
-  }
-  if (msg.id=="nav") {
-    cancelReloadTimeout(); // don't auto-reload to clock now
-    return showMapMessage(msg);
-  }
   active = "overview";
   // Normal text message display
   var title=msg.title, titleFont = fontLarge, lines;
@@ -579,8 +570,8 @@ function showMessageOverview(msgid, persist) {
   Bangle.swipeHandler = (lr,ud) => {
     if (lr>0 && posHandler) posHandler();
     if (lr<0 && negHandler) negHandler();
-    if (ud>0 && idx<MESSAGES.length-1) showMessageOverview(MESSAGES[idx+1].id, true);
-    if (ud<0 && idx>0) showMessageOverview(MESSAGES[idx-1].id, true);
+    if (ud>0 && idx<MESSAGES.length-1) showMessageOverview(MESSAGES[idx+1].id);
+    if (ud<0 && idx>0) showMessageOverview(MESSAGES[idx-1].id);
   };
   Bangle.on("swipe", Bangle.swipeHandler);
   g.reset().clearRect(Bangle.appRect);
@@ -630,7 +621,7 @@ function checkMessages(options) {
   }
   // no new messages: show playing music? Only if we have playing music, or state=="show" (set by messagesmusic)
   if (options.openMusic && MESSAGES.some(m=>m.id=="music" && ((m.track && m.state=="play") || m.state=="show")))
-    return showMessageOverview('music', true);
+    return showMessageOverview('music');
   // no new messages - go to clock?
   if (options.clockIfAllRead && newMessages.length==0)
     return load();

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -724,7 +724,7 @@ function checkMessages(options) {
   // If we have a new message, show it
   if (!options.ignoreUnread && newMessages.length) {
     delete newMessages[0].show; // stop us getting stuck here if we're called a second time
-    showMessagesScroller(newMessages[0]);
+    showMessageRouter(newMessages[0], persist);
     // buzz after showMessagesScroller, so being busy during scroller setup doesn't affect the buzz pattern
     if (global.BUZZ_ON_NEW_MESSAGE) {
       // this is set if we entered the messages app by loading `messagegui.new.js`

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -49,6 +49,7 @@ if (Graphics.prototype.setFontIntl) {
 var active; // active screen (undefined/"list"/"music"/"map"/"overview"/"scroller"/"settings")
 var openMusic = false; // go back to music screen after we handle something else?
 var replying = false; // If we're replying to a message, don't interrupt
+var persist = "messagegui.app.js" === global.__FILE__;
 
 /** this is a timeout if the app has started and is showing a single message
 but the user hasn't seen it (eg no user input) - in which case

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -351,31 +351,29 @@ function showMessagesScroller(msg) {
       if (scrollIdx>shownScrollIdxLast) {shownScrollIdxLast = scrollIdx;}
     },
     select : function(scrollIdx, touch) {
-      for (let i=firstTitleLinePerMsg.length-1; i>=0 ; i--) {
-        if (scrollIdx>=firstTitleLinePerMsg[i]) {
-          if (touch && touch.type===2) {return;}
-          const MSG_SELECTED = MESSAGES[i];
-          WU&&WU.show();
-          print(process.memory());
-          E.showScroller();
-          print(process.memory());
-          updateReadMessages();
-          delete titleLines, allLines;
-          if (touch && touch.type.back) {
-            returnToMain();
-          } else if (!touch || touch.type===0) {
-            setTimeout(()=>{
-              showMessageSettings(MSG_SELECTED)
-            },0);
-          }
-          //print(touch)
-          if (touch && touch.type.swipeLR) {
-            //print("select swipe")
-            if (touch.type.swipeLR>0 && posHandler) {posHandler(MSG_SELECTED);}
-            if (touch.type.swipeLR<0 && negHandler) {negHandler(MSG_SELECTED);}
-          }
-          break;
-        }
+      if (touch && touch.type===2) {return;}
+      const MSG_SELECTED = findSelectedMsg(scrollIdx);
+      WU&&WU.show();
+
+      print(process.memory().free);
+      E.showScroller();
+      Bangle.removeListener("swipe", Bangle.swipeHandler);
+      Bangle.removeListener("touch", touchHandler);
+      print(process.memory().free);
+      updateReadMessages();
+      delete titleLines, allLines;
+      if (touch && touch.type.back) {
+        returnToMain();
+      } else if (!touch || touch.type===0) {
+        setTimeout(()=>{
+          showMessageSettings(MSG_SELECTED)
+        },0);
+      }
+      //print(touch)
+      if (touch && touch.type.swipeLR) {
+        //print("select swipe")
+        if (touch.type.swipeLR>0 && posHandler) {posHandler(MSG_SELECTED);}
+        if (touch.type.swipeLR<0 && negHandler) {negHandler(MSG_SELECTED);}
       }
     },
     back: function () {
@@ -384,6 +382,15 @@ function showMessagesScroller(msg) {
       Bangle.emit("touch", 1, { x: Math.floor(APP_RECT.x2 / 2), y: Math.floor(APP_RECT.y2 / 2), type: { back: true } });
     }
   });
+
+  // helper function for message selection
+  let findSelectedMsg = function(scrollIdx) {
+    for (let i = firstTitleLinePerMsg.length - 1; i >= 0; i--) {
+      if (scrollIdx >= firstTitleLinePerMsg[i]) {
+        return MESSAGES[i];
+      }
+    }
+  }
 
   // Add an external back touch handler.
   let touchHandler = (button, xy)=>{

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -512,7 +512,7 @@ function checkMessages(options) {
   E.showScroller({
     h : 50,
     c : Math.max(MESSAGES.length,3), // workaround for 2v10.219 firmware (min 3 not needed for 2v11)
-    draw : function(idx, r) {"ram"
+    draw : function(idx, r) {"ram";
       var msg = MESSAGES[idx];
       if (msg && msg.new) g.setBgColor(g.theme.bgH).setColor(g.theme.fgH);
       else g.setBgColor(g.theme.bg).setColor(g.theme.fg);
@@ -558,7 +558,7 @@ function checkMessages(options) {
   });
 }
 
-function returnToCheckMessages(clock) {
+function returnToCheckMessages() {
   checkMessages({clockIfNoMsg:1,clockIfAllRead:1,ignoreUnread:settings.ignoreUnread,openMusic});
 }
 

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -352,7 +352,8 @@ function showMessagesScroller(msg) {
     },
     select : function(scrollIdx, touch) {
       if (touch && touch.type===2) {return;}
-      const MSG_SELECTED = findSelectedMsg(scrollIdx);
+      const MSG_SELECTED_IDX = findSelectedMsgIdx(scrollIdx);
+      const MSG_SELECTED = MESSAGES[MSG_SELECTED_IDX];
       WU&&WU.show();
 
       print(process.memory().free);
@@ -411,10 +412,10 @@ function showMessagesScroller(msg) {
   //// Helper functions ////
 
   // helper function for message selection
-  let findSelectedMsg = function(scrollIdx) {
+  let findSelectedMsgIdx = function(scrollIdx) {
     for (let i = firstTitleLinePerMsg.length - 1; i >= 0; i--) {
       if (scrollIdx >= firstTitleLinePerMsg[i]) {
-        return MESSAGES[i];
+        return i;
       }
     }
   }

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -492,10 +492,10 @@ function checkMessages(options) {
     delete newMessages[0].show; // stop us getting stuck here if we're called a second time
     showMessage(newMessages[0].id, false);
     // buzz after showMessage, so being busy during layout doesn't affect the buzz pattern
-    if (global.BUZZ_ON_NEW_MESSAGE) {
+    if (globalThis.BUZZ_ON_NEW_MESSAGE) {
       // this is set if we entered the messages app by loading `messagegui.new.js`
       // ... but only buzz the first time we view a new message
-      global.BUZZ_ON_NEW_MESSAGE = false;
+      globalThis.BUZZ_ON_NEW_MESSAGE = false;
       // messages.buzz respects quiet mode - no need to check here
       require("messages").buzz(newMessages[0].src);
     }

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -282,7 +282,7 @@ function showMessagesScroller(msg) {
   const FONT_HEIGHT = g.getFontHeight();
   let initScroll;
   var titleLines = [];
-  let allLines = [];
+  let allLines = [""];
   let firstTitleLinePerMsg = [];
   let footerImgNeg, footerImgPos;
   for (let i=0 ; i<MESSAGES.length ; i++) {

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -362,9 +362,7 @@ function showMessagesScroller(msg) {
       print(process.memory().free);
       updateReadMessages();
       delete titleLines, allLines;
-      if (touch && touch.type.back) {
-        returnToMain();
-      } else if (!touch || touch.type===0) {
+      if (!touch || touch.type===0) {
         setTimeout(()=>{
           showMessageSettings(MSG_SELECTED)
         },0);
@@ -379,7 +377,7 @@ function showMessagesScroller(msg) {
     back: function () {
       if (!persist) { return load(); }
       Bangle.removeListener("touch", touchHandler);
-      Bangle.emit("touch", 1, { x: Math.floor(APP_RECT.x2 / 2), y: Math.floor(APP_RECT.y2 / 2), type: { back: true } });
+      returnToMain();
     }
   });
 

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -384,6 +384,7 @@ function showMessagesScroller(msg) {
     // if ((left side of Banlge 1 screen) || (top left corner of Bangle 2 screen))
     if ((!xy && 1===button) || (xy && xy.type===0 && xy.x<30 && xy.y<30)) {
       if (!persist) {return load();}
+      WU&&WU.show();
       returnToMain();
       E.stopEventPropagation();
       Bangle.removeListener("touch", touchHandler);
@@ -407,7 +408,7 @@ function showMessagesScroller(msg) {
       setTimeout(()=>{
         if (!persist) {return load();}
         Bangle.removeListener("touch", touchHandler);
-        Bangle.emit("touch",1, {type:{back:true}});
+        Bangle.emit("touch",1, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:{back:true}});
       },0);
     }, BTN);
   }

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -280,13 +280,14 @@ function showMessagesScroller(msg) {
   var bodyFont = fontBig;
   g.setFont(bodyFont);
   const FONT_HEIGHT = g.getFontHeight();
-  let initScroll;
+  let initScrollIdx;
   var titleLines = [];
-  let allLines = [""];
+  let allLines = [" "];
   let firstTitleLinePerMsg = [];
   let footerImgNeg, footerImgPos;
   for (let i=0 ; i<MESSAGES.length ; i++) {
-    if (MSG_IDX === i) {initScroll = allLines.length*FONT_HEIGHT;}
+    if (MSG_IDX === i) {initScrollIdx = allLines.length;
+    }
     let msgIter = MESSAGES[i];
 
     var lines = [];
@@ -325,7 +326,7 @@ function showMessagesScroller(msg) {
   let shownScrollIdxLast = 0;
 
   E.showScroller({
-    scroll : initScroll,
+    scroll : initScrollIdx*FONT_HEIGHT,
     h : FONT_HEIGHT, // height of each menu item in pixels
     c : allLines.length, // number of menu items
     // a function to draw a menu item
@@ -340,7 +341,7 @@ function showMessagesScroller(msg) {
           setColor("#f00").drawImage(footerImgNeg,r.x+5+3,r.y).
           setColor("#0f0").drawImage(footerImgPos,r.w-64-5,r.y);
       }
-      if (0===scrollIdx) {
+      if (allLines[scrollIdx]===" ") {
         g.
           setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="), r.x, r.y-1).
           setColor(g.theme.fg2).drawImage(atob("GBgBABgAAf+AB//gD//wH//4P//8P//8fAA+fAA+f//+f//+/AA//AA/f//+f//+fAA+fAA+P//8P//8H//4D//wB//gAf+AABgA"),r.w-24,r.y-1);
@@ -387,6 +388,11 @@ function showMessagesScroller(msg) {
       E.stopEventPropagation();
       Bangle.removeListener("touch", touchHandler);
       if (btnWatch) {clearWatch(btnWatch); btnWatch = undefined;}
+    } else if (xy && xy.type===0 && xy.x>175-30 && xy.y<30) {
+      Bangle.emit("touch", 2, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:0});
+      E.stopEventPropagation();
+      if (btnWatch) {clearWatch(btnWatch); btnWatch = undefined;}
+      Bangle.removeListener("touch", touchHandler);
     }
   };
   Bangle.prependListener("touch", touchHandler);
@@ -401,7 +407,7 @@ function showMessagesScroller(msg) {
       setTimeout(()=>{
         if (!persist) {return load();}
         Bangle.removeListener("touch", touchHandler);
-        Bangle.emit("touch", 1, {x:Math.floor(APP_RECT.x2/2), y:Math.floor(APP_RECT.y2/2), type:{back:true}});
+        Bangle.emit("touch",1, {type:{back:true}});
       },0);
     }, BTN);
   }

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -722,10 +722,10 @@ function checkMessages(options) {
     delete newMessages[0].show; // stop us getting stuck here if we're called a second time
     showMessagesScroller(newMessages[0]);
     // buzz after showMessagesScroller, so being busy during scroller setup doesn't affect the buzz pattern
-    if (globalThis.BUZZ_ON_NEW_MESSAGE) {
+    if (global.BUZZ_ON_NEW_MESSAGE) {
       // this is set if we entered the messages app by loading `messagegui.new.js`
       // ... but only buzz the first time we view a new message
-      globalThis.BUZZ_ON_NEW_MESSAGE = false;
+      global.BUZZ_ON_NEW_MESSAGE = false;
       // messages.buzz respects quiet mode - no need to check here
       require("messages").buzz(newMessages[0].src);
     }

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -341,7 +341,9 @@ function showMessagesScroller(msg) {
           setColor("#0f0").drawImage(footerImgPos,r.w-64-5,r.y);
       }
       if (0===scrollIdx) {
-        g.setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="), r.x, r.y);
+        g.
+          setColor("#f00").drawImage(atob("GBiBAAAYAAH/gAf/4A//8B//+D///D///H/P/n+H/n8P/n4f/vwAP/wAP34f/n8P/n+H/n/P/j///D///B//+A//8Af/4AH/gAAYAA=="), r.x, r.y-1).
+          setColor(g.theme.fg2).drawImage(atob("GBgBABgAAf+AB//gD//wH//4P//8P//8fAA+fAA+f//+f//+/AA//AA/f//+f//+fAA+fAA+P//8P//8H//4D//wB//gAf+AABgA"),r.w-24,r.y-1);
       }
       if (scrollIdx<shownScrollIdxFirst) {shownScrollIdxFirst = scrollIdx;}
       if (scrollIdx>shownScrollIdxLast) {shownScrollIdxLast = scrollIdx;}

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -284,7 +284,7 @@ function showMessagesScroller(msg) {
   var titleLines = [];
   let allLines = [];
   let firstTitleLinePerMsg = [];
-  let footerImgs = {};
+  let footerImgNeg, footerImgPos;
   for (let i=0 ; i<MESSAGES.length ; i++) {
     if (MSG_IDX === i) {initScroll = allLines.length*FONT_HEIGHT;}
     let msgIter = MESSAGES[i];
@@ -299,14 +299,14 @@ function showMessagesScroller(msg) {
     let footer = [""];
     if (msg.negative) {
       //footer[0] += "<" + "-".repeat(4) + " " + ((!msg.reply&&!msg.positive)?" ".repeat(6):"");
-      footerImgs.neg = {src:atob("PhAB4A8AAAAAAAPAfAMAAAAAD4PwHAAAAAA/H4DwAAAAAH78B8AAAAAA/+A/AAAAAAH/Af//////w/gP//////8P4D///////H/Af//////z/4D8AAAAAB+/AfAAAAAA/H4DwAAAAAPg/AcAAAAADwHwDAAAAAA4A8AAAAAAAA=="),col:"#f00"}
+      footerImgNeg = atob("PhAB4A8AAAAAAAPAfAMAAAAAD4PwHAAAAAA/H4DwAAAAAH78B8AAAAAA/+A/AAAAAAH/Af//////w/gP//////8P4D///////H/Af//////z/4D8AAAAAB+/AfAAAAAA/H4DwAAAAAPg/AcAAAAADwHwDAAAAAA4A8AAAAAAAA==");
     }
     if (msg.reply && reply) {
       //footer[0] += ((!msg.negative)?" ".repeat(6):"") + " " + "-".repeat(4) + ">";
-      footerImgs.pos = {src:atob("QRABAAAAAAAH//+AAAAABgP//8AAAAADgf//4AAAAAHg4ABwAAAAAPh8APgAAAAAfj+B////////geHv///////hf+f///////GPw///////8cGBwAAAAAPx/gDgAAAAAfD/gHAAAAAA8DngOAAAAABwDHP8AAAAADACGf4AAAAAAAAM/w=="),col:"#0f0"}
+      footerImgPos = atob("QRABAAAAAAAH//+AAAAABgP//8AAAAADgf//4AAAAAHg4ABwAAAAAPh8APgAAAAAfj+B////////geHv///////hf+f///////GPw///////8cGBwAAAAAPx/gDgAAAAAfD/gHAAAAAA8DngOAAAAABwDHP8AAAAADACGf4AAAAAAAAM/w==");
     } else if (msg.positive) {
       //footer[0] += ((!msg.negative)?" ".repeat(6):"") + " " + "-".repeat(4) + ">";
-      footerImgs.pos = {src:atob("QRABAAAAAAAAAAOAAAAABgAAA8AAAAADgAAD4AAAAAHgAAPgAAAAAPgAA+AAAAAAfgAD4///////gAPh///////gA+D///////AD4H//////8cPgAAAAAAPw8+AAAAAAAfB/4AAAAAAA8B/gAAAAAABwB+AAAAAAADAB4AAAAAAAAABgAA=="),col:"#0f0"}
+      footerImgPos = atob("QRABAAAAAAAAAAOAAAAABgAAA8AAAAADgAAD4AAAAAHgAAPgAAAAAPgAA+AAAAAAfgAD4///////gAPh///////gA+D///////AD4H//////8cPgAAAAAAPw8+AAAAAAAfB/4AAAAAAA8B/gAAAAAABwB+AAAAAAADAB4AAAAAAAAABgAA==");
     }
     if (!footer) {
       footer = ["-".repeat(12)];
@@ -337,8 +337,8 @@ function showMessagesScroller(msg) {
       g.setFont(bodyFont).setFontAlign(0,-1).drawString(allLines[scrollIdx], r.x+r.w/2, r.y);
       if (allLines[scrollIdx]==="") {
         g.
-          setColor(footerImgs.neg.col).drawImage(footerImgs.neg.src,r.x+5+3,r.y).
-          setColor(footerImgs.pos.col).drawImage(footerImgs.pos.src,r.w-64-5,r.y);
+          setColor("#f00").drawImage(footerImgNeg,r.x+5+3,r.y).
+          setColor("#0f0").drawImage(footerImgPos,r.w-64-5,r.y);
       }
       if (scrollIdx<shownScrollIdxFirst) {shownScrollIdxFirst = scrollIdx;}
       if (scrollIdx>shownScrollIdxLast) {shownScrollIdxLast = scrollIdx;}

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.85",
+  "version": "0.86",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
WIP

Initializes the scroller with ~~three~~ all messages loaded, scrolled to the chosen message. You can scroll up/down to see the rest of the messages.

~~This is far from merge ready and I'm not sure it should ever be merged. Should be implemented as a setting if to be merged I think.~~ I'm inching closer to something that could be considered for merging.

With that said it can be tried from my app loader: https://thyttan.github.io/BangleApps/?id=messagegui