### PR TITLE
Removing non-ASCII characters

### DIFF
--- a/apps/crsclock/crsclock.js
+++ b/apps/crsclock/crsclock.js
@@ -83,7 +83,7 @@ const STATS_FONT_SIZE = 16;
 function getSleepWindowStr() {
   let a = ("0"+S.sleepStart).substr(-2) + ":00";
   let b = ("0"+S.sleepEnd).substr(-2)   + ":00";
-  return a + "–" + b;
+  return a + "-" + b;
 }
 
 function stability(arr, key, hours) {
@@ -518,7 +518,7 @@ function confirmResetAllData() {
   });
 }
 
-// Menu logic: Sleep window, hydration, BT calibration, theme, notifications, bio ref, about — unchanged, use as before
+// Menu logic: Sleep window, hydration, BT calibration, theme, notifications, bio ref, about - unchanged, use as before
 
 function setSleepWindow() {
   let menu = { "": { title: "Select Start Hour" } };
@@ -743,7 +743,7 @@ function showAbout() {
   E.showAlert(
     "Circadian Wellness Clock v" + VERSION + "\n" +
     "Displays your CRS and BioTime.\n" +
-    "© 2025"
+    "Copyright 2025"
   ).then(()=>{
     drawClock();
     Bangle.setUI(uiOpts);


### PR DESCRIPTION
This pull request addresses an issue where non-ASCII punctuation (specifically EN DASH U+2013 and MINUS SIGN U+2212) in crsclock.js caused runtime errors and display corruption when the app was installed via the Development App Loader.