### PR TITLE
Fix emulator race condition in tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -52,18 +52,43 @@ jobs:
         id: detect-apps
         run: |
           set -e  # Exit on error, but handle grep specially
+          
+          # Files that should trigger running all tests
+          # Note: "core" is the submodule - when its commit hash changes, "core" appears in the diff
+          TEST_INFRA_FILES="bin/runapptests.js .github/workflows/nodejs.yml core"
+          
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR: test only changed apps
             CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD)
-            APPS=$(echo "$CHANGED" | grep '^apps/' | cut -d'/' -f2 | sort -u) || APPS=""
           elif [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            # Push to master: test all apps
-            APPS=$(ls apps/*/test.json 2>/dev/null | cut -d'/' -f2) || APPS=""
+            # Push to master: always test all apps
+            APPS=$(ls apps/*/test.json 2>/dev/null | cut -d'/' -f2 | tr '\n' ' ') || APPS=""
+            echo "apps=$APPS" >> $GITHUB_OUTPUT
+            echo "Push to master - testing all apps:$APPS"
+            exit 0
           else
-            # Push to other branches: test only changed apps since master
             CHANGED=$(git diff --name-only origin/master...HEAD)
-            APPS=$(echo "$CHANGED" | grep '^apps/' | cut -d'/' -f2 | sort -u) || APPS=""
           fi
+          
+          # Check if test infrastructure changed - if so, run all tests
+          RUN_ALL=false
+          for f in $TEST_INFRA_FILES; do
+            if echo "$CHANGED" | grep -q "^$f$"; then
+              RUN_ALL=true
+              echo "Test infrastructure changed: $f"
+              break
+            fi
+          done
+          
+          if [ "$RUN_ALL" = "true" ]; then
+            APPS=$(ls apps/*/test.json 2>/dev/null | cut -d'/' -f2 | tr '\n' ' ') || APPS=""
+            echo "apps=$APPS" >> $GITHUB_OUTPUT
+            echo "Test infrastructure changed - testing all apps:$APPS"
+            exit 0
+          fi
+          
+          # Otherwise, test only changed apps
+          APPS=$(echo "$CHANGED" | grep '^apps/' | cut -d'/' -f2 | sort -u) || APPS=""
+          
           # Filter to apps with test.json
           TESTABLE=""
           for app in $APPS; do


### PR DESCRIPTION
## Problem

Tests occasionally fail with:

```
Uncaught SyntaxError: Got [ERASED] expected EOF
```

Reported in https://github.com/espruino/BangleApps/pull/4132 by @thyttan: tests fail initially but succeed on re-run.
Example: https://github.com/espruino/BangleApps/actions/runs/21783161416/attempts/1

## Cause (suspected)

The test runner sends commands without waiting for the emulator to finish processing. When one test ends and the next begins, `factoryReset()` can be called while the previous test's commands are still being processed, corrupting the input stream.

## Solution

- Track emulator ready state (has it output a response?)
- Add `waitForResponse()` to poll until command completes
- Add `safeFactoryReset()` that ensures previous commands finished
- Wait after each test step (`cmd`, `emit`, `load`, etc.)
- Wait after app upload and reset in test setup

## Testing

- All functional tests pass locally and in CI
- Full test suite (all 4 apps): https://github.com/elijahr/BangleApps/actions/runs/21789313739
- No significant increase in test duration
- Also detects test infrastructure changes as a condition for running all app tests in CI (`bin/runapptests.js` `.github/workflows/nodejs.yml` and `core` submodule).