### PR TITLE
Chess: Use button rising edge for Menu

### DIFF
--- a/apps/chess/ChangeLog
+++ b/apps/chess/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Use Bangle.setBacklight()
 0.04: Add option to buzz after computer move
 0.05: Minor code improvements
+0.06: Use button rising edge for Menu

--- a/apps/chess/app.js
+++ b/apps/chess/app.js
@@ -306,4 +306,4 @@ setWatch(() => {
       }
     },
   });
-}, BTN, { repeat: true, edge: "falling" });
+}, BTN, { repeat: true, edge: "rising" });

--- a/apps/chess/metadata.json
+++ b/apps/chess/metadata.json
@@ -2,7 +2,7 @@
   "id": "chess",
   "name": "Chess",
   "shortName": "Chess",
-  "version": "0.05",
+  "version": "0.06",
   "description": "Chess game based on the [p4wn engine](https://p4wn.sourceforge.net/). Drag on the touchscreen to move the green cursor onto a piece, select it with a single touch and drag the now red cursor around. Release the piece with another touch to finish the move. The button opens a menu.",
   "icon": "app.png",
   "tags": "game",


### PR DESCRIPTION
With falling edge and current firmware menu will always reopen on close.