### PR TITLE
feat(sleeplog): introduce multi-sensor 'Sleep Mode' and refine thresholds

### DIFF
--- a/apps/sleeplog/ChangeLog
+++ b/apps/sleeplog/ChangeLog
@@ -23,3 +23,4 @@
 0.25: Put HRM mode behind the setting `Prefer HRM` which defaults to `false`.
       Please enable if you want the HRM behavior from v0.21. The new default
       will be more in line with how version 0.20 worked.
+0.26: Replaced 'Prefer HRM' with 'Sleep Mode' setting, adding an option to require both movement and HRM to detect sleep (prevents false sleep while sitting still).

--- a/apps/sleeplog/README.md
+++ b/apps/sleeplog/README.md
@@ -87,8 +87,10 @@ To make sure the app accurately provides sleep information, it's a good idea to 
         _0:00_ / _1:00_ / ... / __12:00__ / ... / _23:00_
       - __App Timeout__ | app specific lock timeout
         __0s__ / _10s_ / ... / _120s_
-      - __Prefer HRM__ | En-/disables use of HRM readings if they are available for determining sleep states.
-        _on_ / __off__
+      - __Sleep Mode__ | Defines which sensors are used to determine your sleeping state.
+        - **Movement:** Uses only the accelerometer (default).
+        - **HRM:** Uses the heart rate monitor if available (falls back to movement if no pulse is found).
+        - **Both:** Requires *both* the movement and HRM thresholds to indicate sleep. Helps prevent false positives when sitting quietly at a desk.
       - __HRM Thresholds__ submenu
         Changes take effect from now on, not retrospective! HRM works only if polling is enabled in `Health` settings
         - __Deep Sleep__ | deep sleep threshold

--- a/apps/sleeplog/boot.js
+++ b/apps/sleeplog/boot.js
@@ -20,6 +20,23 @@ global.sleeplog = {
   }, require("Storage").readJSON("sleeplog.json", true) || {})
 };
 
+// --- MIGRATION LOGIC (Added in v0.26) ---
+// Catch users who updated from <=v0.25 but haven't opened the settings app yet.
+// Translates the old boolean preference to the new sleepMode in RAM.
+// WHY: In v0.25 and earlier, the HRM setting was a simple boolean called 'preferHRM'.
+// In v0.26, this was replaced by a 3-state 'sleepMode' (0=Movement, 1=HRM, 2=Both).
+// WHAT: This block silently migrates existing users who haven't opened the settings page, yet
+// to the new format, ensuring they don't lose their preference and the app doesn't crash.
+// REMOVAL: This block can be safely removed in a future major update (e.g., v1.0 or 
+// after ~1 year), once we can assume all active users have updated past v0.25.
+// CONSEQUENCE: If removed, users updating directly from <=v0.25 to that future version 
+// will simply lose their old 'preferHRM' preference and default to sleepMode 0.
+if ("preferHRM" in global.sleeplog.conf) {
+  global.sleeplog.conf.sleepMode = global.sleeplog.conf.preferHRM ? 1 : 0;
+  delete global.sleeplog.conf.preferHRM; // clean up RAM
+}
+// ---------------------------------------
+
 // check if service is enabled
 if (global.sleeplog.conf.enabled) {
   // assign functions to global object

--- a/apps/sleeplog/boot.js
+++ b/apps/sleeplog/boot.js
@@ -16,7 +16,7 @@ global.sleeplog = {
     wearTemp: 19.5,
     hrmDeepTh: 60,
     hrmLightTh: 74,
-    preferHRM: false
+    sleepMode: 0
   }, require("Storage").readJSON("sleeplog.json", true) || {})
 };
 
