### PR TITLE
[BackLite] Add button release check

### DIFF
--- a/apps/backlite/ChangeLog
+++ b/apps/backlite/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app! (settings, boot.js).
 0.02: Fix settings defaulting brightness to 0
+0.03: When button is released, cancel long press check. (Remove false triggers)

--- a/apps/backlite/README.md
+++ b/apps/backlite/README.md
@@ -1,15 +1,15 @@
 # BackLite
-### This app needs the latest settings app update (v 0.80), to ensure that setting the brightness to `0` does not default to `1`.
 
 BackLite is an app which greatly conserves battery life by only turning the backlight on when you long press the button from a locked state.
 
 Modern watches have a dedicated button to turn the backlight on, so as not to waste battery in an already light environment. This app recreates that functionality for the Bangle.js, which only has one button.
+#### This app needs settings v0.80 or later to ensure that setting the brightness to `0` does not default to `1`.
 
-#### Warning: This app overwrites the LCD brightness setting in `Bangle.js LCD settings`. If it is changed, the app will basically lose functionality. It auto-fixes itself every boot, so if you change the brightness, just reboot :)
+This app overwrites the LCD brightness setting in `Bangle.js LCD settings`. If it is changed, the app automatically fixes it every boot, so if you change the brightness, just reboot :)
 # Usage
 When you unlock with a press of the button, or any other way you unlock the watch, the backlight will not turn on, as most of the time you are able to read it, due to the transreflective display on the Bangle.js 2. 
 
-If you press and hold the button to unlock the watch (for around half a second), the backlight will turn on for 5 seconds - just enough to see what you need to see. After that, it will turn off again.
+If you press and hold the button to unlock the watch (for around half a second), the backlight will turn on, and stay on until the watch locks.
 
 Some apps like `Light Switch Widget` will prevent this app from working properly.
 # Settings

--- a/apps/backlite/boot.js
+++ b/apps/backlite/boot.js
@@ -29,7 +29,7 @@
         } else {
           Bangle.setLCDBrightness(0);
         }
-        clearTimeout(longPressTimer)
+        longPressTimer = null;
       }, longPressTime); // Slight delay to allow unlock to settle
     }
   });

--- a/apps/backlite/boot.js
+++ b/apps/backlite/boot.js
@@ -11,26 +11,36 @@
   //Set LCD to zero every reboot
   let s = require("Storage").readJSON("setting.json", 1) || {};
   s.brightness = 0;
+  if (!("lcdTimeout" in s)) s.lcdTimeout = 5; // fallback so  logic doesn't break
   require("Storage").writeJSON("setting.json", s);
   //remove large settings object from memory
-  delete s;
+  s=null;
   const longPressTime=400; //(ms)
-
+  var longPressTimer;
   Bangle.on('lock', function(isLocked) {
     Bangle.setLCDBrightness(0);
 
     if (!isLocked) {
       // Just unlocked — give a short delay and check if BTN1 is still pressed
-      setTimeout(() => {
+      longPressTimer=setTimeout(() => {
         if (digitalRead(BTN1)) {
           //set brightness until. locked.
           Bangle.setLCDBrightness(getSettings().brightness);
         } else {
           Bangle.setLCDBrightness(0);
         }
+        clearTimeout(longPressTimer)
       }, longPressTime); // Slight delay to allow unlock to settle
     }
   });
 
+  
+  
+  setWatch(() => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  }, BTN1, { repeat:true, edge:'rising' });
 }
 

--- a/apps/backlite/boot.js
+++ b/apps/backlite/boot.js
@@ -14,7 +14,7 @@
   if (!("lcdTimeout" in s)) s.lcdTimeout = 5; // fallback so  logic doesn't break
   require("Storage").writeJSON("setting.json", s);
   //remove large settings object from memory
-  s=null;
+  delete s;
   const longPressTime=400; //(ms)
   var longPressTimer;
   Bangle.on('lock', function(isLocked) {

--- a/apps/backlite/metadata.json
+++ b/apps/backlite/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "backlite",
   "name": "BackLite",
-  "version": "0.02",
-  "description": "Conserves battery life by turning the backlight on only on a long press of the button from a locked state. **Requires the latest settings update (v0.80)**",
+  "version": "0.03",
+  "description": "Conserves battery life by turning the backlight on only on a long press of the button from a locked state. **Requires Settings app v0.80 or higher**",
   "icon": "icon.png",
   "type": "bootloader",
   "tags": "system",


### PR DESCRIPTION
Just checks if the button is released, then cancel the check for long press, to avoid users pressing once, then once more and the screen turns on.