### PR TITLE
Bump accepted JS version in sanity checks, to allow static properties in apps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -192,7 +192,7 @@ module.exports = {
         "bleServiceOptions": "writable", // available in boot.js code that's called ad part of bootupdate
     },
     "parserOptions": {
-        "ecmaVersion": 11
+        "ecmaVersion": 2022
     },
     "rules": {
         "indent": [

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -49,7 +49,7 @@ var jsparse = (() => {
     return str => {throw new Error("no acorn")};
   }
 
-  return str => acorn.parse(str, { ecmaVersion: 2020 });
+  return str => acorn.parse(str, { ecmaVersion: 2022 });
 })();
 
 

--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -170,7 +170,7 @@ module.exports = {
         "D31": "readonly",
     },
     "parserOptions": {
-        "ecmaVersion": 11,
+        "ecmaVersion": 2022,
     },
     "rules": {
         "no-delete-var": "off",


### PR DESCRIPTION
Espruino supports static properties in classes, introduced by Ecmascript 2022, e.g.:
```
class X {
  static y = "z";
}
```
However, sanitycheck.js and the eslint configuration do not currently understand or permit that syntax (i.e., failing with parse errors).

So, tell the sanity checkers to accept version 2022 of Ecmascript.

This may cause the checkers to allow additional 2022 features which are not supported by Espruino.  However, since this is merely sanity checking, it is probably better to be lenient, and allow Bangle apps to make complete use of those features that *are* supported by Espruino.

<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
