### PR TITLE
rep: fix initial setup of rep

### DIFF
--- a/apps/rep/interface.html
+++ b/apps/rep/interface.html
@@ -102,7 +102,7 @@ function getData() {
 
   Util.showModal("Loading...");
   Util.readStorageJSON(repJson, reps_ => {
-    reps = reps_;
+    reps = reps_ ?? [];
     Util.hideModal();
     for(const rep of reps){
       renderRep(rep);


### PR DESCRIPTION
Rather than leaving `reps` undefined, causing errors and not enabling the upload button