### PR TITLE
terminalclock: Correct ISO date format

### DIFF
--- a/apps/terminalclock/ChangeLog
+++ b/apps/terminalclock/ChangeLog
@@ -11,3 +11,4 @@
 0.10: Add fastloading
 0.11: Add option for ISO 8601 date format
 0.12: Add day of week line
+0.13: Fix ISO 8601 date, add leading zeros to day and month numbers, correct curPos for date function

--- a/apps/terminalclock/app.js
+++ b/apps/terminalclock/app.js
@@ -71,7 +71,7 @@
       curPos++;
 
       ["L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9"].forEach((line) => {
-        if (this[line] === "Date") drawDate(date, this.isoDate, curPos);
+        if (this[line] === "Date") drawDate(date, curPos);
         else if (this[line] === "DOW") drawDOW(date, curPos);
         else if (this[line] === "HR") drawHRM(curPos);
         else if (this[line] === "Motion") drawMotion(curPos);
@@ -130,7 +130,7 @@
       let year = now.getFullYear();
       let month = now.getMonth() + 1; // Months are 0-11
       let day = now.getDate();
-      date = ">" + year + "-" + month + "-" + day;
+      date = ">" + year + "-" + String(month).padStart(2, "0") + "-" + String(day).padStart(2, "0");
     } else {
       let dow = locale.dow(now, 1);
       date = locale.date(now, 1).substr(0, 6); // day and month e.g. 01/02/ from 01/02/2003

--- a/apps/terminalclock/metadata.json
+++ b/apps/terminalclock/metadata.json
@@ -3,7 +3,7 @@
   "name": "Terminal Clock",
   "shortName": "Terminal Clock",
   "description": "A terminal CLI like clock displaying configurable, multiple sensor data",
-  "version": "0.12",
+  "version": "0.13",
   "icon": "app.png",
   "type": "clock",
   "tags": "clock",


### PR DESCRIPTION
This PR adds leading zeros to the day and month when using the ISO date format.

It also corrects the date appearing in the wrong position due to the position variable not being passed correctly.