### PR TITLE
messagegui: Fix bugs related to empty titles and bodies.

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -118,3 +118,4 @@
 0.86: Default to showing message scroller (with title, bigger icon)
 0.87: Make choosing of font size more repeatable
 0.88: Adjust padding calculation so messages are spaced out properly even when using international fonts
+0.89: Fix bugs related to empty titles and bodies

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -361,12 +361,12 @@ function showMessage(msgid, persist) {
   active = "message";
   // Normal text message display
   let src=msg.src||/*LANG*/"Message", srcFont = fontSmall;
-  let title=msg.title, titleFont = fontLarge, lines;
+  let title=msg.title||"", titleFont = fontLarge, lines=[];
   let body=msg.body, bodyFont = fontLarge;
   // If no body, use the title text instead...
-  if (body===undefined) {
+  if (!body) {
     body = title;
-    title = undefined;
+    title = "";
   }
   if (g.setFont(srcFont).stringWidth(src) > g.getWidth()-52)
     srcFont = "4x6";

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.88",
+  "version": "0.89",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
Fixes #3969.  Notification events can now have title or body as empty strings or `undefined` without errors.  Tested using the below notification messages sent from console.  Prior to this commit, all but the two marked test messages created errors.  Also tested with actual task notifications from Android.

```
GB({"t":"notify", "id":987123, "title":"Title"})
GB({"t":"notify", "id":987124, "title":"Title", "body":""})
GB({"t":"notify", "id":987125, "body":"Body"})
GB({"t":"notify", "id":987126, "title":"", "body":"Body"}) // worked before this commit
GB({"t":"notify", "id":987127, "title":""})
GB({"t":"notify", "id":987128, "body":""})
GB({"t":"notify", "id":987129}) // does nothing
```