### PR TITLE
feat: add system Quiet/Silent mode integration to prevent buzzing

### DIFF
--- a/apps/grandfatherclock/README.md
+++ b/apps/grandfatherclock/README.md
@@ -16,6 +16,7 @@ Defaults:
 - The time between count buzzes is 500ms.
 - The meridian buzzes are 50ms long.
 - The time between meridian buzzes is 300ms.
+- Follow system quiet mode is DISABLED
 
 ## Requests
 

--- a/apps/grandfatherclock/settings.js
+++ b/apps/grandfatherclock/settings.js
@@ -12,7 +12,8 @@
         fractions_of_hour: 4, // 4 = 15min intervals, 6 = 10min intervals
         wait_ms: 500,
         meridian_buzz_ms: 50,
-        meridian_buzz_wait_ms: 300
+        meridian_buzz_wait_ms: 300,
+        followQuietMode: true
     }, require('Storage').readJSON("grandfatherclock.json", true) || {});
 
     let writeConfig = function() {
@@ -39,6 +40,12 @@
             value: config.swap_meridian,
             onchange: v => {
                 config.swap_meridian = v;
+                writeConfig();
+            }
+        },"Follow Quite Mode": {
+            value: config.followQuietMode,
+            onchange: v => {
+                config.followQuietMode = v;
                 writeConfig();
             }
         },"Hr attn. buzz length (ms)": {

--- a/apps/grandfatherclock/widget.js
+++ b/apps/grandfatherclock/widget.js
@@ -11,7 +11,8 @@
         fractions_of_hour: 4, // 4 = 15min intervals, 6 = 10min intervals
         wait_ms: 500,
         meridian_buzz_ms: 50,
-        meridian_buzz_wait_ms: 300
+        meridian_buzz_wait_ms: 300,
+        followQuietMode: false
     }, require('Storage').readJSON("grandfatherclock.json", true) || {}); // or, load the app settings file.
 
     WIDGETS["grandfatherclock"] = {
@@ -24,11 +25,13 @@
             }
         }
     };
+    const quietMode= (require("Storage").readJSON("setting.json", 1) || {}).quiet && config.followQuietMode;
 
     let date;
     let fractionMs = 3600000 / config.fractions_of_hour;
 
     let chime = function () {
+        if (quietMode) return;
         date = new Date();
         let hourFrac = Math.floor(date.getMinutes() / (60 / config.fractions_of_hour));
 


### PR DESCRIPTION
I really like my grandfather clock on my wrist :) but I’ve been missing a feature that would prevent it from constantly vibrating while I’m asleep.

I added an option in the settings that, when set to true, follows the system’s silent mode.
