### PR TITLE
promenu: fix settings overwriting

### DIFF
--- a/apps/promenu/ChangeLog
+++ b/apps/promenu/ChangeLog
@@ -13,3 +13,4 @@
 0.09: Don't show "..." if a string isn't truncated (i.e. scrolled)
 0.10: Trigger `remove` callbacks when ending the menu
 0.11: Add options for natural scroll and disabling wrap-around
+0.12: Fix bug where settings would behave as if all were set to false

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -1,7 +1,7 @@
 var _a, _b;
-var settings = (require("Storage").readJSON("promenu.settings.json", true) || {});
-(_a = settings.naturalScroll) !== null && _a !== void 0 ? _a : (settings.naturalScroll = false);
-(_b = settings.wrapAround) !== null && _b !== void 0 ? _b : (settings.wrapAround = true);
+var S = (require("Storage").readJSON("promenu.settings.json", true) || {});
+(_a = S.naturalScroll) !== null && _a !== void 0 ? _a : (S.naturalScroll = false);
+(_b = S.wrapAround) !== null && _b !== void 0 ? _b : (S.wrapAround = true);
 E.showMenu = function (items) {
     var RectRnd = function (x1, y1, x2, y2, r) {
         var pp = [];
@@ -168,7 +168,7 @@ E.showMenu = function (items) {
             }
             else {
                 var lastSelected = selected;
-                if (settings.wrapAround) {
+                if (S.wrapAround) {
                     selected = (selected + dir + menuItems.length) % menuItems.length;
                 }
                 else {
@@ -210,7 +210,7 @@ E.showMenu = function (items) {
         },
     }, function (dir) {
         if (dir)
-            l.move(settings.naturalScroll ? -dir : dir);
+            l.move(S.naturalScroll ? -dir : dir);
         else
             l.select();
     });

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -9,10 +9,9 @@ const enum Consts {
   NAME_SCROLL_PAD = 5,
 }
 
-const settings = (require("Storage").readJSON("promenu.settings.json", true) || {}) as PromenuSettings;
-settings.naturalScroll ??= false;
-settings.wrapAround ??= true;
-
+const S = (require("Storage").readJSON("promenu.settings.json", true) || {}) as PromenuSettings;
+S.naturalScroll ??= false;
+S.wrapAround ??= true;
 
 E.showMenu = (items?: Menu): MenuInstance => {
   const RectRnd = (x1: number, y1: number, x2: number, y2: number, r: number) => {
@@ -217,7 +216,7 @@ E.showMenu = (items?: Menu): MenuInstance => {
 
       } else {
         const lastSelected = selected;
-        if (settings.wrapAround) {
+        if (S.wrapAround) {
           selected = (selected + dir + /*keep +ve*/menuItems.length) % menuItems.length;
         } else {
           selected = E.clip(selected + dir, 0, menuItems.length - 1);
@@ -258,7 +257,7 @@ E.showMenu = (items?: Menu): MenuInstance => {
     },
   } as SetUIArg<"updown">,
   dir => {
-    if (dir) l.move(settings.naturalScroll ? -dir : dir);
+    if (dir) l.move(S.naturalScroll ? -dir : dir);
     else l.select();
   });
 

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -1,8 +1,8 @@
 type ActualMenuItem = Exclude<Menu["..."], MenuOptions | undefined>;
 
 type PromenuSettings = {
-	naturalScroll: boolean,
-	wrapAround: boolean,
+  naturalScroll: boolean,
+  wrapAround: boolean,
 };
 
 const enum Consts {

--- a/apps/promenu/metadata.json
+++ b/apps/promenu/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "promenu",
   "name": "Pro Menu",
-  "version": "0.11",
+  "version": "0.12",
   "description": "Replace the built in menu function. Supports Bangle.js 1 and Bangle.js 2.",
   "icon": "icon.png",
   "type": "bootloader",

--- a/typescript/types/bangle_extensions.d.ts
+++ b/typescript/types/bangle_extensions.d.ts
@@ -8,3 +8,5 @@ type BangleEvents = {
   ["#ondrag"]?: BangleHandler<DragCallback>,
   ["#onstroke"]?: BangleHandler<(event: { xy: Uint8Array, stroke?: string }) => void>,
 };
+
+declare var settings: {}; // settings is commonly used by apps, so declare it here to avoid overwriting it in boot/clkinfo/widgets/etc


### PR DESCRIPTION
promenu declares and uses a global variable, `settings`. This is common in apps such as `settings` and `alarms`, which will come along and overwrite said variable.

This has the effect of all settings in promenu being falsy (unless a setting name overlaps with one from bangle settings). Renaming the variable resolve this problem.