### PR TITLE
tally: fix duplicate menu entries

### DIFF
--- a/apps/tally/ChangeLog
+++ b/apps/tally/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New app!
+0.02: Handle duplicate menu entries in the app

--- a/apps/tally/app.js
+++ b/apps/tally/app.js
@@ -35,7 +35,13 @@ function showTallies(tallies) {
             menu[s] = function () { };
             day = td;
         }
-        menu["".concat(tfmt(tally), ": ").concat(tally.name)] = function () { return editTally(tallies, i); };
+        var title = "".concat(tfmt(tally), ": ").concat(tally.name);
+        var n = 2;
+        while (title in menu) {
+            title = "".concat(tfmt(tally), " (").concat(n, "): ").concat(tally.name);
+            n++;
+        }
+        menu[title] = function () { return editTally(tallies, i); };
     });
     E.showMenu(menu);
 }

--- a/apps/tally/app.ts
+++ b/apps/tally/app.ts
@@ -45,7 +45,13 @@ function showTallies(tallies: Tally[]) {
       day = td;
     }
 
-    menu[`${tfmt(tally)}: ${tally.name}`] = () => editTally(tallies, i);
+    let title = `${tfmt(tally)}: ${tally.name}`;
+    let n = 2;
+    while(title in menu){
+      title = `${tfmt(tally)} (${n}): ${tally.name}`
+      n++;
+    }
+    menu[title] = () => editTally(tallies, i);
   });
 
   E.showMenu(menu);

--- a/apps/tally/metadata.json
+++ b/apps/tally/metadata.json
@@ -2,7 +2,7 @@
   "id": "tally",
   "name": "Tally Keeper",
   "shortName": "Tally",
-  "version": "0.01",
+  "version": "0.02",
   "author": "bobrippling",
   "description": "Add to a tally from clock info",
   "icon": "app.png",


### PR DESCRIPTION
e.g. if the user has the same tally type and time, we only show one

- [x] test