### PR TITLE
[widalarmeta] Add option to only show when on clock

### DIFF
--- a/apps/widalarmeta/ChangeLog
+++ b/apps/widalarmeta/ChangeLog
@@ -14,3 +14,4 @@
 0.10: Change 4x5 font to 6x8, teletext is now default font
 0.11: Bugfix: handle changes in alarms (e.g. done without a load, such as via fastload)
 0.12: Redraw when screen turns on or watch is unlocked
+0.13: Add option to only show when on clock

--- a/apps/widalarmeta/metadata.json
+++ b/apps/widalarmeta/metadata.json
@@ -2,7 +2,7 @@
   "id": "widalarmeta",
   "name": "Alarm & Timer ETA",
   "shortName": "Alarm ETA",
-  "version": "0.12",
+  "version": "0.13",
   "description": "A widget that displays the time to the next Alarm or Timer in hours and minutes, maximum 24h (configurable).",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widalarmeta/settings.js
+++ b/apps/widalarmeta/settings.js
@@ -7,6 +7,7 @@
     padHours: true,
     showSeconds: 0, // 0=never, 1=only when display is unlocked, 2=for less than a minute
     font: 1, // 0=segment style font, 1=teletext font, 2=6x8:1x2
+    whenToShow: 0, // 0=always, 1=on clock only
   }, require("Storage").readJSON(CONFIGFILE,1) || {});
 
   function writeSettings() {
@@ -56,6 +57,15 @@
       format: v => [/*LANG*/"Segment", /*LANG*/"Teletext", /*LANG*/"6x8"][v === undefined ? 1 : v],
       onchange: v => {
         settings.font = v;
+        writeSettings();
+      }
+    },
+    /*LANG*/'When To Show': {
+      value: settings.whenToShow,
+      min: 0, max: 1,
+      format: v => [/*LANG*/"Always", /*LANG*/"On Clock Only"][v === undefined ? 0 : v],
+      onchange: v => {
+        settings.whenToShow = v;
         writeSettings();
       }
     },

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -57,7 +57,8 @@
     let drawSeconds = false;
 
     // If always showing, or the clock is visible
