### PR TITLE
rescalc: use shared color picker for band selection

### DIFF
--- a/apps/rescalc/ChangeLog
+++ b/apps/rescalc/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Fixes colors not matching user input from color menu in some cases, 3 bands are now shown larger, various code improvements.
 0.03: Use transparent icon with better visibility on dark backgrounds, new resistor img with darker outlines
 0.04: Fix capitalization. Improve decimal handling.
+0.05: Use the shared color picker for band selection.

--- a/apps/rescalc/app.js
+++ b/apps/rescalc/app.js
@@ -17,6 +17,7 @@ let colorData = {
   Silver: { multiplier: 0.01, tolerance: 10, hex: '#C0C0C0' },
   None: { tolerance: 20 },
 };
+let validTolerances = [1, 2, 0.5, 0.25, 0.1, 0.05, 5, 10];
 
 function clearScreen() { // Except Back Button
   g.clearRect(24, 0, 176, 24);
@@ -88,9 +89,7 @@ function resistanceToColorBands(resistance, tolerance) {
 
 // Helper function to get color band based on property and value
 function getBandColor(property, value) {
-  let entry = Object.entries(colorData).find(function (entry) {
-    return entry[1][property] === value;
-  });
+  let entry = Object.entries(colorData).find(entry => entry[1][property] === value);
   return entry ? entry[1].hex : undefined;
 }
 
@@ -107,8 +106,6 @@ function drawResistor(colorBands, tolerance) {
   let bandWidth = (resistorBodyWidth - (numColorBands * 2 - 1)) / numColorBands; // width of each band, accounting for the spacing
   let bandHeight = resistorBodyHeight; // height of each band
   let currentX = resistorStartX; // starting point for the first band
-  // Define the tolerance values that will trigger the fourth band
-  let validTolerances = [1, 2, 0.5, 0.25, 0.1, 0.05, 5, 10];
   for (let i = 0; i < numColorBands; i++) {
     // Skip the fourth band and its outlines if the tolerance is not in the valid list
     if (i === 3 && !validTolerances.includes(tolerance)) continue;
@@ -172,8 +169,6 @@ function drawResistance(resistance, tolerance) {
   // Draw the Ohm symbol to the right of the unit
   g.drawImage(omega(), omegaX, y - 13, { scale: 0.45 });
   g.setFontAlign(1, 0).setFont("Vector", 27);
-  // Define the tolerance values that will trigger the fourth band
-  let validTolerances = [1, 2, 0.5, 0.25, 0.1, 0.05, 5, 10];
   // Check if the tolerance is not in the valid list, and if it's not, set it to 20
   if (!validTolerances.includes(tolerance)) {
     tolerance = 20;
@@ -186,6 +181,10 @@ function drawResistance(resistance, tolerance) {
 (function () {
   let colorBands;
   let inputColorBands;
+  let mainMenu;
+  let pickerBandNumber;
+  let pickerNames;
+  let pickerColors;
   let settings = {
     resistance: 0,
     tolerance: 0,
@@ -203,56 +202,86 @@ function drawResistance(resistance, tolerance) {
     inputColorBands = null;
   }
 
-  function showColorBandMenu(bandNumber) {
-    let colorBandMenu = {
-      '': {
-        'title': `Band ${bandNumber}`
-      },
-      '< Back': function () {
-        E.showMenu(colorEntryMenu);
-      },
-    };
-
-    // Populate colorBandMenu with colors from colorData
-    for (let color in colorData) {
-      if (bandNumber === 1 || bandNumber === 2) {
-        if (color !== 'None' && color !== 'Gold' && color !== 'Silver') {
-          (function (color) {
-            colorBandMenu[color] = function () {
-              setBandColor(bandNumber, color);
-            };
-          })(color);
-        }
-      } else if (bandNumber === 3) {
-        if (color !== 'None') {
-          (function (color) {
-            colorBandMenu[color] = function () {
-              setBandColor(bandNumber, color);
-            };
-          })(color);
-        }
-      } else if (bandNumber === 4) {
-        if (colorData[color].hasOwnProperty('tolerance')) {
-          (function (color) {
-            colorBandMenu[color] = function () {
-              setBandColor(bandNumber, color);
-            };
-          })(color);
-        }
-      }
-    }
-    return E.showMenu(colorBandMenu);
+  function openColorBandPicker(bandNumber) {
+    E.showMenu();
+    showColorBandPicker(bandNumber);
   }
 
   function setBandColor(bandNumber, color) {
     settings.colorBands[bandNumber - 1] = color; // arrays are 0-indexed
-    // Update the color band in the colorEntryMenu
-    colorEntryMenu[`${bandNumber}:`].value = color;
-    showColorEntryMenu();
+  }
+
+  function closeColorBandPicker() {
+    // Wait until the picker touch handler unwinds before rebuilding the menu.
+    setTimeout(showColorEntryMenu, 0);
+  }
+
+  function setBandColorFromPicker(color) {
+    setBandColor(pickerBandNumber, pickerNames[pickerColors.indexOf(color)]);
+  }
+
+  function getPickerColors(bandNumber) {
+    let names = [];
+    let colors = [];
+    for (let name in colorData) {
+      if ((bandNumber < 3 && name !== 'None' && name !== 'Gold' && name !== 'Silver') ||
+          (bandNumber === 3 && name !== 'None') ||
+          (bandNumber === 4 && colorData[name].tolerance !== undefined)) {
+        names.push(name);
+        // Pass "None" through as the picker's empty tile sentinel.
+        colors.push(colorData[name].hex || name);
+      }
+    }
+    return {
+      names: names,
+      colors: colors
+    };
+  }
+
+  function showColorBandPicker(bandNumber) {
+    let pickerColorsData = getPickerColors(bandNumber);
+    pickerBandNumber = bandNumber;
+    pickerNames = pickerColorsData.names;
+    pickerColors = pickerColorsData.colors;
+    require("colorpicker").show({
+      colors: pickerColors,
+      emptyColor: 'None',
+      showPreview: false,
+      back: closeColorBandPicker,
+      onSelect: setBandColorFromPicker
+    });
+  }
+
+  function getColorSwatch(hexColor, filled, crossed) {
+    let b = Graphics.createArrayBuffer(16, 16, 4, { msb: true });
+    // Palette slots: background, fill, border, red X.
+    b.palette = new Uint16Array([g.toColor(g.theme.bg), g.toColor(hexColor), g.toColor(g.theme.fg), g.toColor("#f00")]);
+    if (filled) {
+      b.setColor(1).fillRect(1, 1, 14, 14);
+    }
+    b.setColor(2).drawRect(0, 0, 15, 15);
+    if (crossed) {
+      b.setColor(3).drawLine(2, 2, 13, 13);
+      b.drawLine(13, 2, 2, 13);
+    }
+    // Menus treat "\0" + image data as an inline icon in the label.
+    return "\0" + b.asImage("string");
+  }
+
+  function formatBandMenuItem(bandNumber) {
+    let colorName = settings.colorBands[bandNumber - 1];
+    let color = colorData[colorName];
+    if (color && color.hex) return getColorSwatch(color.hex, true, false);
+    if (colorName === 'None') return getColorSwatch(g.theme.bg, false, true);
+    return "";
+  }
+
+  function getBandMenuLabel(bandNumber) {
+    return bandNumber + ": " + formatBandMenuItem(bandNumber);
   }
 
   function showColorEntryMenu() {
-    colorEntryMenu = {
+    let menu = {
       '': {
         'title': 'Band Color'
       },
@@ -260,48 +289,30 @@ function drawResistance(resistance, tolerance) {
         clearScreen();
         E.showMenu(mainMenu);
       },
-      '1:': {
-        value: settings.colorBands[0] || "",
-        format: (v) => `${v}`,
-        onchange: () => {
-          clearScreen();
-          setTimeout(() => showColorBandMenu(1), 5);
-        }
-      },
-      '2:': {
-        value: settings.colorBands[1] || "",
-        format: (v) => `${v}`,
-        onchange: () => {
-          clearScreen();
-          setTimeout(() => showColorBandMenu(2), 5);
-        }
-      },
-      '3:': {
-        value: settings.colorBands[2] || "",
-        format: (v) => `${v}`,
-        onchange: () => {
-          clearScreen();
-          setTimeout(() => showColorBandMenu(3), 5);
-        }
-      },
-      '4:': {
-        value: settings.colorBands[3] || "",
-        format: (v) => `${v}`,
-        onchange: () => {
-          clearScreen();
-          setTimeout(() => showColorBandMenu(4), 5);
-        }
-      },
       'Draw Resistor': function () {
-        inputColorBands = settings.colorBands;
+        if (!settings.colorBands[0] || !settings.colorBands[1] || !settings.colorBands[2]) {
+          return;
+        }
+        inputColorBands = settings.colorBands.slice();
         let values = colorBandsToResistance(inputColorBands);
         settings.resistance = values[0];
         settings.tolerance = values[1];
         showDrawingMenu();
       }
     };
-
-    E.showMenu(colorEntryMenu);
+    menu[getBandMenuLabel(1)] = function () {
+      openColorBandPicker(1);
+    };
+    menu[getBandMenuLabel(2)] = function () {
+      openColorBandPicker(2);
+    };
+    menu[getBandMenuLabel(3)] = function () {
+      openColorBandPicker(3);
+    };
+    menu[getBandMenuLabel(4)] = function () {
+      openColorBandPicker(4);
+    };
+    E.showMenu(menu);
   }
 
   function showMultiplierMenu() {
@@ -316,15 +327,11 @@ function drawResistance(resistance, tolerance) {
 
     // Generate menu items for each Multiplier value in colorData
     for (let color in colorData) {
-      if (colorData[color].hasOwnProperty('multiplier')) {
+      if (colorData[color].multiplier !== undefined) {
         let multiplierValue = parseFloat(colorData[color].multiplier); // Parse the multiplier as a float
         let formattedMultiplier = formatMultiplier(multiplierValue);
         multiplierMenu[`${formattedMultiplier}`] = () => {
           settings.multiplier = multiplierValue;
-          // Update the value of 'Multiplier' in resistanceEntryMenu
-          resistanceEntryMenu["Multiplier"] = function () {
-            showMultiplierMenu();
-          };
           showResistanceEntryMenu();
         };
       }
@@ -355,14 +362,10 @@ function drawResistance(resistance, tolerance) {
 
     // Generate menu items for each tolerance value in colorData
     for (let color in colorData) {
-      if (colorData[color].hasOwnProperty('tolerance')) {
+      if (colorData[color].tolerance !== undefined) {
         let tolerance = parseFloat(colorData[color].tolerance); // Parse the tolerance as a float
         toleranceMenu[`${tolerance}%`] = () => {
           settings.tolerance = tolerance;
-          // Update the value of 'Tolerance (%)' in resistanceEntryMenu
-          resistanceEntryMenu["Tolerance (%)"] = function () {
-            showToleranceMenu();
-          };
           showResistanceEntryMenu();
         };
       }
@@ -373,7 +376,7 @@ function drawResistance(resistance, tolerance) {
   function drawResistorAndResistance(resistance, tolerance) {
     if (inputColorBands) {
       colorBands = inputColorBands.map(color => {
-        if (colorData.hasOwnProperty(color)) {
+        if (colorData[color]) {
           return colorData[color].hex;
         } else {
           return;
@@ -448,7 +451,7 @@ function drawResistance(resistance, tolerance) {
     drawResistorAndResistance(resistance, tolerance);
   }
 
-  let mainMenu = {
+  mainMenu = {
     '': {
       'title': 'Resistor Calc'
     },

--- a/apps/rescalc/app.js
+++ b/apps/rescalc/app.js
@@ -211,11 +211,6 @@ function drawResistance(resistance, tolerance) {
     settings.colorBands[bandNumber - 1] = color; // arrays are 0-indexed
   }
 
-  function closeColorBandPicker() {
-    // Wait until the picker touch handler unwinds before rebuilding the menu.
-    setTimeout(showColorEntryMenu, 0);
-  }
-
   function setBandColorFromPicker(color) {
     setBandColor(pickerBandNumber, pickerNames[pickerColors.indexOf(color)]);
   }
@@ -226,10 +221,9 @@ function drawResistance(resistance, tolerance) {
     for (let name in colorData) {
       if ((bandNumber < 3 && name !== 'None' && name !== 'Gold' && name !== 'Silver') ||
           (bandNumber === 3 && name !== 'None') ||
-          (bandNumber === 4 && colorData[name].tolerance !== undefined)) {
+          (bandNumber === 4 && name !== 'None' && colorData[name].tolerance !== undefined)) {
         names.push(name);
-        // Pass "None" through as the picker's empty tile sentinel.
-        colors.push(colorData[name].hex || name);
+        colors.push(colorData[name].hex);
       }
     }
     return {
@@ -245,25 +239,17 @@ function drawResistance(resistance, tolerance) {
     pickerColors = pickerColorsData.colors;
     require("colorpicker").show({
       colors: pickerColors,
-      emptyColor: 'None',
       showPreview: false,
-      back: closeColorBandPicker,
+      back: showColorEntryMenu,
       onSelect: setBandColorFromPicker
     });
   }
 
-  function getColorSwatch(hexColor, filled, crossed) {
-    let b = Graphics.createArrayBuffer(16, 16, 4, { msb: true });
-    // Palette slots: background, fill, border, red X.
-    b.palette = new Uint16Array([g.toColor(g.theme.bg), g.toColor(hexColor), g.toColor(g.theme.fg), g.toColor("#f00")]);
-    if (filled) {
-      b.setColor(1).fillRect(1, 1, 14, 14);
-    }
+  function getColorSwatch(hexColor) {
+    let b = Graphics.createArrayBuffer(16, 16, 2, { msb: true });
+    b.palette = new Uint16Array([g.toColor(g.theme.bg), g.toColor(hexColor), g.toColor(g.theme.fg), g.toColor(g.theme.fg)]);
+    b.setColor(1).fillRect(1, 1, 14, 14);
     b.setColor(2).drawRect(0, 0, 15, 15);
-    if (crossed) {
-      b.setColor(3).drawLine(2, 2, 13, 13);
-      b.drawLine(13, 2, 2, 13);
-    }
     // Menus treat "\0" + image data as an inline icon in the label.
     return "\0" + b.asImage("string");
   }
@@ -271,8 +257,7 @@ function drawResistance(resistance, tolerance) {
   function formatBandMenuItem(bandNumber) {
     let colorName = settings.colorBands[bandNumber - 1];
     let color = colorData[colorName];
-    if (color && color.hex) return getColorSwatch(color.hex, true, false);
-    if (colorName === 'None') return getColorSwatch(g.theme.bg, false, true);
+    if (color && color.hex) return getColorSwatch(color.hex);
     return "";
   }
 

--- a/apps/rescalc/app.js
+++ b/apps/rescalc/app.js
@@ -182,6 +182,8 @@ function drawResistance(resistance, tolerance) {
   let colorBands;
   let inputColorBands;
   let mainMenu;
+  let colorEntryMenu;
+  let colorEntryMenuScroll = 0;
   let pickerBandNumber;
   let pickerNames;
   let pickerColors;
@@ -200,9 +202,14 @@ function drawResistance(resistance, tolerance) {
     settings = emptySettings;
     colorBands = null;
     inputColorBands = null;
+    colorEntryMenu = undefined;
+    colorEntryMenuScroll = 0;
   }
 
   function openColorBandPicker(bandNumber) {
+    if (colorEntryMenu && colorEntryMenu.scroller) {
+      colorEntryMenuScroll = colorEntryMenu.scroller.scroll;
+    }
     E.showMenu();
     showColorBandPicker(bandNumber);
   }
@@ -265,24 +272,16 @@ function drawResistance(resistance, tolerance) {
     return bandNumber + ": " + formatBandMenuItem(bandNumber);
   }
 
-  function showColorEntryMenu() {
+  function showColorEntryMenu(scroll) {
+    if (scroll !== undefined) colorEntryMenuScroll = scroll;
     let menu = {
       '': {
-        'title': 'Band Color'
+        'title': 'Band Color',
+        'scroll': colorEntryMenuScroll
       },
       '< Back': function () {
         clearScreen();
         E.showMenu(mainMenu);
-      },
-      'Draw Resistor': function () {
-        if (!settings.colorBands[0] || !settings.colorBands[1] || !settings.colorBands[2]) {
-          return;
-        }
-        inputColorBands = settings.colorBands.slice();
-        let values = colorBandsToResistance(inputColorBands);
-        settings.resistance = values[0];
-        settings.tolerance = values[1];
-        showDrawingMenu();
       }
     };
     menu[getBandMenuLabel(1)] = function () {
@@ -297,7 +296,17 @@ function drawResistance(resistance, tolerance) {
     menu[getBandMenuLabel(4)] = function () {
       openColorBandPicker(4);
     };
-    E.showMenu(menu);
+    menu['Draw Resistor'] = function () {
+      if (!settings.colorBands[0] || !settings.colorBands[1] || !settings.colorBands[2]) {
+        return;
+      }
+      inputColorBands = settings.colorBands.slice();
+      let values = colorBandsToResistance(inputColorBands);
+      settings.resistance = values[0];
+      settings.tolerance = values[1];
+      showDrawingMenu();
+    };
+    colorEntryMenu = E.showMenu(menu);
   }
 
   function showMultiplierMenu() {

--- a/apps/rescalc/metadata.json
+++ b/apps/rescalc/metadata.json
@@ -3,7 +3,7 @@
   "name": "Resistor Calculator",
   "shortName": "Resistor Calc",
   "icon": "rescalc.png",
-  "version":"0.04",
+  "version":"0.05",
   "screenshots": [
     {"url": "screenshot.png"},
     {"url": "screenshot-1.png"},

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -2,6 +2,7 @@ exports.show = function(options) {
   var colors;
   var isPicking=true;
   var previewTimeout;
+  var emptyColor = options.emptyColor;
   if (!options.colors||options.colors.length==0) {
     colors = [
       "#000000", "#808080", "#AAAAAA", "#FFFFFF",
@@ -28,6 +29,17 @@ exports.show = function(options) {
   var selectedColors=options.startingSelection?options.startingSelection:[];
   var insetX = (CW * 0.15) | 0;
   var insetY = (CH * 0.15) | 0;
+
+  function drawEmptyTile(x1, y1, x2, y2) {
+    g.setColor(g.theme.bg)
+     .fillRect(x1 + 1, y1 + 1, x2 - 1, y2 - 1)
+     .setColor(g.theme.fg)
+     .drawRect(x1, y1, x2, y2)
+     .setColor("#f00")
+     .drawLine(x1 + 2, y1 + 2, x2 - 2, y2 - 2)
+     .drawLine(x2 - 2, y1 + 2, x1 + 2, y2 - 2);
+  }
+
   function draw() {
     g.clearRect(rect);
     for (var i = 0; i < n; i++) {
@@ -45,10 +57,14 @@ exports.show = function(options) {
           CH -= insetY * 2;
         }
       }
-      g.setColor(colors[i])
-       .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
-       .setColor(g.theme.fg)
-       .drawRect(x, y, x + CW, y + CH);
+      if (colors[i] === emptyColor) {
+        drawEmptyTile(x, y, x + CW, y + CH);
+      } else {
+        g.setColor(colors[i])
+         .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
+         .setColor(g.theme.fg)
+         .drawRect(x, y, x + CW, y + CH);
+      }
       CH=oldCH;
       CW=oldCW;
     }

--- a/modules/colorpicker.js
+++ b/modules/colorpicker.js
@@ -1,8 +1,8 @@
 exports.show = function(options) {
   var colors;
   var isPicking=true;
+  var isClosing=false;
   var previewTimeout;
-  var emptyColor = options.emptyColor;
   if (!options.colors||options.colors.length==0) {
     colors = [
       "#000000", "#808080", "#AAAAAA", "#FFFFFF",
@@ -29,17 +29,6 @@ exports.show = function(options) {
   var selectedColors=options.startingSelection?options.startingSelection:[];
   var insetX = (CW * 0.15) | 0;
   var insetY = (CH * 0.15) | 0;
-
-  function drawEmptyTile(x1, y1, x2, y2) {
-    g.setColor(g.theme.bg)
-     .fillRect(x1 + 1, y1 + 1, x2 - 1, y2 - 1)
-     .setColor(g.theme.fg)
-     .drawRect(x1, y1, x2, y2)
-     .setColor("#f00")
-     .drawLine(x1 + 2, y1 + 2, x2 - 2, y2 - 2)
-     .drawLine(x2 - 2, y1 + 2, x1 + 2, y2 - 2);
-  }
-
   function draw() {
     g.clearRect(rect);
     for (var i = 0; i < n; i++) {
@@ -57,14 +46,10 @@ exports.show = function(options) {
           CH -= insetY * 2;
         }
       }
-      if (colors[i] === emptyColor) {
-        drawEmptyTile(x, y, x + CW, y + CH);
-      } else {
-        g.setColor(colors[i])
-         .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
-         .setColor(g.theme.fg)
-         .drawRect(x, y, x + CW, y + CH);
-      }
+      g.setColor(colors[i])
+       .fillRect(x + 1, y + 1, x + CW - 1, y + CH - 1)
+       .setColor(g.theme.fg)
+       .drawRect(x, y, x + CW, y + CH);
       CH=oldCH;
       CW=oldCW;
     }
@@ -80,11 +65,17 @@ exports.show = function(options) {
     return colors[i];
   }
 
-  function remove() {
+  function cleanup() {
     if(previewTimeout){
       clearTimeout(previewTimeout);
       previewTimeout=null;
     }
+  }
+
+  function closePicker() {
+    if (isClosing) return;
+    isClosing = true;
+    Bangle.setUI();
     options.back();
   }
 
@@ -103,9 +94,9 @@ exports.show = function(options) {
             clearTimeout(previewTimeout);
             previewTimeout=null;
           }
-          previewTimeout=setTimeout(remove, 0.7 * 1000);
+          previewTimeout=setTimeout(closePicker, 0.7 * 1000);
         } else {
-          remove();
+          closePicker();
         }
       }else{
         if(Bangle.haptic) Bangle.haptic();
@@ -123,10 +114,10 @@ exports.show = function(options) {
 
   Bangle.setUI({
     mode: "custom",
-    touch: function(n, e) { onTouch(n, e); },
-    btn: function(n) { remove(); },
-    back: remove,
-    remove: remove,
+    touch: onTouch,
+    btn: closePicker,
+    back: closePicker,
+    remove: cleanup,
     redraw: draw
   });
 

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -35,3 +35,4 @@ E.showMenu(menu);
 
 ## Author
 RKBoss6
+

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -27,7 +27,6 @@ E.showMenu(menu);
 
 `require("colorpicker").show(opts)` takes in an object of options, listed below:
 * `colors`: (Optional), specify a select list of colors to show instead of the default. Must not exceed 36 colors.
-* `emptyColor`: (Optional), specify a value from `colors` that should be rendered as an empty box with a red X instead of a filled color tile.
 * `showPreview`: (Optional), choose whether or not to show a full-screen preview of the color you selected.
 * `onSelect`: (Required), function that is called whenever the user changes the selection (selects or unselects a color). Saving logic goes here. In multi-select mode, this is called on every toggle and is passed the current list of selected colors.
 * `back`: (Required), function that is called to return to previous state. Color picker listeners are automatically removed.

--- a/modules/colorpicker.md
+++ b/modules/colorpicker.md
@@ -27,6 +27,7 @@ E.showMenu(menu);
 
 `require("colorpicker").show(opts)` takes in an object of options, listed below:
 * `colors`: (Optional), specify a select list of colors to show instead of the default. Must not exceed 36 colors.
+* `emptyColor`: (Optional), specify a value from `colors` that should be rendered as an empty box with a red X instead of a filled color tile.
 * `showPreview`: (Optional), choose whether or not to show a full-screen preview of the color you selected.
 * `onSelect`: (Required), function that is called whenever the user changes the selection (selects or unselects a color). Saving logic goes here. In multi-select mode, this is called on every toggle and is passed the current list of selected colors.
 * `back`: (Required), function that is called to return to previous state. Color picker listeners are automatically removed.
@@ -35,4 +36,3 @@ E.showMenu(menu);
 
 ## Author
 RKBoss6
-


### PR DESCRIPTION
Updates Resistor Calculator to use @RKBoss6’s shared color picker module for selecting resistor band colors.
 
~~This also updates the color picker module to support an emptyColor tile rendered as an empty box with a red X. Resistor Calculator uses that for the band 4 no-band / 20% tolerance option.~~

Tested in the app and bin/sanitycheck.js passes. If the shared colorpicker changes look good to @RKBoss6 and everyone else, this should be ready for review.