### PR TITLE
Fix mntclock for weather v2 data

### DIFF
--- a/apps/mtnclock/ChangeLog
+++ b/apps/mtnclock/ChangeLog
@@ -3,3 +3,4 @@
 0.03: Address unexpected undefined when reading weather.json
 0.04: Adding settings and the ability to show the widgets bar
 0.05: Fix the widgets disappearing on weather update
+0.06: Fix weather not correctly updating with Weather data v2

--- a/apps/mtnclock/app.js
+++ b/apps/mtnclock/app.js
@@ -1,5 +1,12 @@
 var data = require("Storage").readJSON("mtnclock.json", 1) || {};
 
+let weather;
+try {
+  weather = require('weather');
+} catch (_err) {
+  weather = undefined;
+}
+
 //seeded RNG to generate stars, snow, etc
 function sfc32(a, b, c, d) {
     return function() {
@@ -336,9 +343,25 @@ function readWeather() {
   }
 }
 
+function updateWeather() {
+  const current = weather.get();
+  if (current) {
+    data.temp = current.temp;
+    data.code = current.code;
+    data.time = Date.now();
+    require("Storage").writeJSON('mtnclock.json', data);
+    setWeather();
+  }
+}
+
+if (weather) {
+  weather.on("update", updateWeather);
+}
+
 const _GB = global.GB;
 global.GB = (event) => {
-  if (event.t==="weather") {
+  if (!weather && event.t==="weather" && event.v !== 2) {
+    // Fallback in case weather app is not installed
     data.temp = event.temp;
     data.code = event.code;
     data.time = Date.now();

--- a/apps/mtnclock/metadata.json
+++ b/apps/mtnclock/metadata.json
@@ -2,7 +2,7 @@
   "id": "mtnclock",
   "name": "Mountain Pass Clock",
   "shortName": "Mtn Clock",
-  "version": "0.05",
+  "version": "0.06",
   "description": "A clock that changes scenery based on time and weather.",
   "readme":"README.md",
   "icon": "app.png",


### PR DESCRIPTION
Because the Mountain Pass Clock app reacts to the weather events directly, it breaks when the Weather app requires weather data v2. The clock reads the fields that are not in v2 data, and this sets the temperature to "undefined".

To not add mandatory dependency of Weather app, I have added both options. React to Weather app update if it's installed and use old (but fixed) way if the app is not installed.