### PR TITLE
cleanup removing wrongly named "Changelog" for three apps

### DIFF
--- a/apps/batterybooster/Changelog
+++ b/apps/batterybooster/Changelog
@@ -1,1 +1,0 @@
-0.1: New app introduced to the app loader!

--- a/apps/cutelauncher/Changelog
+++ b/apps/cutelauncher/Changelog
@@ -1,4 +1,0 @@
-0.27: New app introduced to the app loader!
-0.28: Adjusted icon size to better fit with native dimensions (48x48)
-0.29: Draw function optimization
-0.30: Refine initial scrollbar position

--- a/apps/onewordclock/Changelog
+++ b/apps/onewordclock/Changelog
@@ -1,1 +1,0 @@
-0.97: New app introduced to the app loader!


### PR DESCRIPTION
This was causing problems while trying to clone the repository: https://github.com/espruino/BangleApps/commit/38bce756a2c33820abc44bd0f6902a40a9becd33#diff-d24e4cc8e51380b4b47f84875bfed211ad8fa2c92e96bfaf5985a4d7d2fbd734