### PR TITLE
backswipeedge: don't use JIT for drag handler

### DIFF
--- a/apps/backswipeedge/boot.js
+++ b/apps/backswipeedge/boot.js
@@ -30,7 +30,6 @@
   let trig = false;
 
   Bangle.prependListener("drag", (e) => {
-    "jit";
     // do nothing when showing the clock
     if (Bangle.CLOCK === 1) {
       drag = false;


### PR DESCRIPTION
As discussed in #4157

While the JIT provides a speedup of around 1.6 for the drag handler, we're talking about 2.4 ms without the JIT, on a function that is called maybe 20 times a second.

Plus using the JIT uses up some precious RAM.