### PR TITLE
Update Gallery with optional powersaving settings

### DIFF
--- a/apps/gallery/ChangeLog
+++ b/apps/gallery/ChangeLog
@@ -1,3 +1,4 @@
 0.01: New app!
 0.02: Submitted to app loader
 0.03: Do not invert colors
+0.04: Disable powersaving optional

--- a/apps/gallery/app.js
+++ b/apps/gallery/app.js
@@ -15,6 +15,9 @@ let backlightSetting = storage.readJSON('setting.json').brightness; // LCD brigh
 let angle = 0;              // Store the angle of rotation
 let image;                  // Cache the image here because we access it in multiple places
 
+let appsettings = storage.readJSON('setting.json') || {};
+let disablePowerSaving = appsettings.disablePowerSaving || true; // Default to false if not set
+
 function drawMenu() {
     Bangle.removeListener('touch', drawMenu);   // We no longer want touching to reload the menu
     Bangle.setOptions(cachedOptions);           // The drawImage function set no timeout, undo that
@@ -23,17 +26,18 @@ function drawMenu() {
 
     E.showMenu(imageMenu);
 }
-
+//eslint-disable-next-line no-unused-vars
 function drawImage(fileName) {
     E.showMenu();   // Remove the menu to prevent it from breaking things
     setTimeout(() => { Bangle.on('touch', drawMenu); }, 300);   // Touch the screen to go back to the image menu (300ms timeout to allow user to lift finger)
-    Bangle.setOptions({             // Disable display power saving while showing the image
-        lockTimeout: 0,
-        lcdPowerTimeout: 0,
-        backlightTimeout: 0
-    });
+    if (disablePowerSaving) {    
+        Bangle.setOptions({
+            lockTimeout: 0,
+            lcdPowerTimeout: 0,
+            backlightTimeout: 0
+        });
+    }
     Bangle.setLCDBrightness(1);     // Full brightness
-
     image = eval(storage.read(fileName));   // Sadly, the only reasonable way to do this
     g.clear().reset().setBgColor(0).setColor("#fff").drawImage(image, 88, 88, { rotate: angle });
 }

--- a/apps/gallery/metadata.json
+++ b/apps/gallery/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "gallery",
     "name": "Gallery",
-    "version": "0.03",
+    "version": "0.04",
     "description": "A gallery that lets you view images uploaded with the IDE (see README)",
     "readme": "README.md",
     "icon": "icon.png",
@@ -22,6 +22,10 @@
             "name": "gallery.img",
             "url": "icon.js",
             "evaluate": true
+        },
+        {   "name":"gallery.settings.js",
+            "url":"settings.js"
         }
-    ]
+    ],
+    "data": [{"name":"gallery.json"}]
 }

--- a/apps/gallery/settings.js
+++ b/apps/gallery/settings.js
@@ -1,0 +1,22 @@
+(function back() {
+    const storage = require('Storage');
+    // Load existing settings or initialize defaults
+    let settings = storage.readJSON('setting.json') || {};
+    settings.disablePowerSaving = settings.disablePowerSaving || false; // Default to false if not set
+
+    function saveSettings() {
+        storage.write('setting.json', settings);
+    }
+
+    E.showMenu({
+        '': { 'title': 'Gallery Settings' },
+        'Disable Power Saving': {
+            value: settings.disablePowerSaving,
+            onchange: v => {
+                settings.disablePowerSaving = v;
+                saveSettings();
+            }
+        },
+        '< Back': () => load()
+    });
+})

--- a/apps/gallery/settings.json
+++ b/apps/gallery/settings.json
@@ -1,0 +1,3 @@
+{
+  "disablePowerSaving": true
+}


### PR DESCRIPTION
There were cases when I wanted to display an image on my watch and not have it be set to maximum brightness or prevent the screen from locking. This update creates a settings menu for the Gallery app and enables users to enable or disable the _disable power saving_ feature.