### PR TITLE
patch health date parsing in <utc-0

### DIFF
--- a/apps/health/interface.html
+++ b/apps/health/interface.html
@@ -68,11 +68,11 @@ function getMonthList() {
   Puck.eval(`require("Storage").list(/^health-.*\\.raw$/)`,files=>{
     files = files.map(f => {
       var m = f.match(/^health-([^\.]+)\.raw$/);
-      var [y, d] = m[1].split("-");
+      var [year, month] = m[1].split("-");
       return {
         filename : f,
-        date : m[1], // eg 2021-9
-        str : new Date(y, d-1).toLocaleString(undefined, {month:'long',year:'numeric'})
+        date : m[1], // eg "2021-9"
+        str : new Date(year, month-1).toLocaleString(undefined, {month:'long',year:'numeric'})
       }
     })
     var htmlOverview = `<table class="table table-striped table-hover">


### PR DESCRIPTION
in all timezones with less than a 0 shift from utc, the current health data downloader displays september twice and december never. this is because of how Date works:
```ts
> new Date("2025-9")
< Mon Sep 01 2025 00:00:00 GMT-0700 (Pacific Daylight Time)
> new Date("2025-10")
< Tue Sep 30 2025 17:00:00 GMT-0700 (Pacific Daylight Time)
```
this fixes it by explicitly constructing a date