### PR TITLE
[widalarmeta] Add listeners to draw when unlocked

### DIFF
--- a/apps/widalarmeta/ChangeLog
+++ b/apps/widalarmeta/ChangeLog
@@ -13,3 +13,4 @@
 0.09: Match draw() API e.g. to allow wid_edit to alter this widget
 0.10: Change 4x5 font to 6x8, teletext is now default font
 0.11: Bugfix: handle changes in alarms (e.g. done without a load, such as via fastload)
+0.12: Redraw when screen turns on or watch is unlocked

--- a/apps/widalarmeta/metadata.json
+++ b/apps/widalarmeta/metadata.json
@@ -2,7 +2,7 @@
   "id": "widalarmeta",
   "name": "Alarm & Timer ETA",
   "shortName": "Alarm ETA",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A widget that displays the time to the next Alarm or Timer in hours and minutes, maximum 24h (configurable).",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -133,5 +133,7 @@
     };
 
     Bangle.on("alarmReload", () => WIDGETS["widalarmeta"].reload());
+    Bangle.on("lock", () => WIDGETS["widalarmeta"].draw(WIDGETS["widalarmeta"]))
+    Bangle.on("lcdPower", () => WIDGETS["widalarmeta"].draw(WIDGETS["widalarmeta"]))
   }
 })();


### PR DESCRIPTION
I have this widget set to show seconds only while unlocked, but before this change it wouldn't redraw the widget to show seconds when the display wakes up.

I've been testing it for the past few weeks.