### PR TITLE
Fixed comma drawing on JsonClock

### DIFF
--- a/apps/jsonclock/ChangeLog
+++ b/apps/jsonclock/ChangeLog
@@ -1,2 +1,3 @@
 0.01: first release
 0.02: memory leak fix; color changes to better align with VSCode color scheme; logo is transparent
+0.03: Fixed redrawing of commas

--- a/apps/jsonclock/app.js
+++ b/apps/jsonclock/app.js
@@ -229,6 +229,7 @@ let redraw = function() {
         if (!(key in valsArrs)) continue;
         let valsArr = valsArrs[key];
         if (value === valsArr.text) continue; // No need to update
+        if (valsArr.endComma) value = value.slice(0, -1);
         valsArrs[key].text = value;
 
         // Clear prev values
@@ -239,7 +240,7 @@ let redraw = function() {
         g.drawString(value, valsArr.x, valsArr.y);
         if (valsArr.endComma){
             g.setColor(clrs.brackets);
-            g.drawString(',', valsArr.Banglex + g.stringWidth(value), valsArr.y);
+            g.drawString(',', valsArr.x + g.stringWidth(value), valsArr.y);
         }
     }
 };

--- a/apps/jsonclock/metadata.json
+++ b/apps/jsonclock/metadata.json
@@ -1,6 +1,6 @@
 { "id": "jsonclock",
   "name": "JsonClock",
-  "version": "0.02",
+  "version": "0.03",
   "description": "JSON view of the time, date, steps, battery, and sunrise and sunset times",
   "icon": "app.png",
   "screenshots": [{"url":"dark.png"}],


### PR DESCRIPTION
After a week of daily-wearing the JsonClock, the only issue seen was the commas being drawn incorrectly.
This PR repairs that.