### PR TITLE
anton/slope clocks: pass `redraw` to allow `Bangle.uiRedraw()`

### DIFF
--- a/apps/antonclk/ChangeLog
+++ b/apps/antonclk/ChangeLog
@@ -14,3 +14,4 @@
 0.10: Use Bangle.setUI({remove:...}) to allow loading the launcher without a full reset on 2v16
 0.11: Moved enhanced Anton clock to 'Anton Clock Plus' and stripped this clock back down to make it faster for new users (270ms -> 170ms)
       Modified to avoid leaving functions defined when using setUI({remove:...})
+0.12: Pass in `redraw` to allow `Bangle.uiRedraw()` to redraw the clock

--- a/apps/antonclk/app.js
+++ b/apps/antonclk/app.js
@@ -37,7 +37,9 @@ Bangle.setUI({
     if (drawTimeout) clearTimeout(drawTimeout);
     drawTimeout = undefined;
     delete Graphics.prototype.setFontAnton;
-  }});
+  },
+  redraw: draw,
+});
 // Load widgets
 Bangle.loadWidgets();
 draw();

--- a/apps/antonclk/metadata.json
+++ b/apps/antonclk/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "antonclk",
   "name": "Anton Clock",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A simple clock using the bold Anton font. See `Anton Clock Plus` for an enhanced version",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/antonclkplus/ChangeLog
+++ b/apps/antonclkplus/ChangeLog
@@ -14,3 +14,4 @@
 0.10: Use Bangle.setUI({remove:...}) to allow loading the launcher without a full reset on 2v16
       Modified to avoid leaving functions defined when using setUI({remove:...})
 0.11: Minor code improvements
+0.12: Pass in `redraw` to allow `Bangle.uiRedraw()` to redraw the clock

--- a/apps/antonclkplus/app.js
+++ b/apps/antonclkplus/app.js
@@ -231,7 +231,9 @@ Bangle.setUI({
     drawTimeout = undefined;
     delete Graphics.prototype.setFontAnton;
     delete Graphics.prototype.setFontAntonSmall;
-  }});
+  },
+  redraw: draw,
+});
 // Load widgets
 Bangle.loadWidgets();
 Bangle.drawWidgets();

--- a/apps/antonclkplus/metadata.json
+++ b/apps/antonclkplus/metadata.json
@@ -2,7 +2,7 @@
   "id": "antonclkplus",
   "name": "Anton Clock Plus",
   "shortName": "Anton Clock+",
-  "version": "0.11",
+  "version": "0.12",
   "description": "A clock using the bold Anton font, optionally showing seconds and date in ISO-8601 format.",
   "readme":"README.md",
   "icon": "app.png",

--- a/apps/slopeclockpp/ChangeLog
+++ b/apps/slopeclockpp/ChangeLog
@@ -12,3 +12,4 @@
 0.09: Use clock_info module as an app
 0.10: Option to hide widgets, tweak top widget width to avoid overlap with hour text at 9am
 0.11: Avoid rendering clkinfo in the same colour as the background
+0.12: Pass in `redraw` to allow `Bangle.uiRedraw()` to redraw the clock

--- a/apps/slopeclockpp/app.js
+++ b/apps/slopeclockpp/app.js
@@ -169,7 +169,8 @@ Bangle.setUI({
     delete clockInfoMenu;
     clockInfoMenu2.remove();
     delete clockInfoMenu2;
-  }
+  },
+  redraw: draw,
 });
 // Load widgets
 Bangle.loadWidgets();

--- a/apps/slopeclockpp/metadata.json
+++ b/apps/slopeclockpp/metadata.json
@@ -1,6 +1,6 @@
 { "id": "slopeclockpp",
   "name": "Slope Clock ++",
-  "version":"0.11",
+  "version":"0.12",
   "description": "A clock where hours and minutes are divided by a sloping line. When the minute changes, the numbers slide off the screen. This is a clone of the original Slope Clock which shows extra information and allows the colors to be selected.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],


### PR DESCRIPTION
To allow other apps/bootcode to redraw without a reload