### PR TITLE
drained: handle missed "changing" events

### DIFF
--- a/apps/drained/ChangeLog
+++ b/apps/drained/ChangeLog
@@ -7,3 +7,5 @@
 0.06: Display clock in green when charging, with "charging" text
 0.07: Correctly restore full power when the charged threshold is reached
 0.08: Redisplay immediately on changes to charging status
+0.09: Unconditionally set a battery-check interval in case the "charging"
+  event is missed

--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -120,12 +120,13 @@ Bangle.on("charging", function (charging) {
         drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
     draw();
 });
+drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
 if (!keepStartup) {
-    var storage = require("Storage");
+    var storage_1 = require("Storage");
     for (var _i = 0, exceptions_1 = exceptions; _i < exceptions_1.length; _i++) {
         var boot = exceptions_1[_i];
         try {
-            var js = storage.read("".concat(boot, ".boot.js"));
+            var js = storage_1.read("".concat(boot, ".boot.js"));
             if (js)
                 eval(js);
         }

--- a/apps/drained/app.js
+++ b/apps/drained/app.js
@@ -111,16 +111,15 @@ var checkCharge = function () {
     }
     drainedRestore();
 };
-if (Bangle.isCharging())
-    checkCharge();
-Bangle.on("charging", function (charging) {
+var onChargeChange = function (charging) {
     if (drainedInterval)
         drainedInterval = clearInterval(drainedInterval);
     if (charging)
         drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
     draw();
-});
-drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+};
+Bangle.on("charging", function (state) { return onChargeChange(state); });
+onChargeChange(Bangle.isCharging());
 if (!keepStartup) {
     var storage_1 = require("Storage");
     for (var _i = 0, exceptions_1 = exceptions; _i < exceptions_1.length; _i++) {

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -154,6 +154,9 @@ Bangle.on("charging", charging => {
   draw(); // redraw to update charging status on screen
 });
 
+// set this as a fallback in case we missed the "charging" event
+drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+
 if(!keepStartup){
   const storage = require("Storage");
   for(const boot of exceptions){

--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -143,19 +143,16 @@ const checkCharge = () => {
   drainedRestore();
 };
 
-if (Bangle.isCharging())
-  checkCharge();
-
-Bangle.on("charging", charging => {
+const onChargeChange = (charging: boolean) => {
   if(drainedInterval)
     drainedInterval = clearInterval(drainedInterval) as undefined;
   if(charging)
     drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
   draw(); // redraw to update charging status on screen
-});
+};
 
-// set this as a fallback in case we missed the "charging" event
-drainedInterval = setInterval(checkCharge, interval * 60 * 1000);
+Bangle.on("charging", state => onChargeChange(state /*workaround typing problem*/as boolean));
+onChargeChange(Bangle.isCharging());
 
 if(!keepStartup){
   const storage = require("Storage");

--- a/apps/drained/metadata.json
+++ b/apps/drained/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "drained",
   "name": "Drained",
-  "version": "0.08",
+  "version": "0.09",
   "author": "bobrippling",
   "description": "Switches to displaying a simple clock when the battery percentage is low, and disables some peripherals",
   "readme": "README.md",


### PR DESCRIPTION
Sometimes my watch will change (with `drained` active) past the threshold and not deactivate `drained`. On debugging, the interval isn't set, so we set it unconditionally to ensure we have a charge "watcher".