### PR TITLE
bwclk & bwclklite: Support 12-hour time format.

### DIFF
--- a/apps/bwclk/ChangeLog
+++ b/apps/bwclk/ChangeLog
@@ -33,3 +33,4 @@ clkinfo.addInteractive that would cause ReferenceError.
 0.31: Use clock_info module as an app
 0.32: Make the border of the clock_info box extend all the way to the right of the screen.
 0.33: Fix issue rendering ClockInfos with for fg+bg color set to the same (#2749)
+0.34: Support 12-hour time format

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -239,11 +239,9 @@ let drawTime = function() {
   var y = y1;
   var date = new Date();
 
-  var hours = String(date.getHours());
-  var minutes = date.getMinutes();
-  minutes = minutes < 10 ? String("0") + minutes : minutes;
-  var colon = settings.hideColon ? "" : ":";
-  var timeStr = hours + colon + minutes;
+  var timeStr = locale.time(date, 1);
+  if (settings.hideColon)
+    timeStr = timeStr.replace(":", "");
 
   // Set y coordinates correctly
   y += parseInt((H - y)/2) + 5;

--- a/apps/bwclk/metadata.json
+++ b/apps/bwclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bwclk",
   "name": "BW Clock",
-  "version": "0.33",
+  "version": "0.34",
   "description": "A very minimalistic clock.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/bwclklite/ChangeLog
+++ b/apps/bwclklite/ChangeLog
@@ -36,3 +36,4 @@ clkinfo.addInteractive that would cause ReferenceError.
       Do an quick inital fillRect on theclock info area.
 0.33: Make the border of the clock_info box extend all the way to the right of the screen.
 0.34: Fix issue rendering ClockInfos with for fg+bg color set to the same (#2749)
+0.35: Support 12-hour time format

--- a/apps/bwclklite/app.js
+++ b/apps/bwclklite/app.js
@@ -199,11 +199,9 @@ let drawTime = function() {
   let y = y1;
   let date = new Date();
 
-  let hours = String(date.getHours());
-  let minutes = date.getMinutes();
-  minutes = minutes < 10 ? String("0") + minutes : minutes;
-  let colon = settings.hideColon ? "" : ":";
-  let timeStr = hours + colon + minutes;
+  var timeStr = locale.time(date, 1);
+  if (settings.hideColon)
+    timeStr = timeStr.replace(":", "");
 
   // Set y coordinates correctly
   y += parseInt((H - y)/2) + 5;

--- a/apps/bwclklite/metadata.json
+++ b/apps/bwclklite/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bwclklite",
   "name": "BW Clock Lite",
-  "version": "0.34",
+  "version": "0.35",
   "description": "A very minimalistic clock. This version of BW Clock is quicker at the cost of the custom font.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
This modifies how the time string is generated so it respects the system's locale settings, specifically for 12-hour time.  This is done with the locale package, which also simplifies some of the string handling since the package creates a complete time string.  Note this does not add any display of AM/PM, but neither do any other clock faces.