### PR TITLE
docs(contacts): mention GadgetBridge intents requirements

### DIFF
--- a/apps/contacts/README.md
+++ b/apps/contacts/README.md
@@ -1,6 +1,7 @@
 # Contacts
 
 View, edit and call contacts on your bangle.js. Calling is done via the bluetooth connection to your android phone.
+Requires allowing "intents" in GadgetBridge device settings.
 
 ## Contacts JSON file
 


### PR DESCRIPTION
It took me a `logcat` to realise that this was the reason the contacts apps wouldn't call. Ideally it would be nice if it displayed the error message on the phone or watch, but in the meantime, mentioning it in the README is an improvement IMHO.