### PR TITLE
backswipeedge: fixup readme

### DIFF
--- a/apps/backswipeedge/README.md
+++ b/apps/backswipeedge/README.md
@@ -3,5 +3,3 @@
 Go back by swiping from the right edge of the screen, Android style.
 
 To trigger a backswipe, you have to start at the right edge of the screen, swipe to the left until you feel a tiny buzz and let go. To cancel a backswipe, move your finger to the right until you feel another tiny buzz and let go.
-
-This fires an event `Bangle.backswipe`.


### PR DESCRIPTION
Forgot to remove the `Bangle.backswipe` event from the readme :see_no_evil:  
(That ended up being removed, mainly because it didn't want to work from jitd code)