### PR TITLE
pace: record runs (and update README)

### DIFF
--- a/apps/pace/ChangeLog
+++ b/apps/pace/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Fix menu display - don't draw over the menu and vice-versa. Require
 	double-tap for menu
 0.06: Show GPS strength bar on the left and restore splits from previous run
+0.07: Record runs (via recorder)

--- a/apps/pace/README.md
+++ b/apps/pace/README.md
@@ -6,7 +6,3 @@ Drag up/down on the pause menu to scroll through your splits.
 Press the button to pause/resume - when resumed, pressing the button will pause instantly, regardless of whether the screen is locked.
 
 Double tap the pause screen to access a menu for finer control
-
-# Todo
-
-- Load splits on app start, button to reset (exs is always reset)

--- a/apps/pace/app.js
+++ b/apps/pace/app.js
@@ -143,11 +143,15 @@ var _a;
             .drawString("".concat(i + 1 + splitOffset_1, " ").concat(typeof pace === "number" ? pace.toFixed(2) : pace), 0, y);
     };
     var pauseRun_1 = function () {
+        var _a;
         exs_1.stop();
+        (_a = WIDGETS["recorder"]) === null || _a === void 0 ? void 0 : _a.setRecording(true, { force: "append" });
         draw_1();
     };
     var resumeRun_1 = function () {
+        var _a;
         exs_1.resume();
+        (_a = WIDGETS["recorder"]) === null || _a === void 0 ? void 0 : _a.setRecording(false);
         g.clearRect(Bangle.appRect);
         layout_1.forgetLazyState();
         draw_1();

--- a/apps/pace/app.ts
+++ b/apps/pace/app.ts
@@ -198,11 +198,13 @@ const drawSplit = (i: number, y: number, pace: number | string) =>
 
 const pauseRun = () => {
   exs.stop();
+  (WIDGETS["recorder"] as RecorderWidget | undefined)?.setRecording(true, { force: "append" });
   draw();
 };
 
 const resumeRun = () => {
   exs.resume();
+  (WIDGETS["recorder"] as RecorderWidget | undefined)?.setRecording(false);
 
   g.clearRect(Bangle.appRect); // splits -> layout, clear. layout -> splits, fine
   layout.forgetLazyState();

--- a/apps/pace/metadata.json
+++ b/apps/pace/metadata.json
@@ -1,7 +1,7 @@
 {
 	"id": "pace",
 	"name": "Pace",
-	"version": "0.06",
+	"version": "0.07",
 	"author": "bobrippling",
 	"description": "Show pace and time running splits",
 	"icon": "app.png",


### PR DESCRIPTION
Similarly to `run`/`runplus` and `rep`