### PR TITLE
promenu: workaround `setUI` touch handler bug (2v26/2v27)

### DIFF
--- a/apps/promenu/ChangeLog
+++ b/apps/promenu/ChangeLog
@@ -16,3 +16,4 @@
 0.12: Fix bug where settings would behave as if all were set to false
 0.13: Update to new touch-event handling
 0.14: Fix bug in handling changes to `Bangle.appRect`
+0.15: Workaround bug in 2v26/2v27 firmware

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -126,7 +126,6 @@ E.showMenu = (function (items) {
                             nameScroll_1 = 0;
                     }, 300, name, v, item, idx, x, iy);
                 }
-                g.setColor(g.theme.fg);
                 iy += fontHeight;
                 idx++;
             };
@@ -219,17 +218,19 @@ E.showMenu = (function (items) {
             if (nameScroller)
                 clearInterval(nameScroller);
             Bangle.removeListener("swipe", onSwipe);
-            if (is2v26_27)
+            if (setUITouch)
                 Bangle.removeListener("touch", touchcb);
             (_a = options.remove) === null || _a === void 0 ? void 0 : _a.call(options);
         },
     };
-    var is2v26_27 = process.env.VERSION === "2v26" || process.env.VERSION === "2v27";
-    if (!is2v26_27) {
+    var setUITouch = process.env.VERSION >= "2v26";
+    if (!setUITouch) {
         uiopts.touch = touchcb;
     }
     Bangle.setUI(uiopts, cb);
-    if (is2v26_27) {
+    if (setUITouch) {
+        Bangle.removeListener("touch", Bangle.touchHandler);
+        delete Bangle.touchHandler;
         Bangle.on("touch", touchcb);
     }
     return l;

--- a/apps/promenu/bootb2.js
+++ b/apps/promenu/bootb2.js
@@ -2,7 +2,11 @@ var _a, _b;
 var prosettings = (require("Storage").readJSON("promenu.settings.json", true) || {});
 (_a = prosettings.naturalScroll) !== null && _a !== void 0 ? _a : (prosettings.naturalScroll = false);
 (_b = prosettings.wrapAround) !== null && _b !== void 0 ? _b : (prosettings.wrapAround = true);
-E.showMenu = function (items) {
+E.showMenu = (function (items) {
+    if (items == null) {
+        g.clearRect(Bangle.appRect);
+        return Bangle.setUI();
+    }
     var RectRnd = function (x1, y1, x2, y2, r) {
         var pp = [];
         pp.push.apply(pp, g.quadraticBezier([x2 - r, y1, x2, y1, x2, y1 + r]));
@@ -204,7 +208,10 @@ E.showMenu = function (items) {
         else
             l.select(evt);
     };
-    Bangle.setUI({
+    var touchcb = (function (_button, xy) {
+        cb(void 0, xy);
+    });
+    var uiopts = {
         mode: "updown",
         back: back,
         remove: function () {
@@ -212,11 +219,18 @@ E.showMenu = function (items) {
             if (nameScroller)
                 clearInterval(nameScroller);
             Bangle.removeListener("swipe", onSwipe);
+            if (is2v26_27)
+                Bangle.removeListener("touch", touchcb);
             (_a = options.remove) === null || _a === void 0 ? void 0 : _a.call(options);
         },
-        touch: (function (_button, xy) {
-            cb(void 0, xy);
-        }),
-    }, cb);
+    };
+    var is2v26_27 = process.env.VERSION === "2v26" || process.env.VERSION === "2v27";
+    if (!is2v26_27) {
+        uiopts.touch = touchcb;
+    }
+    Bangle.setUI(uiopts, cb);
+    if (is2v26_27) {
+        Bangle.on("touch", touchcb);
+    }
     return l;
-};
+});

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -257,6 +257,13 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
     else l.select(evt);
   };
 
+  const touchcb = ((_button, xy) => {
+      // since we've specified options.touch,
+      // we need to pass through all taps since the default
+      // touchHandler isn't installed in setUI
+      cb(void 0, xy);
+  }) satisfies TouchCallback;
+
   Bangle.setUI({
     mode: "updown",
     back: back as () => void,
@@ -265,12 +272,7 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
       Bangle.removeListener("swipe", onSwipe);
       options.remove?.();
     },
-    touch: ((_button, xy) => {
-      // since we've specified options.touch,
-      // we need to pass through all taps since the default
-      // touchHandler isn't installed in setUI
-      cb(void 0, xy);
-    }) satisfies TouchCallback,
+    touch: touchcb,
   } as SetUIArg<"updown">, cb);
 
   return l;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -172,7 +172,6 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
           }, 300, name, v, item, idx, x, iy);
         }
 
