### PR TITLE
agenda: fix all-day event offsets in clock info.

### DIFF
--- a/apps/agenda/ChangeLog
+++ b/apps/agenda/ChangeLog
@@ -17,3 +17,4 @@
 0.15: Minor code improvements
 0.16: Correct date for all day events in negative timezones, improve locale display
 0.17: Fixed "Today" and "Tomorrow" labels displaying in non-current weeks
+0.18: Correct date in clockinfo for all-day events in negative timezones

--- a/apps/agenda/agenda.clkinfo.js
+++ b/apps/agenda/agenda.clkinfo.js
@@ -65,7 +65,11 @@
   agenda.forEach((entry, i) => {
 
     var title = entry.title.slice(0,12);
-    var date = new Date(entry.timestamp*1000);
+    // All day events are always in UTC and always start at 00:00:00, so we
+    // need to "undo" the timezone offsetting to make sure that the day is
+    // correct.
+    var offset = entry.allDay ? new Date().getTimezoneOffset() * 60 : 0
+    var date = new Date((entry.timestamp+offset)*1000);
     var dateStr = locale.date(date).replace(/\d\d\d\d/,"");
     var shortStr = ((date-now) > 86400000 || entry.allDay) ? dateStr : locale.time(date,1);
     var color = "#"+(0x1000000+Number(entry.color)).toString(16).padStart(6,"0");

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "agenda",
   "name": "Agenda",
-  "version": "0.17",
+  "version": "0.18",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],


### PR DESCRIPTION
All-day events synchronized from Gadgetbridge always start at midnight UTC, which causes them to display as different days depending on time zone offset (specifically negative offsets display the date as one day early).  This was previously fixed in the agenda app in pull request #3695 (commit bcf88c3). This commit replicates that fix in the clockinfo that agenda provides.

Tested this on my Bangle2 with time zone offsets that are negative, positive, and zero.