### PR TITLE
exactwords: handle widgets; add author tag

### DIFF
--- a/apps/exactwords/ChangeLog
+++ b/apps/exactwords/ChangeLog
@@ -1,1 +1,2 @@
 0.1: New App! Need to work out locale settings
+0.2: Fixes to not draw over widgets

--- a/apps/exactwords/app.js
+++ b/apps/exactwords/app.js
@@ -176,8 +176,10 @@ function wordsFromDayMonth(day, date, month)
 }
 
 function draw() {
-  var x = g.getWidth()/2;
-  var y = g.getHeight()/2;
+  const R = Bangle.appRect;
+  const midX = (R.x + R.x2) / 2;
+  const midY = (R.y + R.y2) / 2;
+  const wrapW = g.getWidth();
   g.reset();
   
   var d = new Date();
@@ -193,13 +195,13 @@ function draw() {
   // draw time
   g.setBgColor(g.theme.bg);
   g.setColor(g.theme.fg);
-  g.clearRect(Bangle.appRect);
+  g.clearRect(R);
   g.setFontAlign(0,0).setFont("Vector",24);
-  g.drawString(g.wrapString(timeStr, g.getWidth()).join("\n"),x,y-24*0);
+  g.drawString(g.wrapString(timeStr, wrapW).join("\n"),midX,midY);
   // draw date
   
   g.setFontAlign(0,1).setFont("Vector",12);
-  g.drawString(g.wrapString(dateStr, g.getWidth()).join("\n"),x,Bangle.appRect.y2);
+  g.drawString(g.wrapString(dateStr, wrapW).join("\n"),midX,R.y2);
   // queue draw in one minute
   queueDraw();
 }
@@ -222,5 +224,5 @@ Bangle.setUI("clock");
 // Load widgets
 Bangle.loadWidgets();
 Bangle.drawWidgets();
-// draw immediately at first, queue update; after loading widgets so appRect is correct
+// draw immediately at first, queue update
 draw();

--- a/apps/exactwords/app.js
+++ b/apps/exactwords/app.js
@@ -177,8 +177,8 @@ function wordsFromDayMonth(day, date, month)
 
 function draw() {
   const R = Bangle.appRect;
-  const midX = (R.x + R.x2) / 2;
-  const midY = (R.y + R.y2) / 2;
+  const midX = g.getHeight() / 2;
+  const midY = g.getWidth() / 2;
   const wrapW = g.getWidth();
   g.reset();
   

--- a/apps/exactwords/app.js
+++ b/apps/exactwords/app.js
@@ -193,21 +193,20 @@ function draw() {
   // draw time
   g.setBgColor(g.theme.bg);
   g.setColor(g.theme.fg);
-  g.clear();
+  g.clearRect(Bangle.appRect);
   g.setFontAlign(0,0).setFont("Vector",24);
   g.drawString(g.wrapString(timeStr, g.getWidth()).join("\n"),x,y-24*0);
   // draw date
   
-  g.setFontAlign(0,0).setFont("Vector",12);
-  g.drawString(g.wrapString(dateStr, g.getWidth()).join("\n"),x,y+12*6);
+  g.setFontAlign(0,1).setFont("Vector",12);
+  g.drawString(g.wrapString(dateStr, g.getWidth()).join("\n"),x,Bangle.appRect.y2);
   // queue draw in one minute
   queueDraw();
 }
 
 // Clear the screen once/, at startup
 g.clear();
-// draw immediately at first, queue update
-draw();
+
 // Stop updates when LCD is off, restart when on
 Bangle.on('lcdPower',on=>{
   if (on) {
@@ -223,3 +222,5 @@ Bangle.setUI("clock");
 // Load widgets
 Bangle.loadWidgets();
 Bangle.drawWidgets();
+// draw immediately at first, queue update; after loading widgets so appRect is correct
+draw();

--- a/apps/exactwords/metadata.json
+++ b/apps/exactwords/metadata.json
@@ -13,6 +13,7 @@
                     { "url":"2358.png" } ],
   "tags": "clock",
   "type": "clock",
+  "author": "bmsleight",
   "supports" : ["BANGLEJS2"],
   "readme": "README.md",
   "storage": [

--- a/apps/exactwords/metadata.json
+++ b/apps/exactwords/metadata.json
@@ -14,6 +14,7 @@
   "tags": "clock",
   "type": "clock",
   "author": "bmsleight",
+  "allow_emulator":true,  
   "supports" : ["BANGLEJS2"],
   "readme": "README.md",
   "storage": [

--- a/apps/exactwords/metadata.json
+++ b/apps/exactwords/metadata.json
@@ -1,7 +1,7 @@
 { "id": "exactwords",
   "name": "Exact Words Clock",
   "shortName":"Exact Words",
-  "version":"0.1",
+  "version":"0.2",
   "description": "Each minute of the day has a different phrase. ",
   "icon": "app.png",
   "screenshots" : [ { "url":"1517.png" },


### PR DESCRIPTION
link: https://kidneyhex.github.io/BangleApps/?id=exactwords

Tagging author: @bmsleight

The original `exactwords` will clear out widgets, so they disappear at times. This just adds using `appRect` to avoid that.

## app.js
* Widgets get cleared by the `g.clear()`, so changing to `g.clearRect(Bangle.appRect)`
* Moved first `draw()` to happen after `loadWidgets` so `appRect` is correct.
* Use `appRect` for some of the calculations (doesn't really affect anything)
* Changed bottom text to align bottom and draw at the bottom of the `appRect`.