### PR TITLE
bwclk: Adjust clkinfo positions for long text.

### DIFF
--- a/apps/bwclk/ChangeLog
+++ b/apps/bwclk/ChangeLog
@@ -34,3 +34,4 @@ clkinfo.addInteractive that would cause ReferenceError.
 0.32: Make the border of the clock_info box extend all the way to the right of the screen.
 0.33: Fix issue rendering ClockInfos with for fg+bg color set to the same (#2749)
 0.34: Support 12-hour time format
+0.35: Adjust clock info positions to better fit long text

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -171,6 +171,7 @@ let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
       strWidth = g.stringWidth(text);
       if (strWidth+imgWidthClear > options.w) {
         g.setMiniFont();
+        text = g.wrapString(text, options.w-imgWidthClear).join("\n");
         strWidth = g.stringWidth(text);
       }
     }

--- a/apps/bwclk/app.js
+++ b/apps/bwclk/app.js
@@ -141,7 +141,7 @@ let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
     var hideClkInfo = info.text == null;
 
     g.reset().setBgColor(g.theme.fg).clearRect(options.x, options.y, options.x+options.w, options.y+options.h);
-    g.setFontAlign(0,0).setColor(g.theme.bg);
+    g.setFontAlign(-1,-1).setColor(g.theme.bg);
 
     if (options.focus){
       var y = hideClkInfo ? options.y+20 : options.y+2;
@@ -157,26 +157,35 @@ let clockInfoMenu = clock_info.addInteractive(clockInfoItems, {
       return;
     }
 
-    // Set text and font
+    // Set text and font, compute sizes.
     var image = info.img;
+    var imgWidth = image == null ? 0 : 24;
+    let imgWidthClear = parseInt(imgWidth*1.3);
     var text = String(info.text);
+    let strWidth;
     if(text.split('\n').length > 1){
       g.setMiniFont();
+      strWidth = g.stringWidth(text);
     } else {
       g.setSmallFont();
+      strWidth = g.stringWidth(text);
+      if (strWidth+imgWidthClear > options.w) {
+        g.setMiniFont();
+        strWidth = g.stringWidth(text);
+      }
     }
 
-    // Compute sizes
-    var strWidth = g.stringWidth(text);
-    var imgWidth = image == null ? 0 : 24;
+    // Compute positions
     var midx = options.x+options.w/2;
+    let imgPosX = Math.max(midx-Math.floor(imgWidthClear/2)-parseInt(strWidth/2), 0);
+    let strPosX = imgPosX+imgWidthClear;
 
     // Draw
     if (image) {
       var scale = imgWidth / image.width;
-      g.drawImage(image, midx-parseInt(imgWidth*1.3/2)-parseInt(strWidth/2), options.y+6, {scale: scale});
+      g.drawImage(image, imgPosX, options.y+6, {scale: scale});
     }
-    g.drawString(text, midx+parseInt(imgWidth*1.3/2), options.y+20);
+    g.drawString(text, strPosX, options.y+6);
 
     // In case we are in focus and the focus box changes (fullscreen yes/no)
     // we draw the time again. Otherwise it could happen that a while line is

--- a/apps/bwclk/metadata.json
+++ b/apps/bwclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bwclk",
   "name": "BW Clock",
-  "version": "0.34",
+  "version": "0.35",
   "description": "A very minimalistic clock.",
   "readme": "README.md",
   "icon": "app.png",


### PR DESCRIPTION
Previously, all text in a clock info entry was centered.  This caused long lines to spill off both sides of the screen, and entries with more than two lines to cover the time.  With this change, clock info text is arranged so it only ever spills off the right and bottom. This allows the start of any text to always be visible, and the time to never be covered, regardless of the amount of text.  To achieve this, multiple lines are now left-aligned instead of center-aligned.

This fixes some of my own issues, but I am open to feedback on this because it might not be the best way to handle arbitrary clock info text.  Also, I have not copied this over to bwclklite yet, but I can do that after everyone is happy with the change.

Here are comparative screenshots for reference.

One long line switches to small font and left alignment:

| bwclk 0.34 | this PR |
|------------|----------|
| ![onelong](https://github.com/user-attachments/assets/b806db1b-df6c-4308-91e5-04ff3e88f650) | ![onelong-new](https://github.com/user-attachments/assets/7ab66586-c151-46fb-92e9-a9e4eb6ec498) |

Two lines change to left alignment:

| bwclk 0.34 | this PR |
|------------|----------|
| ![twoline](https://github.com/user-attachments/assets/c13cfe4f-3ac1-4c6d-a6e9-57d5010ea579) | ![twoline-new](https://github.com/user-attachments/assets/60a2513b-856d-4008-83cd-d4755aefe9b5) |
| ![vic](https://github.com/user-attachments/assets/17bd7b0b-954d-4547-aa65-55b955826ed9) | ![vic-new](https://github.com/user-attachments/assets/5fa8e6cd-676f-4646-8c49-584dc42977d5) |

More than two lines run off the bottom instead of into the time:

| bwclk 0.34 | this PR |
|------------|----------|
| ![threeline](https://github.com/user-attachments/assets/69ffc463-fd0f-40a9-9aae-144c5f112869) | ![threeline-new](https://github.com/user-attachments/assets/a7b3c552-ae53-4e1e-8352-53df92b87820) |
| ![fourline](https://github.com/user-attachments/assets/fc3728ba-e7d9-4388-8b5f-0eb86f7f1a82) | ![fourline-new](https://github.com/user-attachments/assets/4f7f2c44-f9d9-4431-8e04-b25e043cc3b7) |

One short line is unchanged:

| bwclk 0.34 | this PR |
|------------|----------|
| ![oneline](https://github.com/user-attachments/assets/b28b76bf-09b9-48f6-abf7-9aa6c25e4579) | ![oneline-new](https://github.com/user-attachments/assets/f5055521-1c2b-4f8d-89a9-6b320db0bdd1) |
| ![steps](https://github.com/user-attachments/assets/5b5a39c5-1a6a-441d-bf3f-80d51e621500) | ![steps-new](https://github.com/user-attachments/assets/af2a2a0f-4abb-44d6-897a-05cf0977dca1) |