### PR TITLE
calendar: properly display synced all-day events.

### DIFF
--- a/apps/calendar/ChangeLog
+++ b/apps/calendar/ChangeLog
@@ -20,3 +20,4 @@
 0.17: Load holidays before events so the latter is not overpainted
 0.18: Minor code improvements
 0.19: Read events synchronized from Gadgetbridge
+0.20: Correct start time of all-day events synchronized from Gadgetbridge

--- a/apps/calendar/calendar.js
+++ b/apps/calendar/calendar.js
@@ -62,9 +62,11 @@ const loadEvents = () => {
   }));
   // all events synchronized from Gadgetbridge
   events = events.concat((require("Storage").readJSON("android.calendar.json",1) || []).map(a => {
-    // timestamp is in seconds, Date requires milliseconds
-    const date = new Date(a.timestamp * 1000);
-    return {date: date, msg: a.title, type: "e"};
+    // All-day events always start at 00:00:00 UTC, so we need to "undo" the
+    // timezone offsetting to make sure that the day is correct.
+    const offset = a.allDay ? new Date().getTimezoneOffset() * 60 : 0
+    const date = new Date((a.timestamp+offset) * 1000);
+    return {date: date, msg: a.title, type: a.allDay ? "o" : "e"};
   }));
 };
 

--- a/apps/calendar/metadata.json
+++ b/apps/calendar/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "calendar",
   "name": "Calendar",
-  "version": "0.19",
+  "version": "0.20",
   "description": "Monthly calendar, displays holidays uploaded from the web interface and scheduled events.",
   "icon": "calendar.png",
   "screenshots": [{"url":"screenshot_calendar.png"}],


### PR DESCRIPTION
Discovered that, in the events synchronized from Gadgetbridge, all-day events have timestamps that disregard local timezones.  Specifically, all-day events always start at midnight UTC, which caused calendar to display them starting at a different time depending on time zone offset (e.g. for my offset of -5, I see all-day events start at 19:00 the day before).  Borrowed [logic from the agenda app](https://github.com/espruino/BangleApps/blob/c51785467c006b5521def8985b0602e013719653/apps/agenda/agenda.js#L33-L39) to correct this.  This logic shifts an all-day event's start time to start at midnight in the current time zone.

Also specify all-day events as type "o" (other) so the full day is highlighted and the start time is not displayed.

Note that this does nothing to handle all-day events that span more than one day (only the first day is highlighted in the calendar).  Also note that I'm not sure how this will handle time zone changes, like shifting to/from daylight savings time.

Edit to add that I tested this with synchronized events of both all-day and not-all-day types, and with a variety of time zone offsets, including positive, negative, and zero.