-    if (config.whenToShow === 0 || Bangle.CLOCK) {
+    if (config.whenToShow === 1 && !Bangle.CLOCK)
+        return;
       // Determine text and width
       if (next > 0 && next <= config.maxhours*60*60*1000) {
         const hours = Math.floor((next-1) / 3600000).toString();

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -39,6 +39,13 @@
   } // getNextAlarm
 
   function draw(_w, fromInterval) {
+
+    // If only show on clock and not on clock
+    if (config.whenToShow === 1 && !Bangle.CLOCK) {
+      this.nextAlarm = undefined; // make sure to reload later
+      return;
+    }
+
     if (this.nextAlarm === undefined) {
       let alarm = getNextAlarm();
       if (alarm === undefined) {
@@ -56,49 +63,45 @@
     let calcWidth = 0;
     let drawSeconds = false;
 
-    // If always showing, or the clock is visible
-    if (config.whenToShow === 1 && !Bangle.CLOCK)
-        return;
-      // Determine text and width
-      if (next > 0 && next <= config.maxhours*60*60*1000) {
-        const hours = Math.floor((next-1) / 3600000).toString();
-        const minutes = Math.floor(((next-1) % 3600000) / 60000).toString();
-        const seconds = Math.floor(((next-1) % 60000) / 1000).toString();
-        drawSeconds = (config.showSeconds & 0b01 && !Bangle.isLocked()) || (config.showSeconds & 0b10 && next <= 1000*60);
+    // Determine text and width
+    if (next > 0 && next <= config.maxhours*60*60*1000) {
+      const hours = Math.floor((next-1) / 3600000).toString();
+      const minutes = Math.floor(((next-1) % 3600000) / 60000).toString();
+      const seconds = Math.floor(((next-1) % 60000) / 1000).toString();
+      drawSeconds = (config.showSeconds & 0b01 && !Bangle.isLocked()) || (config.showSeconds & 0b10 && next <= 1000*60);
 
-        g.reset(); // reset the graphics context to defaults (color/font/etc)
-        g.setFontAlign(-1,0); // center font in y direction
-        g.clearRect(this.x, this.y, this.x+this.width-1, this.y+23);
+      g.reset(); // reset the graphics context to defaults (color/font/etc)
+      g.setFontAlign(-1,0); // center font in y direction
+      g.clearRect(this.x, this.y, this.x+this.width-1, this.y+23);
 
-        var text = "";
-        if (config.padHours) {
-          text += hours.padStart(2, '0');
-        } else {
-          text += hours;
-        }
-        text += ":" + minutes.padStart(2, '0');
-        if (drawSeconds) {
-          text += ":" + seconds.padStart(2, '0');
-        }
-        if (config.font == 0) {
-          g.setFont("5x9Numeric7Seg:1x2");
-        } else if (config.font == 1) {
-          g.setFont("Teletext5x9Ascii:1x2");
-        } else {
-          // Default to this if no other font is set.
-          g.setFont("6x8:1x2");
-        }
-        g.drawString(text, this.x+1, this.y+12);
+      var text = "";
+      if (config.padHours) {
+        text += hours.padStart(2, '0');
+      } else {
+        text += hours;
+      }
+      text += ":" + minutes.padStart(2, '0');
+      if (drawSeconds) {
+        text += ":" + seconds.padStart(2, '0');
+      }
+      if (config.font == 0) {
+        g.setFont("5x9Numeric7Seg:1x2");
+      } else if (config.font == 1) {
+        g.setFont("Teletext5x9Ascii:1x2");
+      } else {
+        // Default to this if no other font is set.
+        g.setFont("6x8:1x2");
+      }
+      g.drawString(text, this.x+1, this.y+12);
 
-        calcWidth = g.stringWidth(text) + 2; // One pixel on each side
-        this.bellVisible = false;
-      } else if (config.drawBell && this.numActiveAlarms > 0) {
-        calcWidth = 24;
-        // next alarm too far in future, draw only widalarm bell
-        if (this.bellVisible !== true || fromInterval !== true) {
-          g.reset().drawImage(atob("GBgBAAAAAAAAABgADhhwDDwwGP8YGf+YMf+MM//MM//MA//AA//AA//AA//AA//AA//AB//gD//wD//wAAAAADwAABgAAAAAAAAA"),this.x,this.y);
-          this.bellVisible = true;
-        }
+      calcWidth = g.stringWidth(text) + 2; // One pixel on each side
+      this.bellVisible = false;
+    } else if (config.drawBell && this.numActiveAlarms > 0) {
+      calcWidth = 24;
+      // next alarm too far in future, draw only widalarm bell
+      if (this.bellVisible !== true || fromInterval !== true) {
+        g.reset().drawImage(atob("GBgBAAAAAAAAABgADhhwDDwwGP8YGf+YMf+MM//MM//MA//AA//AA//AA//AA//AA//AB//gD//wD//wAAAAADwAABgAAAAAAAAA"),this.x,this.y);
+        this.bellVisible = true;
       }
     }
 

--- a/apps/widalarmeta/widget.js
+++ b/apps/widalarmeta/widget.js
@@ -8,6 +8,7 @@
       padHours: true,
       showSeconds: 0, // 0=never, 1=only when display is unlocked, 2=for less than a minute
       font: 1, // 0=segment style font, 1=teletext font, 2=6x8:1x2
+      whenToShow: 0, // 0=always, 1=on clock only
     }, require("Storage").readJSON("widalarmeta.json",1) || {});
 
       if (config.font == 0) {
@@ -55,44 +56,48 @@
     let calcWidth = 0;
     let drawSeconds = false;
 
-    if (next > 0 && next <= config.maxhours*60*60*1000) {
-      const hours = Math.floor((next-1) / 3600000).toString();
-      const minutes = Math.floor(((next-1) % 3600000) / 60000).toString();
-      const seconds = Math.floor(((next-1) % 60000) / 1000).toString();
-      drawSeconds = (config.showSeconds & 0b01 && !Bangle.isLocked()) || (config.showSeconds & 0b10 && next <= 1000*60);
+    // If always showing, or the clock is visible
+    if (config.whenToShow === 0 || Bangle.CLOCK) {
+      // Determine text and width
+      if (next > 0 && next <= config.maxhours*60*60*1000) {
+        const hours = Math.floor((next-1) / 3600000).toString();
+        const minutes = Math.floor(((next-1) % 3600000) / 60000).toString();
+        const seconds = Math.floor(((next-1) % 60000) / 1000).toString();
+        drawSeconds = (config.showSeconds & 0b01 && !Bangle.isLocked()) || (config.showSeconds & 0b10 && next <= 1000*60);
 
-      g.reset(); // reset the graphics context to defaults (color/font/etc)
-      g.setFontAlign(-1,0); // center font in y direction
-      g.clearRect(this.x, this.y, this.x+this.width-1, this.y+23);
+        g.reset(); // reset the graphics context to defaults (color/font/etc)
+        g.setFontAlign(-1,0); // center font in y direction
+        g.clearRect(this.x, this.y, this.x+this.width-1, this.y+23);
 
-      var text = "";
-      if (config.padHours) {
-        text += hours.padStart(2, '0');
-      } else {
-        text += hours;
-      }
-      text += ":" + minutes.padStart(2, '0');
-      if (drawSeconds) {
-        text += ":" + seconds.padStart(2, '0');
-      }
-      if (config.font == 0) {
-        g.setFont("5x9Numeric7Seg:1x2");
-      } else if (config.font == 1) {
-        g.setFont("Teletext5x9Ascii:1x2");
-      } else {
-        // Default to this if no other font is set.
-        g.setFont("6x8:1x2");
-      }
-      g.drawString(text, this.x+1, this.y+12);
+        var text = "";
+        if (config.padHours) {
+          text += hours.padStart(2, '0');
+        } else {
+          text += hours;
+        }
+        text += ":" + minutes.padStart(2, '0');
+        if (drawSeconds) {
+          text += ":" + seconds.padStart(2, '0');
+        }
+        if (config.font == 0) {
+          g.setFont("5x9Numeric7Seg:1x2");
+        } else if (config.font == 1) {
+          g.setFont("Teletext5x9Ascii:1x2");
+        } else {
+          // Default to this if no other font is set.
+          g.setFont("6x8:1x2");
+        }
+        g.drawString(text, this.x+1, this.y+12);
 
-      calcWidth = g.stringWidth(text) + 2; // One pixel on each side
-      this.bellVisible = false;
-    } else if (config.drawBell && this.numActiveAlarms > 0) {
-      calcWidth = 24;
-      // next alarm too far in future, draw only widalarm bell
-      if (this.bellVisible !== true || fromInterval !== true) {
-        g.reset().drawImage(atob("GBgBAAAAAAAAABgADhhwDDwwGP8YGf+YMf+MM//MM//MA//AA//AA//AA//AA//AA//AB//gD//wD//wAAAAADwAABgAAAAAAAAA"),this.x,this.y);
-        this.bellVisible = true;
+        calcWidth = g.stringWidth(text) + 2; // One pixel on each side
+        this.bellVisible = false;
+      } else if (config.drawBell && this.numActiveAlarms > 0) {
+        calcWidth = 24;
+        // next alarm too far in future, draw only widalarm bell
+        if (this.bellVisible !== true || fromInterval !== true) {
+          g.reset().drawImage(atob("GBgBAAAAAAAAABgADhhwDDwwGP8YGf+YMf+MM//MM//MA//AA//AA//AA//AA//AA//AB//gD//wD//wAAAAADwAABgAAAAAAAAA"),this.x,this.y);
+          this.bellVisible = true;
+        }
       }
     }
 


### PR DESCRIPTION
Link: https://thinkpoop.github.io/BangleApps/?id=widalarmeta

Adds an option to the Alarm ETA widget to only show when on the clock face.

I started using a widget to show the time when not on a clock. This way I see the alarm ETA when on the clock and the current time when not on the clock.

