### PR TITLE
calendar: read events synchronized from Gadgetbridge

### DIFF
--- a/apps/calendar/ChangeLog
+++ b/apps/calendar/ChangeLog
@@ -19,3 +19,4 @@
       Display Widgets in menus
 0.17: Load holidays before events so the latter is not overpainted
 0.18: Minor code improvements
+0.19: Read events synchronized from Gadgetbridge

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -60,6 +60,12 @@ const loadEvents = () => {
     date.setSeconds(time.s);
     return {date: date, msg: a.msg, type: "e"};
   }));
+  // all events synchronized from Gadgetbridge
+  events = events.concat((require("Storage").readJSON("android.calendar.json",1) || []).map(a => {
+    // timestamp is in seconds, Date requires milliseconds
+    const date = new Date(a.timestamp * 1000);
+    return {date: date, msg: a.title, type: "e"};
+  }));
 };
 
 const loadSettings = () => {

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -227,8 +227,8 @@ const drawCalendar = function(date) {
   }, []);
   let i = 0;
   g.setFont("8x12", fontSize);
-  for (y = 0; y < rowN - 1; y++) {
-    for (x = 0; x < colN; x++) {
+  for (let y = 0; y < rowN - 1; y++) {
+    for (let x = 0; x < colN; x++) {
       i++;
       const day = days[i];
       const curMonth = day < 15 ? month+1 : day < 50 ? month-1 : month;

--- a/apps/calendar/metadata.json
+++ b/apps/calendar/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "calendar",
   "name": "Calendar",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Monthly calendar, displays holidays uploaded from the web interface and scheduled events.",
   "icon": "calendar.png",
   "screenshots": [{"url":"screenshot_calendar.png"}],


### PR DESCRIPTION
This is a partial fix for feature request #3707.  This allows synchronized events (stored in "android.calendar.json") to be shown in the app, alongside the manually entered events and alarm events that are already shown.

This is a sort of minimum viable implementation of the feature request, as it does not address most of what @nxdefiant and I discussed.  I hope we can work toward those in the future.  Specifically:

- The file "calendar.days.json" is still read from and written to when creating events in the app.
- All events from "android.calendar.json" are assumed to not be holidays, just regular events.
- No UI is added to expose the extra information available in the synchronized events (e.g. duration, description).