### PR TITLE
swipeinv: (WIP) Add inversion of drag events. Refactor to hijack and modify the

### DIFF
--- a/apps/swipeinv/ChangeLog
+++ b/apps/swipeinv/ChangeLog
@@ -1,2 +1,5 @@
 0.01: New app!
 0.02: Minor code improvements
+0.03: (WIP) Add inversion of drag events. Refactor to hijack and modify the
+	events instead of the handling of them. This should add compatibility with
+	most apps, even if Bangle.setUI is not used.

--- a/apps/swipeinv/boot.js
+++ b/apps/swipeinv/boot.js
@@ -1,4 +1,7 @@
 {
+  // TODO: Should the global case just hijack the swipe and drag events, modifying them before passing on to other listeners?
+  //   - That could be a new separate bootloader app instead though?
+
   const settings = Object.assign({
     global: false,
     apps: []
@@ -10,7 +13,17 @@
       if (typeof mode === "object" && mode.swipe) {
         if (settings.global ^ settings.apps.includes(global.__FILE__)) {
           const origSwipeCb = mode.swipe;
-          mode.swipe = (dirLR, dirUD) => origSwipeCb(dirLR*-1, dirUD*-1);
+          mode.swipe = (dirLR, dirUD) => origSwipeCb(dirLR * -1, dirUD * -1);
+        }
+      }
+      if (typeof mode === "object" && mode.drag) {
+        if (settings.global ^ settings.apps.includes(global.__FILE__)) {
+          const origDragCb = mode.drag;
+          mode.drag = (e) => {
+            e.dx *= -1;
+            e.dy *= -1;
+            origDragCb(e);
+          }
         }
       }
       return setURIOrig(mode, callback);

--- a/apps/swipeinv/metadata.json
+++ b/apps/swipeinv/metadata.json
@@ -3,7 +3,7 @@
   "name": "Swipe inversion",
   "shortName":"Swipe inv.",
   "icon": "app.png",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Inverts swipe direction globally or per app, see settings. If global inversion is enabled, you can unselect the inversion per app and vice versa.",
   "readme":"README.md",
   "type": "bootloader",


### PR DESCRIPTION
	events instead of the handling of them. This should add compatibility with
	most apps, even if Bangle.setUI is not used.

Ping @nxdefiant and @jt-nti , what do you think of this approach?

I'm also thinking of adding settings so horizontal and vertical inversion can be set individually, also per app. 