### PR TITLE
chargerot: attempt `Bangle.uiRedraw()` if possible (optimisation)

### DIFF
--- a/apps/chargerot/ChangeLog
+++ b/apps/chargerot/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Handle missing settings (e.g. first-install)
+0.03: Use Bangle.uiRedraw() if available as an optimisation

--- a/apps/chargerot/boot.js
+++ b/apps/chargerot/boot.js
@@ -5,9 +5,14 @@
     Bangle.on('charging', (charging) => {
         if (charging) {
             g.setRotation(chargingRotation&3,chargingRotation>>2).clear();
-            Bangle.showClock();
         } else {
             g.setRotation(defaultRotation&3,defaultRotation>>2).clear();
+        }
+
+        if (Bangle.uiRedraw) {
+            Bangle.uiRedraw();
+            Bangle.drawWidgets();
+        } else {
             Bangle.showClock();
         }
     });

--- a/apps/chargerot/metadata.json
+++ b/apps/chargerot/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "chargerot",
   "name": "Charge LCD rotation",
-  "version": "0.02",
+  "version": "0.03",
   "description": "When charging, this app can rotate your screen and revert it when unplugged. Made for all sort of cradles.",
   "icon": "icon.png",
   "tags": "battery",


### PR DESCRIPTION
... so we don't require a full `load()`