### PR TITLE
andark: Restore redraw on charging and small fixups

### DIFF
--- a/apps/andark/ChangeLog
+++ b/apps/andark/ChangeLog
@@ -6,4 +6,4 @@
       add settings for widgets, order of drawing and hour hand length
 0.06: Fix issue showing widgets when app is fast-loaded into from launcher with widgets disabled
 0.07: Enable fast loading and queue updates to the second
-0.08: Restore redraw on charging event
+0.08: Restore redraw on charging event + fixup for safer fast-loading

--- a/apps/andark/ChangeLog
+++ b/apps/andark/ChangeLog
@@ -6,3 +6,4 @@
       add settings for widgets, order of drawing and hour hand length
 0.06: Fix issue showing widgets when app is fast-loaded into from launcher with widgets disabled
 0.07: Enable fast loading and queue updates to the second
+0.08: Restore redraw on charging event

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -12,9 +12,9 @@ const zahlpos=(function() {
   let z=[];
   let sk=1;
   for(let i=-10;i<50;i+=5){
-     let win=i*2*Math.PI/60;
-     let xsk =c.x+2+Math.cos(win)*(c.x-10),
-         ysk =c.y+2+Math.sin(win)*(c.x-10);
+    let win=i*2*Math.PI/60;
+    let xsk =c.x+2+Math.cos(win)*(c.x-10),
+        ysk =c.y+2+Math.sin(win)*(c.x-10);
     if(sk==3){xsk-=10;}
     if(sk==6){ysk-=10;}
     if(sk==9){xsk+=10;}
@@ -26,8 +26,7 @@ const zahlpos=(function() {
   return z;
 })();
 
-
-let zeiger = function(len,dia,tim){
+let zeiger = function(len,dia,tim) {
   const x=c.x+ Math.cos(tim)*len/2,
         y=c.y + Math.sin(tim)*len/2,
         d={"d":3,"x":dia/2*Math.cos(tim+Math.PI/2),"y":dia/2*Math.sin(tim+Math.PI/2)},
@@ -81,7 +80,7 @@ let drawNumbers = function() {
   g.setColor(1,1,1);
   g.setBgColor(0,0,0);
   for(let i = 0;i<12;i++){
-     g.drawString(zahlpos[i][0],zahlpos[i][1],zahlpos[i][2],true);
+    g.drawString(zahlpos[i][0],zahlpos[i][1],zahlpos[i][2],true);
   }
 };
 
@@ -96,7 +95,7 @@ let queueDraw = function() {
   }, queueMillis - (Date.now() % queueMillis));
 };
 
-let draw = function(){
+let draw = function() {
   // draw black rectangle in the middle to clear screen from scale and hands
   g.setColor(0,0,0);
   g.fillRect(10,10,2*c.x-10,2*c.x-10);
@@ -114,7 +113,7 @@ let draw = function(){
 };
 
 //draws the scale once the app is startet
-let drawScale = function(){
+let drawScale = function() {
   // clear the screen
   g.setBgColor(0,0,0);
   g.clear();
@@ -141,7 +140,8 @@ Bangle.setUI({
     Bangle.removeListener('lcdPower', updateState);
     Bangle.removeListener('lock', updateState);
     require("widget_utils").show();
-}});
+  }
+});
 // Load widgets if needed, and make them show swipeable
 if (settings.loadWidgets) {
   Bangle.loadWidgets();
@@ -149,24 +149,23 @@ if (settings.loadWidgets) {
 } else if (global.WIDGETS) require("widget_utils").hide();
 
 let updateState = function() {
-   if (Bangle.isLCDOn()) {
-     if (!Bangle.isLocked()) {
-       queueMillis = 1000;
-       unlock = true;
-     } else {
-       queueMillis = 60000;
-       unlock = false;
-   }
-     draw();
-   } else {
+  if (Bangle.isLCDOn()) {
+    if (!Bangle.isLocked()) {
+      queueMillis = 1000;
+      unlock = true;
+    } else {
+      queueMillis = 60000;
+      unlock = false;
+    }
+    draw();
+  } else {
     if (drawTimeout) clearTimeout(drawTimeout);
     drawTimeout = undefined;
-   }
+  }
 };
 
 // Stop updates when LCD is off, restart when on
 Bangle.on('lcdPower', updateState);
-
 Bangle.on('lock', updateState);
 
 let unlock = true;

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -88,6 +88,22 @@ let drawTimeout;
 let queueMillis = 1000;
 let unlock = true;
 
+const updateState = function() {
+  if (Bangle.isLCDOn()) {
+    if (!Bangle.isLocked()) {
+      queueMillis = 1000;
+      unlock = true;
+    } else {
+      queueMillis = 60000;
+      unlock = false;
+    }
+    draw();
+  } else {
+    if (drawTimeout) clearTimeout(drawTimeout);
+    drawTimeout = undefined;
+  }
+};
+
 const queueDraw = function() {
   if (drawTimeout) clearTimeout(drawTimeout);
   drawTimeout = setTimeout(function() {
@@ -150,22 +166,6 @@ if (settings.loadWidgets) {
   Bangle.loadWidgets();
   require("widget_utils").swipeOn();
 } else if (global.WIDGETS) require("widget_utils").hide();
-
-const updateState = function() {
-  if (Bangle.isLCDOn()) {
-    if (!Bangle.isLocked()) {
-      queueMillis = 1000;
-      unlock = true;
-    } else {
-      queueMillis = 60000;
-      unlock = false;
-    }
-    draw();
-  } else {
-    if (drawTimeout) clearTimeout(drawTimeout);
-    drawTimeout = undefined;
-  }
-};
 
 // Stop updates when LCD is off, restart when on
 Bangle.on('lcdPower', updateState);

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -139,6 +139,7 @@ Bangle.setUI({
     drawTimeout = undefined;
     Bangle.removeListener('lcdPower', updateState);
     Bangle.removeListener('lock', updateState);
+    Bangle.removeListener('charging', draw);
     require("widget_utils").show();
   }
 });
@@ -167,6 +168,7 @@ let updateState = function() {
 // Stop updates when LCD is off, restart when on
 Bangle.on('lcdPower', updateState);
 Bangle.on('lock', updateState);
+Bangle.on('charging', draw); // Immediately redraw when charger (dis)connected
 
 let unlock = true;
 updateState();

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -26,7 +26,7 @@ const zahlpos=(function() {
   return z;
 })();
 
-let zeiger = function(len,dia,tim) {
+const zeiger = function(len,dia,tim) {
   const x=c.x+ Math.cos(tim)*len/2,
         y=c.y + Math.sin(tim)*len/2,
         d={"d":3,"x":dia/2*Math.cos(tim+Math.PI/2),"y":dia/2*Math.sin(tim+Math.PI/2)},
@@ -34,7 +34,7 @@ let zeiger = function(len,dia,tim) {
   return pol;
 };
 
-let drawHands = function(d) {
+const drawHands = function(d) {
   let m=d.getMinutes(), h=d.getHours(), s=d.getSeconds();
   g.setColor(1,1,1);
 
@@ -61,20 +61,20 @@ let drawHands = function(d) {
   g.fillCircle(c.x,c.y,4);
 };
 
-let drawText = function(d) {
+const drawText = function(d) {
   g.setFont("Vector",10);
   g.setBgColor(0,0,0);
   g.setColor(1,1,1);
-  let dateStr = require("locale").date(d);
+  const dateStr = require("locale").date(d);
   g.drawString(dateStr, c.x, c.y+20, true);
-  let batStr = Math.round(E.getBattery()/5)*5+"%";
+  const batStr = Math.round(E.getBattery()/5)*5+"%";
   if (Bangle.isCharging()) {
     g.setBgColor(1,0,0);
   }
   g.drawString(batStr, c.x, c.y+40, true);
 };
 
-let drawNumbers = function() {
+const drawNumbers = function() {
   //draws the numbers on the screen
   g.setFont("Vector",20);
   g.setColor(1,1,1);
@@ -86,8 +86,9 @@ let drawNumbers = function() {
 
 let drawTimeout;
 let queueMillis = 1000;
+let unlock = true;
 
-let queueDraw = function() {
+const queueDraw = function() {
   if (drawTimeout) clearTimeout(drawTimeout);
   drawTimeout = setTimeout(function() {
     drawTimeout = undefined;
@@ -95,7 +96,7 @@ let queueDraw = function() {
   }, queueMillis - (Date.now() % queueMillis));
 };
 
-let draw = function() {
+const draw = function() {
   // draw black rectangle in the middle to clear screen from scale and hands
   g.setColor(0,0,0);
   g.fillRect(10,10,2*c.x-10,2*c.x-10);
@@ -113,7 +114,7 @@ let draw = function() {
 };
 
 //draws the scale once the app is startet
-let drawScale = function() {
+const drawScale = function() {
   // clear the screen
   g.setBgColor(0,0,0);
   g.clear();
@@ -150,7 +151,7 @@ if (settings.loadWidgets) {
   require("widget_utils").swipeOn();
 } else if (global.WIDGETS) require("widget_utils").hide();
 
-let updateState = function() {
+const updateState = function() {
   if (Bangle.isLCDOn()) {
     if (!Bangle.isLocked()) {
       queueMillis = 1000;
@@ -171,7 +172,6 @@ Bangle.on('lcdPower', updateState);
 Bangle.on('lock', updateState);
 Bangle.on('charging', draw); // Immediately redraw when charger (dis)connected
 
-let unlock = true;
 updateState();
 drawScale();
 draw();

--- a/apps/andark/app.js
+++ b/apps/andark/app.js
@@ -135,11 +135,12 @@ let drawScale = function() {
 Bangle.setUI({
   mode: "clock",
   remove: function() {
-    if (drawTimeout) clearTimeout(drawTimeout);
-    drawTimeout = undefined;
     Bangle.removeListener('lcdPower', updateState);
     Bangle.removeListener('lock', updateState);
     Bangle.removeListener('charging', draw);
+    // We clear drawTimout after removing all listeners, because they can add one again
+    if (drawTimeout) clearTimeout(drawTimeout);
+    drawTimeout = undefined;
     require("widget_utils").show();
   }
 });

--- a/apps/andark/metadata.json
+++ b/apps/andark/metadata.json
@@ -1,7 +1,7 @@
 { "id": "andark",
   "name": "Analog Dark",
   "shortName":"AnDark",
-  "version":"0.07",
+  "version":"0.08",
   "description": "analog clock face without disturbing widgets",
   "icon": "andark_icon.png",
   "type": "clock",


### PR DESCRIPTION
PR #3678 removed immediate redrawing on charging, which is inconvenient, since when you connect the charger, watches may be locked and thus not redrawing, not showing the charging status. Additionally, I did a small correction regarding to the cleanup order to make fast loading work well, since one timeout was removed before a callback that could reset it again. Also, I did some (I hope) reasonable refactoring. I did all in separate commits to make the review easier.