### PR TITLE
[iOS Integration] Add BangleDumpLocation shortcut compatibility

### DIFF
--- a/apps/ios/ChangeLog
+++ b/apps/ios/ChangeLog
@@ -19,3 +19,4 @@
 0.18: Fix UTF8 conversion (check for `font` library, not `fonts`)
 0.19: Convert numeric weather values to int from BangleDumpWeather shortcut
 0.20: Add feels-like temperature data field to weather parsing from BangleDumpWeather shortcut.
+0.21: Add BangleDumpLocation shortcut, to update location data on watch without needing to use the watch's GPS.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -35,20 +35,21 @@ for now. It's just a few bucks/pounds/euro's.
 If you like to try a free app first, you can always use NRF Toolbox or
 Bluetooth BLE Device Finder to find and connect your Bangle.
 
-### Weather and Calendar
+### Weather, Calendar, and Location
 
-By using the `Shortcuts` app on your phone, you can send weather and calendar data to your watch. This works by sending a notification, which is read by the watch through ANCS. The watch then parses the notification for the data.
+By using the `Shortcuts` app on your phone, you can send weather, calendar, and location data to your watch. This works by sending a notification, which is read by the watch through ANCS. The watch then parses the notification for the data.
 
-While you may write your own shortcuts if you prefer (for example, to get weather from a different source), two are provided:
+While you may write your own shortcuts if you prefer (for example, to get weather from a different source), three are provided:
 
-- Calendar shortcut: https://www.icloud.com/shortcuts/4eac12548b4c424dbcdb1bd58cff338f
-- Weather shortcut: https://www.icloud.com/shortcuts/106c68bfac3746fe9a55761a3be8d092
+- [Calendar shortcut](https://www.icloud.com/shortcuts/4eac12548b4c424dbcdb1bd58cff338f)
+- [Weather shortcut](https://www.icloud.com/shortcuts/106c68bfac3746fe9a55761a3be8d092)
+- [Location shortcut](https://www.icloud.com/shortcuts/853c41e09a8e491f893a63b464d73ea1)
 
-The weather shortcut requires an OpenWeatherMap api key, which you can get for free from https://openweathermap.org/api. The shortcut will prompt you for this when you add it to your phone.
+Note: The shortcuts must keep the names defaulted by the shortcut in order for the watch to detect the weather, calender, or location data. If you rename it from `BangleDump...` to something else, it will no longer get the info, and just display it as a notification on the watch.
 
 These shortcuts can also be automated to run periodically, for example every hour, using the `Automation` tab in the Shortcuts app.
 
-The shortcuts will send a notification, which can be annoying. One potential workaround for this would be to create a focus mode, and have an automation:
+The shortcuts will send a notification. Even though the notification is deleted as soon as Bangle.js receives it, it can be quite annoying. One potential workaround for this would be to create a focus mode, and have an automation:
 - activate the focus mode (hiding notifications from the shortcut)
 - run the shortcut
 - deactivate the focus mode
@@ -60,4 +61,9 @@ Please file any issues on https://github.com/espruino/BangleApps/issues/new?titl
 
 ## Creator
 
-Gordon Williams
+- Gordon Williams
+
+## Contributors
+
+- RKBoss6
+- stweedo

--- a/apps/ios/boot.js
+++ b/apps/ios/boot.js
@@ -191,13 +191,47 @@ E.on('notify',msg=>{
         wind: d.wind,
         wdir: d.wdir,
         loc: d.loc
-    }
+    };
     // Convert string fields to numbers for iOS weather shortcut
     const numFields = ['code', 'wdir', 'temp','feels', 'hi', 'lo', 'hum', 'wind', 'uv', 'rain'];
     numFields.forEach(field => {
       if (weatherEvent[field] != null) weatherEvent[field] = +weatherEvent[field];
     });
     require("weather").update(weatherEvent);
+    NRF.ancsAction(msg.uid, false);
+    return;
+  }
+  
+  if (msg.title === "BangleDumpLocation") {
+    
+    const d = JSON.parse(msg.message);
+    
+    /* Example:
+    {"lat":"2912.0744", "lon":"2333.332", "city":"Chicago"}*/
+    let locationJson = {
+        t: "location",
+        lat:d.lat,
+        lon:d.lon,
+        city:d.city
+    
+    };
+    // Convert string fields to numbers
+    const numFields = ['lat', 'lon'];
+    numFields.forEach(field => {
+      if (locationJson[field] != null) locationJson[field] = +locationJson[field];
+    });
+   
+    //load mylocation file
+    let myLocationJson = Object.assign({
+      lat: d.lat,
+      lon: d.lon,
+      location:d.city
+    }, require("Storage").readJSON("mylocation.json", true) || {});
+    myLocationJson.lon=locationJson.lon;
+    myLocationJson.lat=locationJson.lat;
+    myLocationJson.location=locationJson.city;
+    require("Storage").write("mylocation.json",myLocationJson);
+    
     NRF.ancsAction(msg.uid, false);
     return;
   }

--- a/apps/ios/metadata.json
+++ b/apps/ios/metadata.json
@@ -1,11 +1,12 @@
 {
   "id": "ios",
   "name": "iOS Integration",
-  "version": "0.20",
-  "description": "Display/pull notifications, music, weather, and agenda from iOS devices",
+  "version": "0.21",
+  "description": "Display/pull notifications, music, weather, location, and agenda from iOS devices",
   "icon": "app.png",
   "tags": "tool,system,ios,apple,messages,notifications",
   "dependencies": {"messages":"module"},
+  "dependencies" : {"mylocation":"app" },
   "supports": ["BANGLEJS","BANGLEJS2"],
   "readme": "README.md",
   "storage": [


### PR DESCRIPTION
Added a shortcut to update the bangle's location in `mylocation`, without needing to use the web IDE or watch GPS. Useful for auto updating the location on trips, so sunrise/sunset info stays accurate.

I also made some readme changes, and added a contributors section. I know @stweedo contributed to this app, so I added them under it. If anyone else contributed, and wants to see their name under there, just comment, and I can add it to this PR.