### PR TITLE
runplus: don't infinitely resume a track during a day

### DIFF
--- a/apps/runplus/ChangeLog
+++ b/apps/runplus/ChangeLog
@@ -33,3 +33,5 @@ Write to correct settings file, fixing settings not working.
 	track screen state
 0.30: Change the "time" stat to show active time (duration) rather than
 	elapsed time (fix #3802), and sync with recorder on load
+0.31: "Always resume run" will start a new run at app launch, and resume this
+	run for the duration of the app

--- a/apps/runplus/app.js
+++ b/apps/runplus/app.js
@@ -49,6 +49,7 @@ let settings = Object.assign({
 }, require("Storage").readJSON("runplus.json", 1) || {});
 let statIDs = [settings.B1,settings.B2,settings.B3,settings.B4,settings.B5,settings.B6].filter(s=>s!=="");
 let exs = ExStats.getStats(statIDs, settings);
+let recordMode = settings.alwaysResume ? "new" : undefined; // if always resuming, start a new track then resume into it for subsequent onStartStop()s
 // ---------------------------
 
 // handle the case where we were stopped outside of the app
@@ -98,7 +99,9 @@ function onStartStop() {
       promise = promise.
         then(() => {
           screen = "menu";
-          return WIDGETS["recorder"].setRecording(true, { force : shouldResume?"append":undefined });
+          const ret = WIDGETS["recorder"].setRecording(true, { force : recordMode });
+          if(shouldResume) recordMode = "append"; // subsequent onStartStop()s resume the new recording
+          return ret;
         }).then(() => {
           screen = "main";
           if(!shouldResume){

--- a/apps/runplus/metadata.json
+++ b/apps/runplus/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "runplus",
   "name": "Run+",
-  "version": "0.30",
+  "version": "0.31",
   "author": "thyttan",
   "description": "Displays distance, time, steps, cadence, pace and more for runners. Based on the Run app, but extended with additional screens for heart rate interval training and individual stat focus.",
   "icon": "app.png",


### PR DESCRIPTION
The "always resume" setting is intended to always resume during a single duration of the app, not across separate launches