### PR TITLE
widhrmadv: wake NRF for adverts

### DIFF
--- a/apps/widhrmadv/ChangeLog
+++ b/apps/widhrmadv/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New widget!
+0.02: Ensure bluetooth is on when advertising

--- a/apps/widhrmadv/metadata.json
+++ b/apps/widhrmadv/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "widhrmadv",
   "name": "widhrmadv",
-  "version": "0.01",
+  "version": "0.02",
   "author": "bobrippling",
   "description": "Allows toggleable advertisement of HRM over BLE",
   "readme": "README.md",

--- a/apps/widhrmadv/widget.js
+++ b/apps/widhrmadv/widget.js
@@ -13,10 +13,13 @@
             var wasOn = w.userReq;
             if (wasOn) {
                 require("ble_advert").remove(0x180d);
+                if (!NRF.getSecurityStatus().connected)
+                    NRF.sleep();
             }
             else {
                 require("ble_advert").set(0x180d);
                 register_1();
+                NRF.wake();
             }
             w.userReq = !wasOn;
             apply_1(!wasOn && NRF.getSecurityStatus().connected);

--- a/apps/widhrmadv/widget.ts
+++ b/apps/widhrmadv/widget.ts
@@ -23,9 +23,12 @@ Bangle.on('touch', (_btn, xy) => {
 		const wasOn = w.userReq;
 		if(wasOn){
 			require("ble_advert").remove(0x180d);
+			if(!NRF.getSecurityStatus().connected)
+				NRF.sleep();
 		}else{
 			require("ble_advert").set(0x180d /*, undefined*/);
 			register();
+			NRF.wake();
 		}
 
 		w.userReq = !wasOn;


### PR DESCRIPTION
Otherwise the user has to have BLE turned on in settings in order for a device to then connect (once it notices the adverts)