### PR TITLE
noteify: make notes available to clock info.

### DIFF
--- a/apps/noteify/ChangeLog
+++ b/apps/noteify/ChangeLog
@@ -1,3 +1,4 @@
 0.01: Initial version
 0.02: Use default Bangle formatter for booleans
 0.03: Drop duplicate alarm widget
+0.04: Make notes available to clock info

--- a/apps/noteify/README.md
+++ b/apps/noteify/README.md
@@ -10,6 +10,7 @@ This app uses the [Scheduler library](https://banglejs.com/apps/?id=sched) and r
 * By selecting "set as alarm" or "set as timer", you can also use this note as a custom message for alerts from alarms and timers. Once you hit save, the alarm or timer is set.
 * Any alarms or timers you set will appear under "edit alarms/timers." If the alarm/timer is set to a note, the note will appear on the top of the menu. If an alarm/timer is set without a custom message, it will simply say Alarm or Timer on the top of the menu.
 * On the alarm/timer alert, only the first 30 characters of the note will appear - any more and you run the risk of pushing the sleep/ok buttons off-screen.
+* Notes can be shown in a clock info area so you can leave messages for yourself. Swipe the clock info area left/right to reach the Noteify category, then swipe up/down to switch between notes.
 
 ## Images
 

--- a/apps/noteify/clkinfo.js
+++ b/apps/noteify/clkinfo.js
@@ -1,0 +1,12 @@
+(function() {
+  var notes = require("Storage").readJSON("noteify.json", true) || [];
+  return {
+    name: "Noteify",
+    items: notes.map((entry, i) => ({
+      name: "Noteify "+i,
+      get: () => ({ text: entry.note }),
+      show: function() {},
+      hide: function() {}
+    }))
+  };
+})

--- a/apps/noteify/metadata.json
+++ b/apps/noteify/metadata.json
@@ -1,14 +1,15 @@
 {
   "id": "noteify",
   "name": "Noteify",
-  "version": "0.03",
-  "description": "Write notes using an onscreen keyboard and use them as custom messages for alarms or timers.",
+  "version": "0.04",
+  "description": "Write notes using an onscreen keyboard and use them as custom messages for alarms, timers, or clock infos.",
   "icon": "app.png",
-  "tags": "tool,alarm",
+  "tags": "tool,alarm,clkinfo",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",
   "storage": [
     {"name":"noteify.app.js","url":"app.js"},
+    {"name":"noteify.clkinfo.js","url":"clkinfo.js"},
     {"name":"noteify.img","url":"app-icon.js","evaluate":true}
   ],
   "data": [{"name":"noteify.json"}],


### PR DESCRIPTION
This adds a clock info list for Noteify, with each note as an entry in that list.  This gives a way for a user to put a note directly on any clock with a clock info area.  Loosely inspired by the scratchpad of the Advanced Casio Clock (advcasio).

Tested on my Bangle2 on multiple clocks (bwclk 0.34, circlesclock 0.26, slopeclockpp 0.11, lcdclock 0.07, lcdclockplus 0.03, lato 0.04) with zero notes, one note, and multiple notes.  Notes don't always show up well on all clocks, depending on line count and line length.  This code does not attempt to shorten the notes to display better because the clocks are all so different in how they display the text.