### PR TITLE
edgeclk: Reset graphics before initial clearing of the screen.

### DIFF
--- a/apps/edgeclk/ChangeLog
+++ b/apps/edgeclk/ChangeLog
@@ -2,3 +2,5 @@
 0.02: Fix reset of progress bars on midnight. Fix display of 100k+ steps.
 0.03: Added option to display weather.
 0.04: Added option to display live updates of step count.
+0.05: Reset graphics before initial clearing of the screen. Helps in some
+      situations if using fastload utils.

--- a/apps/edgeclk/app.js
+++ b/apps/edgeclk/app.js
@@ -336,7 +336,7 @@
   /* Startup Process
   ------------------------------------------------------------------------------*/
 
-  g.clear();
+  g.reset().clear();
   drawAll();
   startTimers();
   registerEvents();

--- a/apps/edgeclk/app.js
+++ b/apps/edgeclk/app.js
@@ -336,7 +336,7 @@
   /* Startup Process
   ------------------------------------------------------------------------------*/
 
-  g.reset().clear();
+  g.clear(1);
   drawAll();
   startTimers();
   registerEvents();

--- a/apps/edgeclk/metadata.json
+++ b/apps/edgeclk/metadata.json
@@ -2,7 +2,7 @@
   "id": "edgeclk",
   "name": "Edge Clock",
   "shortName": "Edge Clock",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Crisp clock with perfect readability.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
Helps in some situations if using fastload utils where the graphics from the previous app would not be cleared.

What triggered the issue for me was:

1. Use fasload utils
2. have a message notification pending showing with `widmsggrid`
3. exit `spotrem` by clicking the HW button on the main ui.
4. edgeclk is displayed but the `spotrem` graphics are showing behind the clock graphics.

I didn't figure out what exactly caused it, but maybe somehow the theme bg color ended up transparent or not set for the `g.clear()` call. This change seems to fix it. But don't know if we should be looking to fix something somewhere else.