### PR TITLE
Weather: Add v2 weather parsing in Weather App (forecast support)

### DIFF
--- a/apps/weather/ChangeLog
+++ b/apps/weather/ChangeLog
@@ -26,3 +26,9 @@
 0.27: Add UV index display
 0.28: Fix UV positioning, hide when 0
 0.29: Add feels-like temperature data and clock_info
+0.30: Refactor code to more modern javascript style
+      Split settings and weather data into two files in storage
+      Add support for new version of weather data and forecast from GadgetBridge (requires version 0.86.0 or higher)
+      Add support to automatically fetch weather at time interval defined in settings (requires GadgetBridge version 0.86.0 or higher)
+      Add button to settings to force fetch weather data (requires GadgetBridge version 0.86.0 or higher)
+      Add new API to get weather from Weather App for other Apps

--- a/apps/weather/README.md
+++ b/apps/weather/README.md
@@ -77,7 +77,7 @@ Adds:
 
 * Expiration time span can be set after which the local weather data is considered as invalid
 * Automatic weather data request interval can be set (weather data are pushed to Bangle automatically, but this can help in cases when it fails) (requires Gadgetbridge v0.86+)
-* Forecast weather data can be enabled (this requires other App to use the data, Weather App itself doesn't show the forecast data) (requires Gadgetbridge v0.86+)
+* Extended or forecast weather data can be enabled (this requires other App to use this data, Weather App itself doesn't show the forecast data) (requires Gadgetbridge v0.86+)
 * Widget can be hidden
 * To change the units for wind speed, you can install the [`Languages app`](https://banglejs.com/apps/?id=locale) which
 allows you to choose the units used for speed/distance/temperature and so on.
@@ -89,15 +89,17 @@ allows you to choose the units used for speed/distance/temperature and so on.
 
 ## Weather App API
 
+Note: except `getWeather()` and `get()` it is android only for now
+
 Weather App can provide weather and forecast data to other Apps.
 
-* Get weather data without forecast:
+* Get weather data without forecast/extended:
   ```javascript
    const weather = require("weather");
    weatherData = weather.getWeather(false);  // or weather.get()
   ```
 
-* Get weather data with forecast (needs forecast enabled in settings):
+* Get weather data with forecast/extended (needs forecast/extended enabled in settings):
   ```javascript
    const weather = require("weather");
    weatherData = weather.getWeather(true);

--- a/apps/weather/README.md
+++ b/apps/weather/README.md
@@ -3,7 +3,7 @@
 This allows your Bangle.js to display weather reports from the Gadgetbridge app for an Android phone, or by using the iOS shortcut below to push weather information.
 
 It adds a widget with a weather pictogram and the temperature.
-It also adds a ClockInfo list to Bangle.js. 
+It also adds a ClockInfo list to Bangle.js.
 You can view the full report through the app:
 
 ![Screenshot](screenshot.png)
@@ -12,35 +12,35 @@ You can view the full report through the app:
 
 Use the iOS shortcut [here](https://www.icloud.com/shortcuts/73be0ce1076446f3bdc45a5707de5c4d). The shortcut uses Apple Weather for weather updates, and sends a notification, which is read by Bangle.js. To push weather every hour, or interval, you will need to create a shortcut automation for every time you want to push the weather.
 
-
 ## Android Setup
 
-1. Install [Gadgetbridge for Android](https://f-droid.org/packages/nodomain.freeyourgadget.gadgetbridge/) on your phone.
-2. Set up [Gadgetbridge weather reporting](https://codeberg.org/Freeyourgadget/Gadgetbridge/wiki/Weather).
-
-If using the `Bangle.js Gadgetbridge` app on your phone (as opposed to the standard F-Droid `Gadgetbridge`) you need to set the package name
-to `com.espruino.gadgetbridge.banglejs` in the settings of the weather app (`settings -> gadgetbridge support -> package name`).
+1. Install [Gadgetbridge for Android](https://f-droid.org/packages/nodomain.freeyourgadget.gadgetbridge/) on your phone
+2. Set up [Gadgetbridge weather reporting](https://gadgetbridge.org/basics/features/weather/)
 
 ### Android Weather Apps
 
-There are two weather apps for Android that can connect with Gadgetbridge:
+There are multiple weather apps for Android that can connect with Gadgetbridge:
 
 * Tiny Weather Forecast Germany
- * F-Droid - https://f-droid.org/en/packages/de.kaffeemitkoffein.tinyweatherforecastgermany/
- * Source code - https://codeberg.org/Starfish/TinyWeatherForecastGermany
- 
+  * F-Droid - https://f-droid.org/en/packages/de.kaffeemitkoffein.tinyweatherforecastgermany/
+  * Source code - https://codeberg.org/Starfish/TinyWeatherForecastGermany
+
 * QuickWeather
- * F-Droid - https://f-droid.org/en/packages/com.ominous.quickweather/
- * Google Play - https://play.google.com/store/apps/details?id=com.ominous.quickweather
- * Source code - https://github.com/TylerWilliamson/QuickWeather
- 
+  * F-Droid - https://f-droid.org/en/packages/com.ominous.quickweather/
+  * Google Play - https://play.google.com/store/apps/details?id=com.ominous.quickweather
+  * Source code - https://github.com/TylerWilliamson/QuickWeather
+
+* Breezy Weather
+  * F-Droid - https://f-droid.org/en/packages/org.breezyweather/
+  * Source code - https://github.com/breezy-weather/breezy-weather
+
 ### Tiny Weather Forecast Germany
 
 Even though Tiny Weather Forecast Germany is made for Germany, it can be used around the world. To do this:
- 
+
 1. Tap on the three dots in the top right hand corner and go to settings
 2. Go down to Location and tap on the checkbox labeled "Use location services". You may also want to check on the "Check Location checkbox". Alternatively, you may select the "manual" checkbox and choose your location.
-3. Scroll down further to the "other" section and tap "Gadgetbridge support". Then tap on "Enable". You may also choose to tap on "Send current time". 
+3. Scroll down further to the "other" section and tap "Gadgetbridge support". Then tap on "Enable". You may also choose to tap on "Send current time".
 4. If you're using the specific Gadgetbridge for Bangle.JS app, you'll want to tap on "Package name." In the dialog box that appears, you'll want to put in "com.espruino.gadgetbridge.banglejs" without the quotes. If you're using the original Gadgetbridge, leave this as the default.
 
 ### QuickWeather
@@ -51,9 +51,17 @@ If you're using OpenWeatherMap you will need the "One Call By Call" plan, which 
 
 When you first load QuickWeather, it will take you through the setup process. You will fill out all the required information as well as put your API key in. If you do not have the "One Call By Call", or commonly known as "One Call", API, you will need to sign up for that. QuickWeather will work automatically with both the main version of Gadgetbridge and Gadgetbridge for Bangle.JS.
 
+### Breezy Weather
+
+Enabling connection to Gadgetbridge:
+
+1. Tap on the three dots in the top right hand corner and go to settings
+2. Find "Widgets & Live wallpaper" settings
+3. Under "Data sharing" tap on "Send Gadgetbridge data" and enable for Gadgetbridge flavor you are using
+
 ### Weather Notification
 
-**Note:** at one time, the Weather Notification app also worked with Gadgetbridge. However, many users are reporting it's no longer seeing the OpenWeatherMap API key as valid. The app has not received any updates since August of 2020, and may be unmaintained. 
+**Note:** at one time, the Weather Notification app also worked with Gadgetbridge. However, many users are reporting it's no longer seeing the OpenWeatherMap API key as valid. The app has not received any updates since August of 2020, and may be unmaintained.
 
 ## Clock Infos
 
@@ -67,7 +75,9 @@ Adds:
 
 ## Settings
 
-* Expiration timespan can be set after which the local weather data is considered as invalid
+* Expiration time span can be set after which the local weather data is considered as invalid
+* Automatic weather data request interval can be set (weather data are pushed to Bangle automatically, but this can help in cases when it fails) (requires Gadgetbridge v0.86+)
+* Forecast weather data can be enabled (this requires other App to use the data, Weather App itself doesn't show the forecast data) (requires Gadgetbridge v0.86+)
 * Widget can be hidden
 * To change the units for wind speed, you can install the [`Languages app`](https://banglejs.com/apps/?id=locale) which
 allows you to choose the units used for speed/distance/temperature and so on.
@@ -76,3 +86,42 @@ allows you to choose the units used for speed/distance/temperature and so on.
 
 * BTN2: opens the launcher (Bangle.js 1)
 * BTN: opens the launcher (Bangle.js 2)
+
+## Weather App API
+
+Weather App can provide weather and forecast data to other Apps.
+
+* Get weather data without forecast:
+  ```javascript
+   const weather = require("weather");
+   weatherData = weather.getWeather(false);  // or weather.get()
+  ```
+
+* Get weather data with forecast (needs forecast enabled in settings):
+  ```javascript
+   const weather = require("weather");
+   weatherData = weather.getWeather(true);
+  ```
+
+* Fetch new data from Gadgetbridge:
+  ```javascript
+   const weather = require("weather");
+   weather.updateWeather(false); // Can set to true if we want to ignore debounce
+  ```
+
+* React to updated weather data:
+  ```javascript
+   const weather = require("weather");
+
+   // For weather data without forecast
+   weather.on("update", () => {
+     currentData = weather.getWeather(false);
+     // console.log(currentData);
+   }
+
+   // For weather data with forecast
+   weather.on("update2", () => {
+     currentData = weather.getWeather(true);
+     // console.log(currentData);
+   }
+  ```

--- a/apps/weather/app.js
+++ b/apps/weather/app.js
@@ -16,24 +16,24 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
         render: l => {
           if (!current || current.uv === undefined) return;
           const uv = Math.min(parseInt(current.uv), 11); // Cap at 11
-          
+
           // UV color thresholds: [max_value, color] based on WHO standards
           const colors = [[2,"#0F0"], [5,"#FF0"], [7,"#F80"], [10,"#F00"], [11,"#F0F"]];
           const color = colors.find(c => uv <= c[0])[1];
-          
+
           // Setup and measure label
           g.setFont("6x8").setFontAlign(-1, 0);
           const label = "UV: ";
           const labelW = g.stringWidth(label);
-          
+
           // Calculate centered position (4px block + 1px spacing) * blocks - last spacing
           const totalW = labelW + uv * 5 - (uv > 0 ? 1 : 0);
           const x = l.x + (l.w - totalW) / 2;
           const y = l.y + l.h+6;
-          
+
           // Draw label
           g.setColor(g.theme.fg).drawString(label, x, y);
-          
+
           // Draw UV blocks
           g.setColor(color);
           for (let i = 0; i < uv; i++) {
@@ -58,7 +58,7 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
         {type: "txt", font: "6x8", pad: 2, halign: 1, label: /*LANG*/"Hum:"},
         {type: "txt", font: "9%", pad: 2, halign: 1, id: "hum", label: "000%"},
       ]},
-      
+
       {filly: 1},
       {type: "txt", font: "6x8", pad: 2, halign: -1, label: /*LANG*/"Wind"},
       {type: "h", halign: -1, c: [
@@ -79,7 +79,7 @@ var layout = new Layout({type:"v", bgCol: g.theme.bg, c: [
 ]}, {lazy: true});
 
 function formatDuration(millis) {
-  let pluralize = (n, w) => n + " " + w + (n == 1 ? "" : "s");
+  let pluralize = (n, w) => `${n} ${w}${n === 1 ? "" : "s"}`;
   if (millis < 60000) return /*LANG*/"< 1 minute";
   if (millis < 3600000) return pluralize(Math.floor(millis/60000), /*LANG*/"minute");
   if (millis < 86400000) return pluralize(Math.floor(millis/3600000), /*LANG*/"hour");
@@ -98,11 +98,11 @@ function draw() {
   }else{
     layout.feelslike.label = feelsLikeTemp[1]+feelsLikeTemp[2];
   }
-  
-  layout.hum.label = current.hum+"%";
+
+  layout.hum.label = `${current.hum}%`;
   const wind = locale.speed(current.wind).match(/^(\D*\d*)(.*)$/);
   layout.wind.label = wind[1];
-  layout.windUnit.label = wind[2] + " " + (current.wrose||'').toUpperCase();
+  layout.windUnit.label = `${wind[2]} ${(current.wrose||'').toUpperCase()}`;
   layout.cond.label = current.txt.charAt(0).toUpperCase()+(current.txt||'').slice(1);
   layout.loc.label = current.loc;
   layout.updateTime.label = `${formatDuration(Date.now() - current.time)} ago`; // How to autotranslate this and similar?

--- a/apps/weather/clkinfo.js
+++ b/apps/weather/clkinfo.js
@@ -1,5 +1,4 @@
-
-(function() {
+(() => {
     var weather;
     var weatherLib = require("weather");
 
@@ -8,9 +7,9 @@
       if(weather){
         weather.temp = require("locale").temp(weather.temp-273.15);
         weather.feels = require("locale").temp(weather.feels-273.15);
-        weather.hum = weather.hum + "%";
+        weather.hum = `${weather.hum}%`;
         weather.wind = require("locale").speed(weather.wind).match(/^(\D*\d*)(.*)$/);
-        weather.wind = Math.round(weather.wind[1]) + "kph";
+        weather.wind = `${Math.round(weather.wind[1])}kph`;
       } else {
         weather = {
           temp: "?",

--- a/apps/weather/lib.js
+++ b/apps/weather/lib.js
@@ -1,5 +1,5 @@
-const storage = require('Storage');
-const B2 = process.env.HWVERSION===2;
+const storage = require("Storage");
+const B2 = process.env.HWVERSION === 2;
 
 let expiryTimeout;
 function scheduleExpiry(json) {
@@ -7,7 +7,7 @@ function scheduleExpiry(json) {
     clearTimeout(expiryTimeout);
     expiryTimeout = undefined;
   }
-  let expiry = "expiry" in json ? json.expiry : 2*3600000;
+  let expiry = "expiry" in json ? json.expiry : 2 * 3600000;
   if (json.weather && json.weather.time && expiry) {
     let t = json.weather.time + expiry - Date.now();
     expiryTimeout = setTimeout(update, t);
@@ -15,7 +15,7 @@ function scheduleExpiry(json) {
 }
 
 function update(weatherEvent) {
-  let json = storage.readJSON('weather.json')||{};
+  let json = storage.readJSON("weather.json") || {};
 
   if (weatherEvent) {
     let weather = weatherEvent.clone();
@@ -24,92 +24,90 @@ function update(weatherEvent) {
     if (weather.wdir != null) {
       // Convert numeric direction into human-readable label
       let deg = weather.wdir;
-      while (deg<0 || deg>360) {
-        deg = (deg+360)%360;
+      while (deg < 0 || deg > 360) {
+        deg = (deg + 360) % 360;
       }
-      weather.wrose = ['n','ne','e','se','s','sw','w','nw','n'][Math.floor((deg+22.5)/45)];
+      weather.wrose = ["n", "ne", "e", "se", "s", "sw", "w", "nw", "n"][Math.floor((deg + 22.5) / 45)];
     }
 
     json.weather = weather;
-  }
-  else {
+  } else {
     delete json.weather;
   }
 
-
-  storage.write('weather.json', json);
+  storage.write("weather.json", json);
   scheduleExpiry(json);
   exports.emit("update", json.weather);
 }
 exports.update = update;
 const _GB = global.GB;
 global.GB = (event) => {
-  if (event.t==="weather") update(event);
+  if (event.t === "weather") update(event);
   if (_GB) setTimeout(_GB, 0, event);
 };
 
-exports.get = function() {
-  return (storage.readJSON('weather.json')||{}).weather;
-}
+exports.get = () => {
+  return (storage.readJSON("weather.json") || {}).weather;
+};
 
-scheduleExpiry(storage.readJSON('weather.json')||{});
+scheduleExpiry(storage.readJSON("weather.json") || {});
 
 function getPalette(monochrome, ovr) {
   var palette;
-  if(monochrome) {
+  if (monochrome) {
     palette = {
-      sun: '#FFF',
-      cloud: '#FFF',
-      bgCloud: '#FFF',
-      rain: '#FFF',
-      lightning: '#FFF',
-      snow: '#FFF',
-      mist: '#FFF',
-      background: '#000'
+      sun: "#FFF",
+      cloud: "#FFF",
+      bgCloud: "#FFF",
+      rain: "#FFF",
+      lightning: "#FFF",
+      snow: "#FFF",
+      mist: "#FFF",
+      background: "#000",
     };
   } else {
     if (B2) {
       if (ovr.theme.dark) {
         palette = {
-          sun: '#FF0',
-          cloud: '#FFF',
-          bgCloud: '#777', // dithers on B2, but that's ok
-          rain: '#0FF',
-          lightning: '#FF0',
-          snow: '#FFF',
-          mist: '#FFF'
+          sun: "#FF0",
+          cloud: "#FFF",
+          bgCloud: "#777", // dithers on B2, but that's ok
+          rain: "#0FF",
+          lightning: "#FF0",
+          snow: "#FFF",
+          mist: "#FFF",
         };
       } else {
         palette = {
-          sun: '#FF0',
-          cloud: '#777', // dithers on B2, but that's ok
-          bgCloud: '#000',
-          rain: '#00F',
-          lightning: '#FF0',
-          snow: '#0FF',
-          mist: '#0FF'
+          sun: "#FF0",
+          cloud: "#777", // dithers on B2, but that's ok
+          bgCloud: "#000",
+          rain: "#00F",
+          lightning: "#FF0",
+          snow: "#0FF",
+          mist: "#0FF",
         };
       }
     } else {
       if (ovr.theme.dark) {
         palette = {
-          sun: '#FE0',
-          cloud: '#BBB',
-          bgCloud: '#777',
-          rain: '#0CF',
-          lightning: '#FE0',
-          snow: '#FFF',
-          mist: '#FFF'
+          sun: "#FE0",
+          cloud: "#BBB",
+          bgCloud: "#777",
+          rain: "#0CF",
+          lightning: "#FE0",
+          snow: "#FFF",
+          mist: "#FFF",
         };
       } else {
         palette = {
-          sun: '#FC0',
-          cloud: '#000',
-          bgCloud: '#777',
-          rain: '#07F',
-          lightning: '#FC0',
-          snow: '#CCC',
-          mist: '#CCC'
+          sun: "#FC0",
+          cloud: "#000",
+          bgCloud: "#777",
+          rain: "#07F",
+          lightning: "#FC0",
+          snow: "#CCC",
+          mist: "#CCC",
         };
       }
     }
@@ -117,10 +115,10 @@ function getPalette(monochrome, ovr) {
   return palette;
 }
 
-exports.getColor = function(code) {
+exports.getColor = (code) => {
   const codeGroup = Math.round(code / 100);
   const palette = getPalette(0, g);
-  const cloud = g.blendColor(palette.cloud, palette.bgCloud, .5); //theme independent
+  const cloud = g.blendColor(palette.cloud, palette.bgCloud, 0.5); //theme independent
   switch (codeGroup) {
     case 2: return g.blendColor(cloud, palette.lightning, .5);
     case 3: return palette.rain;
@@ -144,7 +142,7 @@ exports.getColor = function(code) {
       }
     default: return cloud;
   }
-}
+};
 
 /**
  *
@@ -158,9 +156,9 @@ exports.getColor = function(code) {
  * @param ovr Graphics instance (or undefined for g)
  * @param monochrome If true, produce a monochromatic icon
  */
-exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
+exports.drawIcon = (cond, x, y, r, ovr, monochrome) => {
   var palette;
-  if(!ovr) ovr = g;
+  if (!ovr) ovr = g;
 
   palette = getPalette(monochrome, ovr);
 
@@ -257,7 +255,7 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
 
   function drawSnow(x, y, r) {
     function rotatePoints(points, pivotX, pivotY, angle) {
-      for(let i = 0; i<points.length; i += 2) {
+      for (let i = 0; i < points.length; i += 2) {
         const x = points[i];
         const y = points[i+1];
         points[i] = Math.cos(angle)*(x-pivotX)-Math.sin(angle)*(y-pivotY)+
@@ -269,7 +267,7 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
 
     ovr.setColor(palette.snow);
     const w = 1/12*r;
-    for(let i = 0; i<=6; ++i) {
+    for (let i = 0; i <= 6; ++i) {
       const points = [
         x+w, y,
         x-w, y,
@@ -279,7 +277,7 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
       rotatePoints(points, x, y, i/3*Math.PI);
       ovr.fillPoly(points);
 
-      for(let j = -1; j<=1; j += 2) {
+      for (let j = -1; j <= 1; j += 2) {
         const points = [
           x+w, y+7/12*r,
           x-w, y+7/12*r,
@@ -317,8 +315,8 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
   }
 
   /*
-  * Choose weather icon to display based on weather description
-  */
+   * Choose weather icon to display based on weather description
+   */
   function chooseIconByTxt(txt) {
     if (!txt) return () => {};
     txt = txt.toLowerCase();
@@ -336,7 +334,8 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
     if (txt.includes("few clouds")) return drawFewClouds;
     if (txt.includes("scattered clouds")) return drawCloud;
     if (txt.includes("clouds")) return drawBrokenClouds;
-    if (txt.includes("mist") ||
+    if (
+      txt.includes("mist") ||
       txt.includes("smoke") ||
       txt.includes("haze") ||
       txt.includes("sand") ||
@@ -344,16 +343,17 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
       txt.includes("fog") ||
       txt.includes("ash") ||
       txt.includes("squalls") ||
-      txt.includes("tornado")) {
+      txt.includes("tornado")
+    ) {
       return drawMist;
     }
     return drawUnknown;
   }
 
   /*
-  * Choose weather icon to display based on weather conditition code
-  * https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
-  */
+   * Choose weather icon to display based on weather condition code
+   * https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
+   */
   function chooseIconByCode(code) {
     const codeGroup = Math.round(code / 100);
     switch (codeGroup) {
@@ -382,16 +382,15 @@ exports.drawIcon = function(cond, x, y, r, ovr, monochrome) {
   }
 
   function chooseIcon(cond) {
-    if (typeof (cond)==="object") {
+    if (typeof cond === "object") {
       if ("code" in cond) return chooseIconByCode(cond.code);
       if ("txt" in cond) return chooseIconByTxt(cond.txt);
-    } else if (typeof (cond)==="number") {
+    } else if (typeof cond === "number") {
       return chooseIconByCode(cond.code);
-    } else if (typeof (cond)==="string") {
+    } else if (typeof cond === "string") {
       return chooseIconByTxt(cond.txt);
     }
     return drawUnknown;
   }
   chooseIcon(cond)(x, y, r);
-
 };

--- a/apps/weather/metadata.json
+++ b/apps/weather/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "weather",
   "name": "Weather",
-  "version": "0.29",
+  "version": "0.30",
   "description": "Show Gadgetbridge/iOS weather report",
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],
@@ -16,5 +16,5 @@
     {"name":"weather.settings.js","url":"settings.js"},
     {"name":"weather.clkinfo.js","url":"clkinfo.js"}
   ],
-  "data": [{"name":"weather.json"}]
+  "data": [{"name":"weatherSetting.json"},{"name":"weather.json"},{"name":"weather2.json"}]
 }

--- a/apps/weather/settings.js
+++ b/apps/weather/settings.js
@@ -19,6 +19,8 @@
     storage.write("weatherSetting.json", settings);
   }
 
+  const DATA_TYPE = ["basic", "extended", "forecast"];
+
   E.showMenu({
     "": { "title": "Weather" },
     "Expiry": {
@@ -45,11 +47,14 @@
       },
       onchange: (x) => save("refresh", x),
     },
-    Forecast: {
-      value: "forecast" in settings ? settings.forecast : false,
-      onchange: () => {
-        settings.forecast = !settings.forecast;
-        save("forecast", settings.forecast);
+    "Data type": {
+      value: DATA_TYPE.indexOf(settings.dataType ?? "basic"),
+      format: (v) => DATA_TYPE[v],
+      min: 0,
+      max: DATA_TYPE.length - 1,
+      onchange: (v) => {
+        settings.dataType = DATA_TYPE[v];
+        save("dataType", settings.dataType);
       },
     },
     "Hide Widget": {

--- a/apps/weather/settings.js
+++ b/apps/weather/settings.js
@@ -1,31 +1,31 @@
-(function(back) {
-  const storage = require('Storage');
-  let settings = storage.readJSON('weather.json', 1) || {};
+(back) => {
+  const storage = require("Storage");
+  let settings = storage.readJSON("weather.json", 1) || {};
   function save(key, value) {
     settings[key] = value;
-    storage.write('weather.json', settings);
+    storage.write("weather.json", settings);
   }
   E.showMenu({
-    '': { 'title': 'Weather' },
-    'Expiry': {
-      value: "expiry" in settings ? settings["expiry"] : 2*3600000,
+    "": { "title": "Weather" },
+    "Expiry": {
+      value: "expiry" in settings ? settings.expiry : 2 * 3600000,
       min: 0,
-      max : 24*3600000,
-      step: 15*60000,
-      format: x => {
-        if (x == 0) return "none";
-        if (x < 3600000) return Math.floor(x/60000) + "m";
-        if (x < 86400000) return Math.floor(x/36000)/100 + "h";
+      max: 24 * 3600000,
+      step: 15 * 60000,
+      format: (x) => {
+        if (x === 0) return "none";
+        if (x < 3600000) return `${Math.floor(x / 60000)}m`;
+        if (x < 86400000) return `${Math.floor(x / 36000) / 100}h`;
       },
-      onchange: x => save('expiry', x),
+      onchange: (x) => save("expiry", x),
     },
-    'Hide Widget': {
+    "Hide Widget": {
       value: "hide" in settings ? settings.hide : false,
       onchange: () => {
-        settings.hide = !settings.hide
-        save('hide', settings.hide);
+        settings.hide = !settings.hide;
+        save("hide", settings.hide);
       },
     },
-    '< Back': back,
+    "< Back": back,
   });
-})
+};

--- a/apps/weather/settings.js
+++ b/apps/weather/settings.js
@@ -1,10 +1,24 @@
 (back) => {
   const storage = require("Storage");
-  let settings = storage.readJSON("weather.json", 1) || {};
+  let settings = storage.readJSON("weatherSetting.json", 1);
+
+  // Handle transition from old weather.json to new weatherSetting.json
+  if (settings == null) {
+    const settingsOld = storage.readJSON("weather.json", 1) || {};
+    settings = {
+      expiry: "expiry" in settingsOld ? settingsOld.expiry : 2 * 3600000,
+      hide: "hide" in settingsOld ? settingsOld.hide : false,
+    };
+    if (settingsOld != null && settingsOld.weather != null && settingsOld.weather.time != null) {
+      settings.time = settingsOld.weather.time;
+    }
+  }
+
   function save(key, value) {
     settings[key] = value;
-    storage.write("weather.json", settings);
+    storage.write("weatherSetting.json", settings);
   }
+
   E.showMenu({
     "": { "title": "Weather" },
     "Expiry": {
@@ -19,12 +33,34 @@
       },
       onchange: (x) => save("expiry", x),
     },
+    "Refresh Rate": {
+      value: "refresh" in settings ? settings.refresh : 0,
+      min: 0,
+      max: 24 * 3600000,
+      step: 15 * 60000,
+      format: (x) => {
+        if (x === 0) return "never";
+        if (x < 3600000) return `${Math.floor(x / 60000)}m`;
+        if (x < 86400000) return `${Math.floor(x / 36000) / 100}h`;
+      },
+      onchange: (x) => save("refresh", x),
+    },
+    Forecast: {
+      value: "forecast" in settings ? settings.forecast : false,
+      onchange: () => {
+        settings.forecast = !settings.forecast;
+        save("forecast", settings.forecast);
+      },
+    },
     "Hide Widget": {
       value: "hide" in settings ? settings.hide : false,
       onchange: () => {
         settings.hide = !settings.hide;
         save("hide", settings.hide);
       },
+    },
+    "Force refresh": () => {
+      require("weather").updateWeather(true);
     },
     "< Back": back,
   });

--- a/apps/weather/settings.js
+++ b/apps/weather/settings.js
@@ -21,7 +21,7 @@
 
   const DATA_TYPE = ["basic", "extended", "forecast"];
 
-  E.showMenu({
+  menuItems = {
     "": { "title": "Weather" },
     "Expiry": {
       value: "expiry" in settings ? settings.expiry : 2 * 3600000,
@@ -35,7 +35,26 @@
       },
       onchange: (x) => save("expiry", x),
     },
-    "Refresh Rate": {
+    "Hide Widget": {
+      value: "hide" in settings ? settings.hide : false,
+      onchange: () => {
+        settings.hide = !settings.hide;
+        save("hide", settings.hide);
+      },
+    },
+    "< Back": back,
+  };
+
+  // Add android only settings
+  let android = false;
+  try {
+    if (require("android") != null) {
+      android = true;
+    }
+  } catch (_) {}
+
+  if (android) {
+    menuItems["Refresh Rate"] = {
       value: "refresh" in settings ? settings.refresh : 0,
       min: 0,
       max: 24 * 3600000,
@@ -46,8 +65,9 @@
         if (x < 86400000) return `${Math.floor(x / 36000) / 100}h`;
       },
       onchange: (x) => save("refresh", x),
-    },
-    "Data type": {
+    };
+
+    menuItems["Data type"] = {
       value: DATA_TYPE.indexOf(settings.dataType ?? "basic"),
       format: (v) => DATA_TYPE[v],
       min: 0,
@@ -56,17 +76,12 @@
         settings.dataType = DATA_TYPE[v];
         save("dataType", settings.dataType);
       },
-    },
-    "Hide Widget": {
-      value: "hide" in settings ? settings.hide : false,
-      onchange: () => {
-        settings.hide = !settings.hide;
-        save("hide", settings.hide);
-      },
-    },
-    "Force refresh": () => {
+    };
+
+    menuItems["Force refresh"] = () => {
       require("weather").updateWeather(true);
-    },
-    "< Back": back,
-  });
+    };
+  }
+
+  E.showMenu(menuItems);
 };

--- a/apps/weather/widget.js
+++ b/apps/weather/widget.js
@@ -6,7 +6,7 @@
   let settings;
 
   function loadSettings() {
-    settings = require("Storage").readJSON("weather.json", 1) || {};
+    settings = require("Storage").readJSON("weatherSetting.json", 1) || {};
   }
 
   function setting(key) {

--- a/apps/weather/widget.js
+++ b/apps/weather/widget.js
@@ -1,53 +1,53 @@
 (() => {
-  const weather = require('weather');
-  
+  const weather = require("weather");
+
   var dirty = false;
-  
+
   let settings;
 
   function loadSettings() {
-    settings = require('Storage').readJSON('weather.json', 1) || {};
+    settings = require("Storage").readJSON("weather.json", 1) || {};
   }
 
   function setting(key) {
     if (!settings) { loadSettings(); }
     const DEFAULTS = {
-      'expiry': 2*3600000,
-      'hide': false
+      "expiry": 2*3600000,
+      "hide": false
     };
     return (key in settings) ? settings[key] : DEFAULTS[key];
   }
 
   weather.on("update", w => {
-    if (setting('hide')) return;
+    if (setting("hide")) return;
     if (w) {
-      if (!WIDGETS["weather"].width) {
-        WIDGETS["weather"].width = 20;
+      if (!WIDGETS.weather.width) {
+        WIDGETS.weather.width = 20;
         Bangle.drawWidgets();
       } else if (Bangle.isLCDOn()) {
-        WIDGETS["weather"].draw();
+        WIDGETS.weather.draw();
       } else {
         dirty = true;
       }
     }
     else {
-      WIDGETS["weather"].width = 0;
+      WIDGETS.weather.width = 0;
       Bangle.drawWidgets();
     }
   });
 
-  Bangle.on('lcdPower', on => {
-    if (on && dirty && !setting('hide')) {
-      WIDGETS["weather"].draw();
+  Bangle.on("lcdPower", on => {
+    if (on && dirty && !setting("hide")) {
+      WIDGETS.weather.draw();
       dirty = false;
     }
   });
 
-  WIDGETS["weather"] = {
+  WIDGETS.weather = {
     area: "tl",
-    width: weather.get() && !setting('hide') ? 20 : 0,
+    width: weather.get() && !setting("hide") ? 20 : 0,
     draw: function() {
-      if (setting('hide')) return;
+      if (setting("hide")) return;
       const w = weather.get();
       if (!w) return;
       g.reset();
@@ -56,17 +56,17 @@
         weather.drawIcon(w, this.x+10, this.y+8, 7.5);
       }
       if (w.temp) {
-        let t = require('locale').temp(w.temp-273.15);  // applies conversion
+        let t = require("locale").temp(w.temp-273.15);  // applies conversion
         t = t.match(/[\d\-]*/)[0]; // but we have no room for units
         g.reset();
         g.setFontAlign(0, 1); // center horizontally at bottom of widget
-        g.setFont('6x8', 1);
+        g.setFont("6x8", 1);
         g.drawString(t, this.x+10, this.y+24);
       }
     },
-    reload:function() {
+    reload:() => {
       loadSettings();
-      WIDGETS["weather"].redraw();
+      WIDGETS.weather.redraw();
     },
   };
 })();


### PR DESCRIPTION
This PR adds:
- Adjust code to unified and more modern javascript style
  - The main reasoning for fixing formatting of the code is that at first I thought I would fork the Weather App to a new one with forecast, but after discussion on GadgetBrige PR with weather data it was decided to keep it in the current Weather App. So I reused the code I had and tried to keep the improvements to readability.
- Split settings and weather data into two files in storage
  - It's cleaner this way to keep settings separate from weather data
- Add support for new version of weather data and forecast from GadgetBridge (requires version 0.86.0 or higher)
- Add support to automatically fetch weather at time interval defined in settings (requires GadgetBridge version 0.86.0 or higher)
- Add button to settings to force fetch weather data (requires GadgetBridge version 0.86.0 or higher)
- Add new API to get weather from Weather App for other Apps
  - This is described more in readme with examples

The forecast data are parsed only when requested by `weather.getWeather(true)` to minimize processing time used. 

PS: I haven't tested it on BangleJS 1 and I haven't tested how it behaves with older version of GadgetBridge, but I don't see reason why it should break.

PSS: I wanted to add the support for forecast parsing/api separately, as I don't know how long it will take me to make the App to show the forecast data (mostly figuring out the design of it as there is not much screen space). However, with this change, someone else can make their own in the meantime or use the data for other purpose.