### PR TITLE
alarm: allow deletion of expired alarms

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -56,3 +56,4 @@
 0.50: Bangle.js 2: Long touch of alarm in main menu toggle it on/off. Touching the icon on
 	the right will do the same.
 0.51: Fix long-touch to enable alarm/timer not updating time (fix #3804)
+0.52: Allow deletion of alarms once they sound (like timers and events)

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -293,7 +293,6 @@ function showEditAlarmMenu(selectedAlarm, alarmIndex, withDate, scroll, group) {
     delete menu[/*LANG*/"Day"];
     delete menu[/*LANG*/"Month"];
     delete menu[/*LANG*/"Year"];
-    delete menu[/*LANG*/"Delete After Expiration"];
   }
 
   if (!isNew) {

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.51",
+  "version": "0.52",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",
   "tags": "tool,alarm",


### PR DESCRIPTION
I keep finding myself needing this without wanting to go to the event menu