### PR TITLE
agenda: Fixed bug where "Today" and "Tomorrow" labels display in non-current weeks.

### DIFF
--- a/apps/agenda/ChangeLog
+++ b/apps/agenda/ChangeLog
@@ -16,3 +16,4 @@
 0.14: Fixed "Today" and "Yesterday" wrongly displayed for allDay events on some time zones
 0.15: Minor code improvements
 0.16: Correct date for all day events in negative timezones, improve locale display
+0.17: Fixed "Today" and "Tomorrow" labels displaying in non-current weeks

--- a/apps/agenda/agenda.js
+++ b/apps/agenda/agenda.js
@@ -44,11 +44,12 @@ function formatDay(date) {
     return formattedDate;
   }
   const today = new Date(Date.now());
-  if (date.getDay() == today.getDay() && date.getMonth() == today.getMonth())
+  if (date.getDate() == today.getDate())
      return /*LANG*/"Today ";
   else {
-    const tomorrow = new Date(Date.now() + 86400 * 1000);
-    if (date.getDay() == tomorrow.getDay() && date.getMonth() == tomorrow.getMonth()) {
+    const tomorrow = new Date(Date.now());
+    tomorrow.setDate(today.getDate + 1);
+    if (date.getDate() == tomorrow.getDate()) {
        return /*LANG*/"Tomorrow ";
     }
     return formattedDate;

--- a/apps/agenda/agenda.js
+++ b/apps/agenda/agenda.js
@@ -47,8 +47,8 @@ function formatDay(date) {
   if (date.getDate() == today.getDate())
      return /*LANG*/"Today ";
   else {
-    const tomorrow = new Date(Date.now());
-    tomorrow.setDate(today.getDate + 1);
+    var tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
     if (date.getDate() == tomorrow.getDate()) {
        return /*LANG*/"Tomorrow ";
     }

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "agenda",
   "name": "Agenda",
-  "version": "0.16",
+  "version": "0.17",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],


### PR DESCRIPTION
This fixes a bug where the "Today" and "Tomorrow" labels display on future weeks due to matching on day of the week instead of date, e.g. if today is Thursday an event on Thursday next week will be labelled "Today".