### PR TITLE
android: pass HTTP request timeout to Gadgetbridge

### DIFF
--- a/apps/android/lib.js
+++ b/apps/android/lib.js
@@ -321,6 +321,7 @@ exports.httpHandler = (url,options) => {
   if (options.method) req.method = options.method;
   if (options.body) req.body = options.body;
   if (options.headers) req.headers = options.headers;
+  req.timeout = options.timeout || 30000;
   exports.gbSend(req);
   //create the promise
   var promise = new Promise(function(resolve,reject) {
@@ -329,7 +330,7 @@ exports.httpHandler = (url,options) => {
       //if after "timeoutMillisec" it still hasn't answered -> reject
       delete Bangle.httpRequest[options.id];
       reject("Timeout");
-    },options.timeout||30000)};
+    },req.timeout)};
   });
   return promise;
 };


### PR DESCRIPTION
Currently, Gadgetbridge (Android) does not use the timeout value specified in a HTTP request. This is not according to the current documentation, and also not expected behaviour.

This PR fixes this - on the Bangle.js side. I've also created a PR in the [Gadgetbridge repo](https://codeberg.org/Freeyourgadget/Gadgetbridge). Both changes can be rolled-out independently.