### PR TITLE
[Clock Info] Altitude clockInfo uses locale for distance units

### DIFF
--- a/apps/clock_info/ChangeLog
+++ b/apps/clock_info/ChangeLog
@@ -19,3 +19,4 @@
 0.18: Tweak BLE icon to add gap and ensure middle of B isn't filled
 0.19: Fix Altitude ClockInfo after BLE added
       Tapping Altitude now updates the reading
+0.20: Altitude ClockInfo now uses the distance units set in locale.

--- a/apps/clock_info/lib.js
+++ b/apps/clock_info/lib.js
@@ -2,6 +2,7 @@
 
 let storage = require("Storage");
 let stepGoal = undefined;
+let stepUpdateInterval;
 // Load step goal from health app and pedometer widget
 let d = storage.readJSON("health.json", true) || {};
 stepGoal = d.stepGoal;
@@ -49,7 +50,8 @@ exports.load = function() {
     try {
       Bangle.getPressure().then(data=>{
         if (!data) return;
-        alt = Math.round(data.altitude) + "m";
+
+        alt =require("locale").distance(data.altitude);
         bangleItems.find(i=>i.name=="Altitude").emit("redraw");
       });
     } catch (e) {
@@ -85,8 +87,9 @@ exports.load = function() {
           text : v, v : v, min : 0, max : stepGoal,
         img : atob("GBiBAAcAAA+AAA/AAA/AAB/AAB/gAA/g4A/h8A/j8A/D8A/D+AfH+AAH8AHn8APj8APj8AHj4AHg4AADAAAHwAAHwAAHgAAHgAADAA==")
       };},
-      show : function() { Bangle.on("step", stepUpdateHandler); stepUpdateHandler(); },
-      hide : function() { Bangle.removeListener("step", stepUpdateHandler); },
+      show : function() { stepUpdateInterval=setInterval(stepUpdateHandler,150000); stepUpdateHandler(); },
+      hide : function() { clearInterval(stepUpdateInterval); },
+      run:stepUpdateHandler
     },
     { name : "HRM",
       hasRange : true,

--- a/apps/clock_info/metadata.json
+++ b/apps/clock_info/metadata.json
@@ -1,7 +1,7 @@
 { "id": "clock_info",
   "name": "Clock Info Module",
   "shortName": "Clock Info",
-  "version":"0.19",
+  "version":"0.20",
   "description": "A library used by clocks to provide extra information on the clock face (Altitude, BPM, etc)",
   "icon": "app.png",
   "type": "module",


### PR DESCRIPTION
Instead of always showing the altitude in meters, it now gets the correct unit set from locale, and can display in feet, meters, or kilometers/miles if the altitude is too great.