### PR TITLE
[owmweather] prevent updating settings.updated when call to OWM fails

### DIFF
--- a/apps/owmweather/ChangeLog
+++ b/apps/owmweather/ChangeLog
@@ -7,3 +7,4 @@
 0.07: Update weather after reconnecting bluetooth if update is due, refactor code
 0.08: Undo change to One Call API 3.0
 0.09: Fix infinite loop when settings.updated is not defined
+0.10: Fix settings.updated being updated even when OWM call failed

--- a/apps/owmweather/boot.js
+++ b/apps/owmweather/boot.js
@@ -10,10 +10,14 @@
     return settings.refresh * 1000 * 60 + 1;  // +1 <- leave some slack
   };
 
-  let onCompleted = function () {
+  let onCompleted = function (result) {
     loading = false;
-    settings.updated = Date.now();
-    require('Storage').writeJSON("owmweather.json", settings);
+    if(typeof result === "string") {
+      console.log("owmweather error: " + result);
+    } else {
+      settings.updated = Date.now();
+      require('Storage').writeJSON("owmweather.json", settings);
+    }
     if (timeoutRef) clearTimeout(timeoutRef);
     timeoutRef = setTimeout(loadIfDueAndReschedule, refreshMillis());
   };

--- a/apps/owmweather/boot.js
+++ b/apps/owmweather/boot.js
@@ -12,12 +12,15 @@
 
   let onCompleted = function (result) {
     loading = false;
-    if(typeof result === "string") {
-      console.log("owmweather error: " + result);
-    } else {
-      settings.updated = Date.now();
-      require('Storage').writeJSON("owmweather.json", settings);
-    }
+    settings.updated = Date.now();
+    require('Storage').writeJSON("owmweather.json", settings);
+    if (timeoutRef) clearTimeout(timeoutRef);
+    timeoutRef = setTimeout(loadIfDueAndReschedule, refreshMillis());
+  };
+
+  let onError = function(e) {
+    console.log("owmweather error:", e);
+    loading = false;
     if (timeoutRef) clearTimeout(timeoutRef);
     timeoutRef = setTimeout(loadIfDueAndReschedule, refreshMillis());
   };
@@ -34,7 +37,7 @@
     if (!MillisUntilDue || MillisUntilDue <= 0) {
       if (!loading) {
         loading = true;
-        require("owmweather").pull(onCompleted);
+        require("owmweather").pull(onCompleted, onError);
       }
     } else {
       // called to early, reschedule

--- a/apps/owmweather/lib.js
+++ b/apps/owmweather/lib.js
@@ -33,7 +33,7 @@ function parseWeather(response) {
   }
 }
 
-exports.pull = function(completionCallback) {
+exports.pull = function(completionCallback, errorCallback) {
   let location = require("Storage").readJSON("mylocation.json", 1) || {
     "lat": 51.50,
     "lon": 0.12,
@@ -46,9 +46,9 @@ exports.pull = function(completionCallback) {
       let result = parseWeather(event.resp);
       if (completionCallback) completionCallback(result);
     }).catch((e)=>{
-      if (completionCallback) completionCallback(e);
+      if (errorCallback) errorCallback(e);
     });
   } else {
-    if (completionCallback) completionCallback(/*LANG*/"No http method found");
+    if (errorCallback) errorCallback(/*LANG*/"No http method found");
   }
 };

--- a/apps/owmweather/metadata.json
+++ b/apps/owmweather/metadata.json
@@ -1,7 +1,7 @@
 { "id": "owmweather",
   "name": "OpenWeatherMap weather provider",
   "shortName":"OWM Weather",
-  "version": "0.09",
+  "version": "0.10",
   "description": "Pulls weather from OpenWeatherMap (OWM) API",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Link: https://thinkpoop.github.io/BangleApps/?id=owmweather

In `boot.js` function `onCompleted`, the `settings.updated` value is always updated, even if it's being called during error handing. 

Example:
GB gets disconnected.
OWMWeather tries to refresh, gets a timeout, sets settings.updated to now + 1hr.
GB gets reconnected.
OWMWeather checks settings.updated and thinks it doesn't need , even though the data is bad.