### PR TITLE
qcenter: fix semi-unsafe use of fastload

### DIFF
--- a/apps/qcenter/ChangeLog
+++ b/apps/qcenter/ChangeLog
@@ -4,3 +4,5 @@
 0.04: Fix timeouts closing fast loaded apps
 0.05: Minor code improvements
 0.06: Enable fast load with Bangle.load
+0.07: Disable fast load for now since we are not sure if the app we load into
+      uses widgets or not (can be mitigated by use of `launch_utils`).

--- a/apps/qcenter/app.js
+++ b/apps/qcenter/app.js
@@ -72,7 +72,7 @@ let appButtons = groupBy3(pinnedApps).map((appGroup, i) => {
       pad: 5,
       src: require("Storage").read(app.icon),
       scale: 0.75,
-      cb: l => setTimeout(() => Bangle.load(app.src), 0),
+      cb: l => setTimeout(() => load(app.src), 0),
     };
   });
 });

--- a/apps/qcenter/metadata.json
+++ b/apps/qcenter/metadata.json
@@ -2,7 +2,7 @@
   "id": "qcenter",
   "name": "Quick Center",
   "shortName": "QCenter",
-  "version": "0.06",
+  "version": "0.07",
   "description": "An app for quickly launching your favourite apps, inspired by the control centres of other watches.",
   "icon": "app.png",
   "tags": "",


### PR DESCRIPTION
We are not sure if the app we load into uses widgets or not. That can be mitigated by use of `launch_utils` if we want to enable fastloading again.

Reference: https://github.com/espruino/BangleApps/pull/4114#discussion_r2712796728
<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