@@ -159,16 +159,26 @@ if (global.sleeplog.conf.enabled) {
       if (!data.movement&&!data.bpm) return;
       // add timestamp rounded to 10min, corrected to 10min ago
       data.timestamp = data.timestamp || ((Date.now() / 6E5 | 0) - 1) * 6E5;
-      // add preliminary status depending on charging and movement thresholds
+      // add preliminary status depending on charging, movement, and HRM thresholds
       // 1 = not worn, 2 = awake, 3 = light sleep, 4 = deep sleep
-      if(data.bpm && global.sleeplog.conf.preferHRM){
-        data.status = Bangle.isCharging() ? 1 :
-          data.bpm <= global.sleeplog.conf.hrmDeepTh ? 4 :
-          data.bpm <= global.sleeplog.conf.hrmLightTh ? 3 : 2;
-      }else{
-        data.status = Bangle.isCharging() ? 1 :
-          data.movement <= global.sleeplog.conf.deepTh ? 4 :
-          data.movement <= global.sleeplog.conf.lightTh ? 3 : 2;
+      var conf = global.sleeplog.conf;
+      if (Bangle.isCharging()) {
+        data.status = 1;
+      } else {
+        // Calculate theoretical status for both sensors independently
+        var hStatus = data.bpm ? (data.bpm <= conf.hrmDeepTh ? 4 : (data.bpm <= conf.hrmLightTh ? 3 : 2)) : 0;
+        var mStatus = data.movement <= conf.deepTh ? 4 : (data.movement <= conf.lightTh ? 3 : 2);
+
+        if (conf.sleepMode === 1 && data.bpm) {
+          // 1: HRM only (Fallback to movement if HRM fails)
+          data.status = hStatus;
+        } else if (conf.sleepMode === 2 && data.bpm) {
+          // 2: Require Both (The "more awake" sensor wins)
+          data.status = Math.min(hStatus, mStatus);
+        } else {
+          // 0: Movement only (or fallback if HRM fails in mode 1/2)
+          data.status = mStatus;
+        }
       }
 
       // check if changing to deep sleep from non sleeping

--- a/apps/sleeplog/metadata.json
+++ b/apps/sleeplog/metadata.json
@@ -2,7 +2,7 @@
   "id":"sleeplog",
   "name":"Sleep Log",
   "shortName": "SleepLog",
-  "version": "0.25",
+  "version": "0.26",
   "description": "Log and view your sleeping habits. This app uses built in movement calculations or HRM data, if enabled. View data from Bangle.js, or from the web app.",
   "icon": "app.png",
   "type": "app",

--- a/apps/sleeplog/settings.js
+++ b/apps/sleeplog/settings.js
@@ -321,7 +321,7 @@
         value: settings.hrmDeepTh,
         step: 1,
         min: 30,
-        max: 100,
+        max: 200,
         wrap: true,
         noList: true,
         onchange: v => {
@@ -333,7 +333,7 @@
         value: settings.hrmLightTh,
         step: 1,
         min: 30,
-        max: 100,
+        max: 200,
         wrap: true,
         noList: true,
         onchange: v => {
@@ -373,7 +373,7 @@
       
       /*LANG*/"Deep Sleep": {
         value: settings.deepTh,
-        step: 10,
+        step: 1,
         min: 30,
         max: 500,
         wrap: true,
@@ -385,7 +385,7 @@
       },
       /*LANG*/"Light Sleep": {
         value: settings.lightTh,
-        step: 10,
+        step: 1,
         min: 100,
         max: 800,
         wrap: true,

--- a/apps/sleeplog/settings.js
+++ b/apps/sleeplog/settings.js
@@ -16,7 +16,7 @@
     lightTh: 300,//    threshold for light sleep
     hrmLightTh: 74,//    threshold for light sleep with HRM
     hrmDeepTh:60,//     threshold for deep sleep with HRM
-    preferHRM: false, // prefer hrm based sleep state determination
+    sleepMode: 0, // 0=Movement, 1=HRM, 2=Both
     wearTemp: 19.5, //    temperature threshold to count as worn
     // app settings
     breakToD: 12, //    [h] time of day when to start/end graphs
@@ -25,6 +25,22 @@
 
   // assign loaded settings to default values
   var settings = Object.assign({},defaults, require("Storage").readJSON(filename, true));
+
+  // --- MIGRATION LOGIC (Added in v0.26) ---
+  // WHY: In v0.25 and earlier, the HRM setting was a simple boolean called 'preferHRM'.
+  // In v0.26, this was replaced by a 3-state 'sleepMode' (0=Movement, 1=HRM, 2=Both).
+  // WHAT: This block silently migrates existing users to the new format upon opening
+  // the settings, ensuring they don't lose their preference and the app doesn't crash.
+  // REMOVAL: This block can be safely removed in a future major update (e.g., v1.0 or 
+  // after ~1 year), once we can assume all active users have updated past v0.25.
+  // CONSEQUENCE: If removed, users updating directly from <=v0.25 to that future version 
+  // will simply lose their old 'preferHRM' preference and default to sleepMode 0.
+  if ("preferHRM" in settings) {
+    settings.sleepMode = settings.preferHRM ? 1 : 0;
+    delete settings.preferHRM;
+    require("Storage").writeJSON(filename, settings);
+  }
+  // ----------------------------------------
 
   // write change to storage
   function writeSetting() {
@@ -436,10 +452,13 @@
             writeSetting();
           }
         },
-        /*LANG*/"Prefer HRM": {
-          value: settings.preferHRM,
+        /*LANG*/"Sleep Mode": {
+          value: settings.sleepMode,
+          min: 0,
+          max: 2,
+          format: v => [/*LANG*/"Movement", /*LANG*/"HRM", /*LANG*/"Both"][v],
           onchange: v => {
-            settings.preferHRM = v;
+            settings.sleepMode = v;
             writeSetting();
           }
         },


### PR DESCRIPTION
### Description
This PR addresses false sleep detections (e.g., classifying stationary desk work as sleep) by allowing users to mandate both Movement and HRM thresholds simultaneously. It also adjusts settings bounds to allow finer tuning for users with higher resting movement baselines.

### Technical Implementation

**1. Multi-Sensor Logic (`boot.js`):**
Replaced the rigid `preferHRM` boolean tree with a calculated state approach. We calculate theoretical sleep statuses (`hStatus` and `mStatus`) for both sensors independently.
If `sleepMode === 2` (Both), the logic uses `Math.min(hStatus, mStatus)`. Since lower integers represent "more awake" states (2 = awake, 4 = deep sleep), the sensor that detects the most activity acts as an overriding failsafe, effectively filtering out false positives. If `data.bpm` is falsy, it automatically falls back to `mStatus`.

**2. Graceful Settings Migration (`settings.js`):**
To maintain backward compatibility with existing `sleeplog.json` configurations, a silent migration block was added. Upon opening the settings, if the legacy `preferHRM` key exists, it translates the boolean into the new `sleepMode` integer format (0 or 1) and cleans up the old key.

**3. UI/Thresholds:**
- Replaced the `preferHRM` toggle with a 3-state Choice Menu (Movement / HRM / Both).
- Increased `max` bounds for deep/light HRM thresholds up to 200 and adjusted `step` to 1 to allow high-granularity tuning.

**Checklist:**
- [x] Tested locally on Bangle.js 2.
- [x] Version bumped in `metadata.json`.
- [x] No changes to other apps included.

**App Loader Link:**
https://fabiank-dev.github.io/BangleApps/