-        g.setColor(g.theme.fg);
         iy += fontHeight;
         idx++;
       }

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -13,7 +13,12 @@ const prosettings = (require("Storage").readJSON("promenu.settings.json", true) 
 prosettings.naturalScroll ??= false;
 prosettings.wrapAround ??= true;
 
-E.showMenu = (items?: Menu): MenuInstance => {
+E.showMenu = ((items?: Menu): MenuInstance | void => {
+  if(items == null){
+    g.clearRect(Bangle.appRect);
+    return Bangle.setUI();
+  }
+
   const RectRnd = (x1: number, y1: number, x2: number, y2: number, r: number) => {
     const pp = [];
     pp.push(...g.quadraticBezier([x2 - r, y1, x2, y1, x2, y1 + r]));
@@ -269,4 +274,4 @@ E.showMenu = (items?: Menu): MenuInstance => {
   } as SetUIArg<"updown">, cb);
 
   return l;
-};
+}) as typeof E.showMenu;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -264,7 +264,7 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
       cb(void 0, xy);
   }) satisfies TouchCallback;
 
-  Bangle.setUI({
+  const uiopts = {
     mode: "updown",
     back: back as () => void,
     remove: () => {
@@ -273,7 +273,9 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
       options.remove?.();
     },
     touch: touchcb,
-  } as SetUIArg<"updown">, cb);
+  } as SetUIArg<"updown">;
+
+  Bangle.setUI(uiopts, cb);
 
   return l;
 }) as typeof E.showMenu;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -270,12 +270,26 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
     remove: () => {
       if (nameScroller) clearInterval(nameScroller);
       Bangle.removeListener("swipe", onSwipe);
+      if(is2v26_27)
+          Bangle.removeListener("touch", touchcb);
       options.remove?.();
     },
-    touch: touchcb,
-  } as SetUIArg<"updown">;
+  } satisfies SetUIArg<"updown">;
+
+  const is2v26_27 = process.env.VERSION === "2v26" || process.env.VERSION === "2v27";
+  if (!is2v26_27) {
+      // no need for workaround
+      (uiopts as any).touch = touchcb;
+  }
 
   Bangle.setUI(uiopts, cb);
+
+  if(is2v26_27){
+      // work around:
+      // - https://github.com/espruino/Espruino/issues/2648
+      // - https://github.com/orgs/espruino/discussions/7697#discussioncomment-13782299
+      Bangle.on("touch", touchcb);
+  }
 
   return l;
 }) as typeof E.showMenu;

--- a/apps/promenu/bootb2.ts
+++ b/apps/promenu/bootb2.ts
@@ -259,7 +259,7 @@ E.showMenu = ((items?: Menu): MenuInstance | void => {
 
   Bangle.setUI({
     mode: "updown",
-    back,
+    back: back as () => void,
     remove: () => {
       if (nameScroller) clearInterval(nameScroller);
       Bangle.removeListener("swipe", onSwipe);

--- a/apps/promenu/metadata.json
+++ b/apps/promenu/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "promenu",
   "name": "Pro Menu",
-  "version": "0.14",
+  "version": "0.15",
   "description": "Replace the built in menu function. Supports Bangle.js 1 and Bangle.js 2.",
   "icon": "icon.png",
   "type": "bootloader",


### PR DESCRIPTION
See https://github.com/orgs/espruino/discussions/7697#discussioncomment-13782299 and espruino/Espruino#2648

Tested - bug is gone on 2v27 with this workaround