### PR TITLE
fix: Erroneous apostrophe preventing firmware updates

### DIFF
--- a/apps/fwupdate/custom.html
+++ b/apps/fwupdate/custom.html
@@ -177,7 +177,7 @@ function checkForFileOnServer() {
     releaseFiles.sort().reverse().forEach(function(f) {
       var name = f.substr(f.substr(0,f.length-1).lastIndexOf('/')+1);
       console.log("Found "+name);
-      domFirmwareList.innerHTML += `<li>Release${getDescription(name)}: <a href="${f}'" class="fw-link">${name}</a></li>`;
+      domFirmwareList.innerHTML += `<li>Release${getDescription(name)}: <a href="${f}" class="fw-link">${name}</a></li>`;
       domFirmware.style = "";
     });
     getFilesFromURL("https://www.espruino.com/binaries/travis/master/",regex, function(travisFiles) {


### PR DESCRIPTION
Hi! I noticed this was preventing the fwupdate app from actually downloading and installing firmware updates on my watches, because the accidental dangling apostrophe in the URL for each firmware entry both would cause a 404, but also prevents the `downloadURL` function from passing because it expects the URL to end with `.zip` or `.hex`.