### PR TITLE
ios 0.19: Convert numeric weather values to int from BangleDumpWeather shortcut

### DIFF
--- a/apps/ios/ChangeLog
+++ b/apps/ios/ChangeLog
@@ -17,3 +17,4 @@
 0.16: Always request Current Time service from iOS
 0.17: Default to passing full UTF8 strings into messages app (which can now process them with an international font)
 0.18: Fix UTF8 conversion (check for `font` library, not `fonts`)
+0.19: Convert numeric weather values to int from BangleDumpWeather shortcut

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -191,6 +191,11 @@ E.on('notify',msg=>{
         wdir: d.wdir,
         loc: d.loc
     }
+    // Convert string fields to numbers for iOS weather shortcut
+    const numFields = ['code', 'wdir', 'temp', 'hi', 'lo', 'hum', 'wind', 'uv', 'rain'];
+    numFields.forEach(field => {
+      if (weatherEvent[field] != null) weatherEvent[field] = +weatherEvent[field];
+    });
     require("weather").update(weatherEvent);
     NRF.ancsAction(msg.uid, false);
     return;

--- a/apps/ios/metadata.json
+++ b/apps/ios/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "ios",
   "name": "iOS Integration",
-  "version": "0.18",
+  "version": "0.19",
   "description": "Display notifications/music/etc from iOS devices",
   "icon": "app.png",
   "tags": "tool,system,ios,apple,messages,notifications",


### PR DESCRIPTION
This ensures the numeric values are not being treated as strings when received from iOS shortcut BangleDumpWeather. It allows the weather codes to be parsed correctly to show the correct icons. Other numerical values were added for good measure. 

This was in regards to discussion [7791](https://github.com/orgs/espruino/discussions/7791).