### PR TITLE
launch: fix fullscreen and showClocks setting

### DIFF
--- a/apps/launch/ChangeLog
+++ b/apps/launch/ChangeLog
@@ -23,3 +23,4 @@
 0.21: Make the "App source not found" warning less buggy
 0.22: Add less padding between launcher items, use new font if available in 2v26+
 0.23: Draw a placeholder screen right at the start to speed up apparent boot time
+0.24: Fix fullscreen when fastloading the launcher. (TODO:fix back btn flicker)

--- a/apps/launch/ChangeLog
+++ b/apps/launch/ChangeLog
@@ -24,3 +24,5 @@
 0.22: Add less padding between launcher items, use new font if available in 2v26+
 0.23: Draw a placeholder screen right at the start to speed up apparent boot time
 0.24: Fix fullscreen when fastloading the launcher. (TODO:fix back btn flicker)
+      Fix showClocks setting not taking effect by now clearing cache when
+      changing those settings.

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -85,13 +85,9 @@
         if (lockTimeout) clearTimeout(lockTimeout);
         Bangle.removeListener("lock", lockHandler);
         // Restore widgets if they were hidden by fullscreen setting
-        if (global.WIDGETS) require("widget_utils").show();
+        if (global.WIDGETS && settings.fullscreen) require("widget_utils").show();
       }
     });
-    if (settings.fullscreen) {
-      require("widget_utils").hide();
-      scroller.draw(); // FIX: The red back button will flicker before the widget is hidden and scroller redrawn.
-    }
     g.flip(); // force a render before widgets have finished drawing
 
     // 10s of inactivity goes back to clock

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -22,8 +22,11 @@
   let height = 50*scaleval;
 
   // Now apps list is loaded - render
-  if (!settings.fullscreen)
+  if (!settings.fullscreen) {
     Bangle.loadWidgets();
+  } else if (global.WIDGETS) {
+    require("widget_utils").hide();
+  }
   let R = Bangle.appRect;
   g.reset().clearRect(R).setColor("#888");
   for (var y=R.y;y<R.y2;y+=height) {
@@ -54,7 +57,7 @@
 
 
   const drawMenu = () => {
-    E.showScroller({
+    let scroller = E.showScroller({
       h : height, c : apps.length,
       draw : (i, r) => {
         var app = apps[i];
@@ -81,8 +84,14 @@
         // cleanup the timeout to not leave anything behind after being removed from ram
         if (lockTimeout) clearTimeout(lockTimeout);
         Bangle.removeListener("lock", lockHandler);
+        // Restore widgets if they were hidden by fullscreen setting
+        if (global.WIDGETS) require("widget_utils").show();
       }
     });
+    if (settings.fullscreen) {
+      require("widget_utils").hide();
+      scroller.draw(); // FIX: The red back button will flicker before the widget is hidden and scroller redrawn.
+    }
     g.flip(); // force a render before widgets have finished drawing
 
     // 10s of inactivity goes back to clock

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -57,7 +57,7 @@
 
 
   const drawMenu = () => {
-    let scroller = E.showScroller({
+    E.showScroller({
       h : height, c : apps.length,
       draw : (i, r) => {
         var app = apps[i];

--- a/apps/launch/metadata.json
+++ b/apps/launch/metadata.json
@@ -2,7 +2,7 @@
   "id": "launch",
   "name": "Launcher",
   "shortName": "Launcher",
-  "version": "0.23",
+  "version": "0.24",
   "description": "This is needed to display a menu allowing you to choose your own applications. You can replace this with a customised launcher.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/launch/settings.js
+++ b/apps/launch/settings.js
@@ -10,6 +10,9 @@
     settings[key] = value;
     require("Storage").write("launch.json",settings);
   }
+  function clearCache() {
+    require("Storage").erase("launch.cache.json")
+  }
   const appMenu = {
     "": { "title": /*LANG*/"Launcher" },
     /*LANG*/"< Back": back,
@@ -26,7 +29,10 @@
     },
     /*LANG*/"Show Clocks": {
       value: settings.showClocks == true,
-      onchange: (m) => { save("showClocks", m) }
+      onchange: (m) => {
+        save("showClocks", m);
+        clearCache();
+      }
     },
     /*LANG*/"Fullscreen": {
       value: settings.fullscreen == true,


### PR DESCRIPTION
0.24: Fix fullscreen when fastloading the launcher. (TODO:fix back btn flicker)
      Fix respecting the showClocks setting.

Try it via my app loader: https://thyttan.github.io/BangleApps/?id=launch

closes #3786 and #3785

@gfwilliams because it is a core app.