### PR TITLE
[clockcal] Added an option to show weeks prior to the current week on clock calendar

### DIFF
--- a/apps/clockcal/ChangeLog
+++ b/apps/clockcal/ChangeLog
@@ -8,3 +8,4 @@
 0.08: Fixed typo in settings.js for DRAGDOWN to make option work
 0.09: You can now back out of the calendar using the button
 0.10: Fix linter warnings
+0.11: Added option to show prior weeks on clock calendar

--- a/apps/clockcal/app.js
+++ b/apps/clockcal/app.js
@@ -188,7 +188,7 @@ function drawWatch() {
             bottomrightY = y * CELL_H + CAL_Y;
             g.setFont("Vector", 16);
             var fg = ((s.REDSUN && rD.getDay() == 0) || (s.REDSAT && rD.getDay() == 6)) ? '#f00' : '#fff';
-            if (y == 1 && today == rDate) {
+            if (y == s.CAL_ROWS_PRIOR + 1 && today == rDate) {
                 g.setColor('#0f0');
                 g.fillRect(bottomrightX - CELL_W + 1, bottomrightY - CELL_H - 1, bottomrightX, bottomrightY - 2);
                 g.setColor('#000');

--- a/apps/clockcal/app.js
+++ b/apps/clockcal/app.js
@@ -2,7 +2,8 @@ Bangle.setUI("clock");
 Bangle.loadWidgets();
 
 var s = Object.assign({
-    CAL_ROWS: 4, //number of calendar rows.(weeks) Shouldn't exceed 5 when using widgets.
+    CAL_ROWS: 4, //total number of calendar rows.(weeks) Shouldn't exceed 5 when using widgets.
+    CAL_ROWS_PRIOR: 0, //number of calendar rows.(weeks) that show above the current week
     BUZZ_ON_BT: true, //2x slow buzz on disconnect, 2x fast buzz on connect. Will be extra widget eventually
     MODE24: true, //24h mode vs 12h mode
     FIRSTDAY: 6, //First day of the week: mo, tu, we, th, fr, sa, su
@@ -178,7 +179,7 @@ function drawWatch() {
     const dow = (s.FIRSTDAY + d.getDay()) % 7; //MO=0, SU=6
     const today = d.getDate();
     var rD = new Date(d.getTime());
-    rD.setDate(rD.getDate() - dow);
+    rD.setDate(rD.getDate() - dow - s.CAL_ROWS_PRIOR * 7);
     var rDate = rD.getDate();
     g.setFontAlign(1, 1);
     for (var y = 1; y <= s.CAL_ROWS; y++) {

--- a/apps/clockcal/settings.js
+++ b/apps/clockcal/settings.js
@@ -2,6 +2,7 @@
     var FILE = "clockcal.json";
     const defaults={
         CAL_ROWS: 4, //number of calendar rows.(weeks) Shouldn't exceed 5 when using widgets.
+        CAL_ROWS_PRIOR: 0, //number of calendar rows.(weeks) that show above the current week
         BUZZ_ON_BT: true, //2x slow buzz on disconnect, 2x fast buzz on connect. Will be extra widget eventually
         MODE24: true, //24h mode vs 12h mode
         FIRSTDAY: 6, //First day of the week: mo, tu, we, th, fr, sa, su
@@ -36,6 +37,14 @@
             min: 0, max: 6,
             onchange: v => {
                 settings.CAL_ROWS = v;
+                writeSettings();
+            }
+        },
+        '#Cal Rows Prior': {
+            value: settings.CAL_ROWS_PRIOR,
+            min: 0, max: 4,
+            onchange: v => {
+                settings.CAL_ROWS_PRIOR = v;
                 writeSettings();
             }
         },

--- a/apps/clockcal/settings.js
+++ b/apps/clockcal/settings.js
@@ -1,7 +1,7 @@
 (function (back) {
     var FILE = "clockcal.json";
     const defaults={
-        CAL_ROWS: 4, //number of calendar rows.(weeks) Shouldn't exceed 5 when using widgets.
+        CAL_ROWS: 4, //total number of calendar rows.(weeks) Shouldn't exceed 5 when using widgets.
         CAL_ROWS_PRIOR: 0, //number of calendar rows.(weeks) that show above the current week
         BUZZ_ON_BT: true, //2x slow buzz on disconnect, 2x fast buzz on connect. Will be extra widget eventually
         MODE24: true, //24h mode vs 12h mode


### PR DESCRIPTION
- Added setting `CAL_ROWS_PRIOR: 0-4`. This does not affect `CAL_ROWS`
- In app.js, `drawWatch()` will now subtract `CAL_ROWS_PRIOR * 7` from the first day of the clock calendar
- In app.js, `drawWatch()` will now find `today` by accounting for `CAL_ROWS_PRIOR`