### PR TITLE
Create colorpicker module

### DIFF
--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -15,6 +15,7 @@ exports.show = function(options) {
   if(colors.length>36) throw new Error("More than 36 colors provided, cannot display");
   
   if(!options.onSelect) throw new Error("No onSelect function provided");
+  if(!options.back) throw new Error("No back function provided");
   
   var rect = Bangle.appRect;
   var W = rect.w;

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -4,7 +4,7 @@ exports.show = function(options) {
   var previewTimeout;
   if (!options.colors||options.colors.length==0) {
     colors = [
-      "#000000", "#555555", "#AAAAAA", "#FFFFFF",
+      "#000000", "#808080", "#AAAAAA", "#FFFFFF",
       "#FF9999", "#FFCC99", "#FFFF99", "#99FF99", "#99FFFF", "#9999FF", "#FF99FF",
       "#FF0000", "#FF8800", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF",
       "#880000", "#884400", "#888800", "#008800", "#008888", "#000088", "#880088"

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -65,12 +65,11 @@ exports.show = function(options) {
   }
 
   function remove() {
-    if(previewTimeout)clearTimeout(previewTimeout);
-    if(options.back){
-      options.back();
-    }else{
-      throw new Error("No back function provided");
+    if(previewTimeout){
+      clearTimeout(previewTimeout);
+      previewTimeout=null;
     }
+    options.back();
   }
 
   function onTouch(btn, xy) {
@@ -82,14 +81,18 @@ exports.show = function(options) {
         if(Bangle.haptic) Bangle.haptic();
         options.onSelect(col);
         if (options.showPreview === undefined || options.showPreview) {
-          g.setColor(col);
-          g.fillRect(rect);
+          g.setColor(col)
+          .fillRect(rect);
+          if(previewTimeout){
+            clearTimeout(previewTimeout);
+            previewTimeout=null;
+          }
           previewTimeout=setTimeout(remove, 0.7 * 1000);
         } else {
           remove();
         }
       }else{
-        Bangle.haptic()
+        if(Bangle.haptic) Bangle.haptic();
         if(selectedColors.includes(col)){
           //unselect
           selectedColors=selectedColors.filter(color => color !== col);

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -1,0 +1,84 @@
+exports.show = function(options) {
+  Bangle.removeAllListeners("touch");
+  Bangle.removeAllListeners("drag");
+
+  var colors;
+  var isPicking=true;
+  if (!options.colors) {
+    // use default 25 colors
+    colors = [
+      "#000000", "#555555", "#AAAAAA", "#FFFFFF",
+      "#FF9999", "#FFCC99", "#FFFF99", "#99FF99", "#99FFFF", "#9999FF", "#FF99FF",
+      "#FF0000", "#FF8800", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF",
+      "#880000", "#884400", "#888800", "#008800", "#008888", "#000088", "#880088"
+    ];
+  } else {
+    colors = options.colors;
+  }
+  if(colors.length>36){
+    throw new Error("More than 36 colors provided, cannot display")
+  }
+  var rect = Bangle.appRect;
+  var W = rect.w;
+  var H = rect.h;
+  var n = colors.length;
+  var COLS = Math.round(Math.sqrt(n));
+  var ROWS = Math.ceil(n / COLS);
+  var CW = (W / COLS) | 0;
+  var CH = (H / ROWS) | 0;
+
+  function draw() {
+    g.clearRect(rect);
+    for (var i = 0; i < n; i++) {
+      var col = i % COLS;
+      var row = (i / COLS) | 0;
+      var x = rect.x + col * CW;
+      var y = rect.y + row * CH;
+      g.setColor(colors[i])
+       .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
+       .setColor(g.theme.fg)
+       .drawRect(x, y, x + CW, y + CH);
+    }
+  }
+
+  function colorAt(x, y) {
+    var col = ((x - rect.x) / CW) | 0;
+    var row = ((y - rect.y) / CH) | 0;
+    var i = row * COLS + col;
+    if (i < 0 || i >= n) return null;
+    return colors[i];
+  }
+
+  function remove() {
+    if(options.back){
+      options.back();
+    }else{
+      throw new Error("No back function provided");
+    }
+  }
+
+  function onTouch(btn, xy) {
+    if(isPicking){
+      Bangle.haptic();
+      isPicking=false;
+      var col = colorAt(xy.x, xy.y);
+      if (!col) return;
+      options.onSelect(col);
+      if (options.showPreview === undefined || options.showPreview) {
+        g.setColor(col);
+        g.fillRect(rect);
+        setTimeout(remove, 0.8 * 1000);
+      } else {
+        remove();
+    }
+    }
+  }
+
+  Bangle.setUI({
+    mode: "custom",
+    touch: function(n, e) { onTouch(n, e); },
+    btn: function(n) { remove(); }
+  });
+
+  draw();
+};

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -1,11 +1,8 @@
 exports.show = function(options) {
-  Bangle.removeAllListeners("touch");
-  Bangle.removeAllListeners("drag");
-
   var colors;
   var isPicking=true;
-  if (!options.colors) {
-    // use default 25 colors
+
+  if (!options.colors||options.colors.length==0) {
     colors = [
       "#000000", "#555555", "#AAAAAA", "#FFFFFF",
       "#FF9999", "#FFCC99", "#FFFF99", "#99FF99", "#99FFFF", "#9999FF", "#FF99FF",
@@ -42,6 +39,7 @@ exports.show = function(options) {
   }
 
   function colorAt(x, y) {
+    if(y<rect.y)return null;
     var col = ((x - rect.x) / CW) | 0;
     var row = ((y - rect.y) / CH) | 0;
     var i = row * COLS + col;
@@ -59,15 +57,16 @@ exports.show = function(options) {
 
   function onTouch(btn, xy) {
     if(isPicking){
-      Bangle.haptic();
-      isPicking=false;
       var col = colorAt(xy.x, xy.y);
       if (!col) return;
-      options.onSelect(col);
+      isPicking=false;
+      Bangle.haptic();
+      if(options.onSelect) options.onSelect(col);
+      else throw new Error("No onSelect function provided")
       if (options.showPreview === undefined || options.showPreview) {
         g.setColor(col);
         g.fillRect(rect);
-        setTimeout(remove, 0.8 * 1000);
+        setTimeout(remove, 0.7 * 1000);
       } else {
         remove();
     }

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -1,8 +1,4 @@
 exports.show = function(options) {
-  /*
-  Bangle.removeAllListeners("touch");
-  Bangle.removeAllListeners("drag");
-  */
   var colors;
   var isPicking=true;
   var previewTimeout;
@@ -27,7 +23,8 @@ exports.show = function(options) {
   var ROWS = Math.ceil(n / COLS);
   var CW = (W / COLS) | 0;
   var CH = (H / ROWS) | 0;
-
+  var selectedColors=options.startingSelection?options.startingSelection:[];
+  
   function draw() {
     g.clearRect(rect);
     for (var i = 0; i < n; i++) {
@@ -35,11 +32,25 @@ exports.show = function(options) {
       var row = (i / COLS) | 0;
       var x = rect.x + col * CW;
       var y = rect.y + row * CH;
+      var oldCH=CH;
+      var oldCW=CW;
+      if(options.multiSelect){
+        if(selectedColors.includes(colors[i])){
+          //selected
+          x+=4
+          y+=4
+          CH-=8
+          CW-=8
+        }
+      }
       g.setColor(colors[i])
        .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
        .setColor(g.theme.fg)
        .drawRect(x, y, x + CW, y + CH);
+      CH=oldCH;
+      CW=oldCW;
     }
+    
   }
 
   function colorAt(x, y) {
@@ -64,17 +75,29 @@ exports.show = function(options) {
     if(isPicking){
       var col = colorAt(xy.x, xy.y);
       if (!col) return;
-      isPicking=false;
-      Bangle.haptic();
-      if(options.onSelect) options.onSelect(col);
-      else throw new Error("No onSelect function provided")
-      if (options.showPreview === undefined || options.showPreview) {
-        g.setColor(col);
-        g.fillRect(rect);
-        previewTimeout=setTimeout(remove, 0.7 * 1000);
-      } else {
-        remove();
-    }
+      if(!options.multiSelect){
+        isPicking=false;
+        Bangle.haptic();
+        if(options.onSelect) options.onSelect(col);
+        else throw new Error("No onSelect function provided")
+        if (options.showPreview === undefined || options.showPreview) {
+          g.setColor(col);
+          g.fillRect(rect);
+          previewTimeout=setTimeout(remove, 0.7 * 1000);
+        } else {
+          remove();
+        }
+      }else{
+        Bangle.haptic()
+        options.onSelect(selectedColors);
+        if(selectedColors.includes(col)){
+          //unselect
+          selectedColors=selectedColors.filter(color => color !== col);
+        }else{
+          selectedColors.push(col)
+        }
+        draw()
+      }
     }
   }
 
@@ -85,4 +108,4 @@ exports.show = function(options) {
   });
 
   draw();
-}
+};

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -1,7 +1,11 @@
 exports.show = function(options) {
+  /*
+  Bangle.removeAllListeners("touch");
+  Bangle.removeAllListeners("drag");
+  */
   var colors;
   var isPicking=true;
-
+  var previewTimeout;
   if (!options.colors||options.colors.length==0) {
     colors = [
       "#000000", "#555555", "#AAAAAA", "#FFFFFF",
@@ -48,6 +52,7 @@ exports.show = function(options) {
   }
 
   function remove() {
+    if(previewTimeout)clearTimeout(previewTimeout);
     if(options.back){
       options.back();
     }else{
@@ -66,7 +71,7 @@ exports.show = function(options) {
       if (options.showPreview === undefined || options.showPreview) {
         g.setColor(col);
         g.fillRect(rect);
-        setTimeout(remove, 0.7 * 1000);
+        previewTimeout=setTimeout(remove, 0.7 * 1000);
       } else {
         remove();
     }
@@ -80,4 +85,4 @@ exports.show = function(options) {
   });
 
   draw();
-};
+}

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -12,9 +12,10 @@ exports.show = function(options) {
   } else {
     colors = options.colors;
   }
-  if(colors.length>36){
-    throw new Error("More than 36 colors provided, cannot display")
-  }
+  if(colors.length>36) throw new Error("More than 36 colors provided, cannot display")
+  
+  if(!options.onSelect) throw new Error("No onSelect function provided")
+  
   var rect = Bangle.appRect;
   var W = rect.w;
   var H = rect.h;
@@ -78,8 +79,7 @@ exports.show = function(options) {
       if(!options.multiSelect){
         isPicking=false;
         Bangle.haptic();
-        if(options.onSelect) options.onSelect(col);
-        else throw new Error("No onSelect function provided")
+        options.onSelect(col);
         if (options.showPreview === undefined || options.showPreview) {
           g.setColor(col);
           g.fillRect(rect);

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -78,7 +78,7 @@ exports.show = function(options) {
       if (!col) return;
       if(!options.multiSelect){
         isPicking=false;
-        Bangle.haptic();
+        if(Bangle.haptic) Bangle.haptic();
         options.onSelect(col);
         if (options.showPreview === undefined || options.showPreview) {
           g.setColor(col);

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -104,7 +104,10 @@ exports.show = function(options) {
   Bangle.setUI({
     mode: "custom",
     touch: function(n, e) { onTouch(n, e); },
-    btn: function(n) { remove(); }
+    btn: function(n) { remove(); },
+    back: remove,
+    remove: remove,
+    redraw: draw
   });
 
   draw();

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -12,9 +12,9 @@ exports.show = function(options) {
   } else {
     colors = options.colors;
   }
-  if(colors.length>36) throw new Error("More than 36 colors provided, cannot display")
+  if(colors.length>36) throw new Error("More than 36 colors provided, cannot display");
   
-  if(!options.onSelect) throw new Error("No onSelect function provided")
+  if(!options.onSelect) throw new Error("No onSelect function provided");
   
   var rect = Bangle.appRect;
   var W = rect.w;
@@ -25,7 +25,8 @@ exports.show = function(options) {
   var CW = (W / COLS) | 0;
   var CH = (H / ROWS) | 0;
   var selectedColors=options.startingSelection?options.startingSelection:[];
-  
+  var insetX = (CW * 0.15) | 0;
+  var insetY = (CH * 0.15) | 0;
   function draw() {
     g.clearRect(rect);
     for (var i = 0; i < n; i++) {
@@ -37,11 +38,10 @@ exports.show = function(options) {
       var oldCW=CW;
       if(options.multiSelect){
         if(selectedColors.includes(colors[i])){
-          //selected
-          x+=4
-          y+=4
-          CH-=8
-          CW-=8
+          x += insetX;
+          y += insetY;
+          CW -= insetX * 2;
+          CH -= insetY * 2;
         }
       }
       g.setColor(colors[i])
@@ -89,13 +89,13 @@ exports.show = function(options) {
         }
       }else{
         Bangle.haptic()
-        options.onSelect(selectedColors);
         if(selectedColors.includes(col)){
           //unselect
           selectedColors=selectedColors.filter(color => color !== col);
         }else{
           selectedColors.push(col)
         }
+        options.onSelect(selectedColors);
         draw()
       }
     }

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -1,5 +1,8 @@
 # Color Picker
-A module for showing a color picker for easy picking and setting of colors
+A module for showing a color picker for easy picking and setting of colors.
+
+<img width="176" height="176" alt="d" src="https://github.com/user-attachments/assets/1fbde2f8-e25a-4a9b-9ce8-40803ae14adb" />
+
 ## Usage
 Example usage:
 ```javascript

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -28,7 +28,7 @@ E.showMenu(menu);
 `require("colorpicker").show(opts)` takes in an object of options, listed below:
 * `colors`: (Optional), specify a select list of colors to show instead of the default. Must not exceed 36 colors.
 * `showPreview`: (Optional), choose whether or not to show a full-screen preview of the color you selected.
-* `onSelect`: (Required), function that is called when user selects a color. Saving logic goes here. If in multi-select mode, this is called every time a new color is selected.
+* `onSelect`: (Required), function that is called whenever the user changes the selection (selects or unselects a color). Saving logic goes here. In multi-select mode, this is called on every toggle and is passed the current list of selected colors.
 * `back`: (Required), function that is called to return to previous state. Color picker listeners are automatically removed.
 * `multiSelect` (Optional), if true, then the color picker allows the user to select multiple colors and returns a list of colors in `onSelect`
 * `startingSelection` (Optional, only for multi-select mode), array of colors selected at the start, for setting restoration.

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -1,0 +1,33 @@
+# Color Picker
+A module for showing a color picker for easy picking and setting of colors
+## Usage
+Example usage:
+```javascript
+var menu={
+  "Color Picker" : function(){
+    require("colorpicker").show({
+      onSelect:function(color){
+        print(color);
+      },
+      showPreview:true,
+      back:function(){
+        E.showMenu(menu);
+      }
+
+    });
+  }
+}
+E.showMenu(menu);
+
+```
+<b>Options:</b>
+
+`require("colorpicker").show(opts)` takes in an object of options, listed below:
+* `colors`: (Optional), specify a select list of colors to show instead of the default. Must not exceed 36 colors.
+* `showPreview`: (Optional), choose whether or not to show a full-screen preview of the color you selected.
+* `onSelect`: (Required), function that is called when user selects a color. Saving logic goes here.
+* `back`: (Required), function that is called to return to previous state. Color picker listeners are automatically removed.
+
+## Author
+RKBoss6
+

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -28,8 +28,10 @@ E.showMenu(menu);
 `require("colorpicker").show(opts)` takes in an object of options, listed below:
 * `colors`: (Optional), specify a select list of colors to show instead of the default. Must not exceed 36 colors.
 * `showPreview`: (Optional), choose whether or not to show a full-screen preview of the color you selected.
-* `onSelect`: (Required), function that is called when user selects a color. Saving logic goes here.
+* `onSelect`: (Required), function that is called when user selects a color. Saving logic goes here. If in multi-select mode, this is called every time a new color is selected.
 * `back`: (Required), function that is called to return to previous state. Color picker listeners are automatically removed.
+* `multiSelect` (Optional), if true, then the color picker allows the user to select multiple colors and returns a list of colors in `onSelect`
+* `startingSelection` (Optional, only for multi-select mode), array of colors selected at the start, for setting restoration.
 
 ## Author
 RKBoss6


### PR DESCRIPTION
Creates colorpicker module as an easy way for apps to present users with a color selection menu. 
I've been wanting a menu that could do this for a while, as the alternative before was to make a scroll menu with all the colors and have the users scroll through all of them, instead of being able to see them at a glance. Currently this only works on bangle.js 2, I'm not exactly sure how to convert it to bangle.js 1 as well. This can be used in places like clock_bg, where users need to select multiple colors, or even in the theme menu and other system-level places if the need arises.

This is my first module, so let me know if I need to do anything else or did something wrong :)

Single color mode:
<img width="176" height="176" alt="d" src="https://github.com/user-attachments/assets/413747fb-7eed-4305-a79a-623047d735b3" />

Multi-select mode:
<img width="176" height="176" alt="download (7)" src="https://github.com/user-attachments/assets/8ae3a263-54a6-4feb-a2a3-698a7f2fa298" />


You can look at an example implementation in the [Clock Background app on my app loader](https://rkboss6.github.io/BangleApps/?id=clockbg), and just upload the module to your watch as `colorpicker` via web ide.

For bangle.js 1 compatibility, would the best course of action be to make the up/down buttons change the highlighted color, then a select is used to select it?