### PR TITLE
[A Battery Widget] Background color matches Bangle’s theme

### DIFF
--- a/apps/wid_a_battery_widget/ChangeLog
+++ b/apps/wid_a_battery_widget/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Internal id update to wid_* as per Gordon's request (2021/11/21)
 0.03: Support dark themes
 0.04: Increase screen update rate when charging
+0.05: Add support for all foreground and background colors (2025/7/5)

--- a/apps/wid_a_battery_widget/metadata.json
+++ b/apps/wid_a_battery_widget/metadata.json
@@ -3,7 +3,7 @@
   "name": "A Battery Widget (with percentage)",
   "shortName":"A Battery Widget",
   "icon": "widget.png",
-  "version":"0.04",
+  "version":"0.05",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/wid_a_battery_widget/widget.js
+++ b/apps/wid_a_battery_widget/widget.js
@@ -3,8 +3,8 @@
   const intervalHigh = 2000; // update time when charging
 
   let COLORS = {
-    'white':    g.theme.dark ? "#000" : "#fff",
-    'black':    g.theme.dark ? "#fff" : "#000",
+    'bg':    g.theme.bg,
+    'fg':    g.theme.fg,
     'charging': "#08f",
     'high':     g.theme.dark ? "#fff" : "#000",
     'low':      "#f00",
@@ -24,7 +24,7 @@
 
     let xl = x+4+l*(s-12)/100;
 
-    g.setColor(COLORS.white);
+    g.setColor(COLORS.bg);
     g.fillRect(x+2,y+5,x+s-6,y+18);
 
     g.setColor(levelColor(l));
@@ -35,7 +35,7 @@
     g.fillRect(x+s-3,y+8,x+s-2,y+16); // tip of the battery
     g.fillRect(x+4,y+15,xl,y+16); // charging bar
 
-    g.setColor(COLORS.black);
+    g.setColor(COLORS.fg);
     g.setFontAlign(0,0);
     g.setFont('6x8');
     g.drawString(l, x + 14, y + 10);


### PR DESCRIPTION
Rather than defaulting to black or white, this uses the background and foreground colors that the rest of the bangle uses, for greater cohesion with users’ themes.