### PR TITLE
boot: allow fast load to clock if WIDGETS is not defined.

### DIFF
--- a/apps/boot/ChangeLog
+++ b/apps/boot/ChangeLog
@@ -80,3 +80,5 @@
 0.67: When generating .clkinfocache, apply configured exclusions
 0.68: Allow setting screen brightness to 0
       Implement "Charge Vibration" option in Settings (was in widbat before)
+      Allow fast load to clock if WIDGETS are not defined.
+

--- a/apps/boot/bootloader.js
+++ b/apps/boot/bootloader.js
@@ -1,9 +1,9 @@
 // This runs after a 'fresh' boot
 var s = require("Storage").readJSON("setting.json",1)||{};
 /* If were being called from JS code in order to load the clock quickly (eg from a launcher)
-and the clock in question doesn't have widgets, force a normal 'load' as this will then
-reset everything and remove the widgets. */
-if (global.__FILE__ && !s.clockHasWidgets) {load();throw "Clock has no widgets, can't fast load";}
+and the clock in question doesn't have widgets, and widgets are loaded, force a normal 'load'
+as this will then reset everything and remove the widgets. */
+if (global.__FILE__ && !s.clockHasWidgets && global.WIDGETS!==undefined) {load();throw "Widgets defined and clock has no widgets, can't fast load";}
 // Otherwise continue to try and load the clock
 var _clkApp = require("Storage").read(s.clock);
 if (!_clkApp) {


### PR DESCRIPTION
As discussed in https://github.com/espruino/BangleApps/pull/4114#issuecomment-3778294375.

<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
