### PR TITLE
Fixed taglauncher crashing with certain apps installed

### DIFF
--- a/apps/taglaunch/ChangeLog
+++ b/apps/taglaunch/ChangeLog
@@ -4,3 +4,4 @@
       Add tag 'health' for apps like Heart Rate Monitor
 0.04: Fix remove handler
 0.05: Make the "App source not found" warning less buggy
+0.06: Fixed a crash if an app has no tags (app.tags is undefined)

--- a/apps/taglaunch/README.md
+++ b/apps/taglaunch/README.md
@@ -26,5 +26,5 @@ Creator
 Contributors
 --------
 
-[atjn](https://github.com/atjn)
-[BlueFox4](https://github.com/BlueFox4)
+- [atjn](https://github.com/atjn)
+- [BlueFox4](https://github.com/BlueFox4)

--- a/apps/taglaunch/README.md
+++ b/apps/taglaunch/README.md
@@ -1,4 +1,4 @@
-Launcher
+Tag Launcher
 ========
 
 Based on the default launcher but puts all applications in a submenu by their tag.

--- a/apps/taglaunch/README.md
+++ b/apps/taglaunch/README.md
@@ -13,3 +13,18 @@ Settings
 - `Vector Font Size` - The size of the font if `Font` is set to `Vector`. Default `10`.
 - `Show Clocks` -  If set to `No` then clocks won't appear in the app list. Default `Yes`.
 - `Fullscreen` - If set to `Yes` then widgets won't be loaded. Default `No`.
+
+
+Acknowledgements
+========
+
+Creator
+--------
+
+[nxdefiant](https://github.com/nxdefiant)
+
+Contributors
+--------
+
+[atjn](https://github.com/atjn)
+[BlueFox4](https://github.com/BlueFox4)

--- a/apps/taglaunch/app.js
+++ b/apps/taglaunch/app.js
@@ -48,15 +48,20 @@ if (launchCache.hash!=launchHash) {
     .filter(app=>app && app.type=="app" || app.type=="clock" || !app.type)
     .sort((a,b)=>sort(a,b))
     .forEach(app => {
-      let appTags = app.tags.split(",")
-        .map(tag => tag.trim())
-        .map(tag => tag === "tools" ? "tool" : tag) // tool = tools
-        .filter(tag => Object.keys(tags).includes(tag));
-      if (appTags.length === 0) {
+      let appTags = [];
+      if (!app.tags) {
         appTags.push("misc");
-      } else if (appTags.length > 1 && appTags.indexOf("tool") >= 0) {
-        // everything has tag 'tool', unregister when at least one other known tag
-        appTags.splice(appTags.indexOf("tool"), 1);
+      } else {
+        appTags = app.tags.split(",")
+          .map(tag => tag.trim())
+          .map(tag => tag === "tools" ? "tool" : tag) // tool = tools
+          .filter(tag => Object.keys(tags).includes(tag));
+        if (appTags.length === 0) {
+          appTags.push("misc");
+        } else if (appTags.length > 1 && appTags.indexOf("tool") >= 0) {
+          // everything has tag 'tool', unregister when at least one other known tag
+          appTags.splice(appTags.indexOf("tool"), 1);
+        }
       }
       appTags.forEach(tag => appsByTag[tag].push(app));
     });

--- a/apps/taglaunch/metadata.json
+++ b/apps/taglaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "taglaunch",
   "name": "Tag Launcher",
   "shortName": "Taglauncher",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Launcher that puts all applications into submenus based on their tag. With many applications installed this can result in a faster application selection than the linear access of the default launcher.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
If an app has no tags (e.g. [Drained](https://banglejs.com/apps/?id=drained&readme), in my case), it caused taglauncher to crash because of a missing check (and in turn running .split on undefined). This missing check was added and apps without the tag are now added to the Misc category automatically.
I also fixed some code indentation issues.

Real changes to app.js only from lines 51-61 in the old app.js (or ll. 75-90 in the new app.js).