### PR TITLE
Fix accelrec metadata: Remove BANGLEJS support

### DIFF
--- a/apps/accelrec/metadata.json
+++ b/apps/accelrec/metadata.json
@@ -6,7 +6,7 @@
   "description": "This app puts the Bangle's accelerometer into 100Hz mode and reads 2 seconds worth of data after movement starts. The data can then be exported back to the PC.",
   "icon": "app.png",
   "tags": "",
-  "supports": ["BANGLEJS","BANGLEJS2"],
+  "supports": ["BANGLEJS2"],
   "readme": "README.md",
   "interface": "interface.html",
   "storage": [


### PR DESCRIPTION
Fixes #4022

The accelrec app uses `Bangle.accelWr()` which is only available on Bangle.js 2.
Removed "BANGLEJS" from the supports array in metadata.json.