### PR TITLE
[Smart Battery Module] API changes

### DIFF
--- a/apps/smartbatt/ChangeLog
+++ b/apps/smartbatt/ChangeLog
@@ -1,2 +1,3 @@
 v0.01: New app!
 v0.02: Add dynamic intervals, depending on total cycles recorded
+v0.03: Return more data inside of module.get();

--- a/apps/smartbatt/ChangeLog
+++ b/apps/smartbatt/ChangeLog
@@ -1,3 +1,3 @@
 v0.01: New app!
 v0.02: Add dynamic intervals, depending on total cycles recorded
-v0.03: Return more data inside of module.get();
+v0.03: Return more data inside of .get();

--- a/apps/smartbatt/README.md
+++ b/apps/smartbatt/README.md
@@ -46,4 +46,5 @@ From any app, you can call `require("smartbatt")` and then one of the functions 
 ## Creator
 - RKBoss6
 ## Contributors
-- RelapsingCertainly
+- sonicityV
+

--- a/apps/smartbatt/README.md
+++ b/apps/smartbatt/README.md
@@ -34,13 +34,14 @@ From any app, you can call `require("smartbatt")` and then one of the functions 
 * `require("smartbatt").get()` - Returns an object that contains:
 
   
-  * `hrsRemaining` - Hours remaining
+  * `hrsLeft` - Hours remaining
   * `avgDrainage` - Learned battery drainage per hour
-  * `totalCycles` - Total times the battery has been recorded and averaged
+  * `cycles` - Total times the battery has been recorded and averaged
+  * `timeLastRecorded` - The time when the module last updated the average, in unix seconds. (1757421612)
+  * `battLastRecorded` - The battery percent when the module last updated the average.
   * `totalHours` - Total hours recorded
   * `batt` - Current battery level
 
-    
 * `require("smartbatt").deleteData()` - Deletes all learned data. (Automatically re-learns)
 ## Creator
 - RKBoss6

--- a/apps/smartbatt/metadata.json
+++ b/apps/smartbatt/metadata.json
@@ -2,7 +2,7 @@
   "id": "smartbatt",
   "name": "Smart Battery Module",
   "shortName": "Smart Battery",
-  "version": "0.02",
+  "version": "0.03",
   "description": "Provides a `smartbatt` module that returns the battery in days, and learns from daily usage over time for accurate predictions.",
   "icon": "app.png",
   "type": "module",

--- a/apps/smartbatt/module.js
+++ b/apps/smartbatt/module.js
@@ -119,7 +119,7 @@
 
 
   // Estimate hours remaining
-  function estimateBatteryLife() {
+  function getExportData() {
     let data = getData();
     var batt = E.getBattery();
     var hrsLeft = Math.abs(batt / data.avgBattDrainage);
@@ -128,7 +128,9 @@
       hrsLeft: hrsLeft,
       avgDrainage:data.avgBattDrainage,
       totalHours:data.totalHours,
-      cycles:data.totalCycles
+      cycles:data.totalCycles,
+      timeLastRecorded: data.timeLastRecorded,
+      battLastRecorded: data.battLastRecorded,
     };
   }
 
@@ -139,7 +141,7 @@
   // Expose public API
   exports.record = recordBattery;
   exports.deleteData = deleteData;
-  exports.get = estimateBatteryLife;
+  exports.get = getExportData;
   exports.changeInterval = function (newInterval) {
     clearInterval(interval);
     interval = setInterval(recordBattery, newInterval);


### PR DESCRIPTION
This just returns more in the exports.get() function, and has updated documentation along with it. Because the most recent update (maybe a day ago) is not yet deployed to the app loader, should I change the version for this one as well?