### PR TITLE
Replace non-ASCII dashes with ASCII hyphens to fix loader parsing and display issues

### DIFF
--- a/apps/crsclock/crsclock.js
+++ b/apps/crsclock/crsclock.js
@@ -83,7 +83,7 @@ const STATS_FONT_SIZE = 16;
 function getSleepWindowStr() {
   let a = ("0"+S.sleepStart).substr(-2) + ":00";
   let b = ("0"+S.sleepEnd).substr(-2)   + ":00";
-  return a + "–" + b;
+  return a + "-" + b;
 }
 
 function stability(arr, key, hours) {
@@ -610,7 +610,7 @@ function calibrateBT() {
         Bangle.setUI(uiOpts);
       });
     })(d);
-    m["−" + d + "h"] = (() => () => {
+    m["-" + d + "h"] = (() => () => {
       S.phaseOffset -= d;
       saveSettings();
       E.showAlert("Offset now: " + (S.phaseOffset>=0? "+"+S.phaseOffset : S.phaseOffset) + "h").then(() => {
@@ -711,7 +711,7 @@ function setBioTimeReference() {
   E.showMenu(m);
 
   function promptRefTime() {
-    E.showPrompt("Hour (0–23)?").then(h => {
+    E.showPrompt("Hour (0-23)?").then(h => {
       if (h===undefined || h<0 || h>23) {
         E.showAlert("Invalid hour").then(() => {
           drawClock();
@@ -720,7 +720,7 @@ function setBioTimeReference() {
         return;
       }
       S.bioTimeRefHour = h;
-      E.showPrompt("Minute (0–59)?").then(m => {
+      E.showPrompt("Minute (0-59)?").then(m => {
         if (m===undefined || m<0 || m>59) {
           E.showAlert("Invalid minute").then(() => {
             drawClock();


### PR DESCRIPTION
This PR addresses two critical bugs that occur only when installing the app via the development App Loader (they do not appear when uploading the script directly through the Web IDE):

Malformed regex / syntax error

Cause: The source uses the Unicode minus sign (U+2212) in the BT calibration menu, which the Espruino minifier mis-parses and embeds into crsclock.app.js as an unfinished regex.

Symptom:

Uncaught SyntaxError: Got UNFINISHED REGEX expected ']'
Location: crsclock.js ≈ lines 612–614.

Garbled on-device text

Cause: Use of the EN DASH (U+2013) in prompt strings for the sleep window and range selections.

Symptom: Dash characters render as â (mojibake) on Bangle.js.

Locations:

Sleep window label (lines 84–86)

Range prompts (lines 714 & 723)

All non-ASCII dashes have been normalised to the standard ASCII hyphen-minus (-) so that both the Espruino minifier and the Bangle.js firmware handle them correctly.

Changes:

crsclock.js

Replaced all occurrences of U+2013 (EN DASH) and U+2212 (MINUS SIGN) with -

Updated prompt strings and menu labels accordingly

crsclock.app.js (auto-generated; should now minify without errors)

Verification:

Uploaded via App Loader—BT calibration menu works, no syntax errors in console
Sleep-window settings now display 08:00–22:00 (with ASCII hyphen) correctly on the device
Uploaded via Web IDE—unchanged behaviour, as expected

References:

Sleep window string initially using EN DASH (lines 84–86)
Unicode minus sign in BT calibration menu (lines 612–614)
Range prompts using EN DASH (lines 714 & 723)