### PR TITLE
[schedclock] allow setting random faces per entry; fix 24h selection

### DIFF
--- a/apps/schedclock/ChangeLog
+++ b/apps/schedclock/ChangeLog
@@ -1,1 +1,3 @@
 0.01: New App!
+0.02: Add multiple clock faces per entry and apply one at random
+      Fix bug handling 24h format in settings 

--- a/apps/schedclock/README.md
+++ b/apps/schedclock/README.md
@@ -27,6 +27,12 @@ If you skip this step, orphaned alarms may cause error logs but won't affect fun
 
 You can also remove the extra `schedclock` alarms manually with the [Scheduler](/?id=sched) app.
 
+## Fastload Utils
+
+If you are using `Fastload Utils` (https://banglejs.com/apps/?id=fastload) it may not load the new face until the next time it does a full load.
+
+You may be able to work around this by enabling FastLoad's setting to detect settings changes.
+
 ## Creator
 
 [kidneyhex](https://github.com/kidneyhex)

--- a/apps/schedclock/metadata.json
+++ b/apps/schedclock/metadata.json
@@ -1,7 +1,7 @@
 { "id": "schedclock",
   "name": "Schedule Clock Faces",
   "shortName":"Sched Clock",
-  "version":"0.01",
+  "version":"0.02",
   "author": "kidneyhex",
   "description": "Change clock faces on a schedule.",
   "icon": "app.png",


### PR DESCRIPTION
Link: https://kidneyhex.github.io/BangleApps/?id=schedclock

## Overview

1. Add ability to select multiple clockfaces per schedule entry and have one set at random.

2. Fix bug making 24h always display as 12h when setting the hour in settings.


## Details

### readme.md

- Added note about `fastload utils` compatibility

### lib.js

- Removed passing clockface js file name into onAlarm, instead read clockface array from settings file

### settings.js

- Changed from selecting one clockface from a list, to using checkboxes to select multiple
- Add validation that at least face is selected before saving entry
- Fix spelling of `meridian` variable (from meridean)
- Remove passing "1" when getting meridian -- this was causing 24h to always display as 12h
- Rename `validationError` to `hasScheduleConflict` to be more specific