### PR TITLE
widadjust: fix text display

### DIFF
--- a/apps/widadjust/ChangeLog
+++ b/apps/widadjust/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Use default Bangle formatter for booleans
 0.03: Add option to hide widget
 0.04: Add auto-adjust app
+0.05: Fix auto-adjust text display

--- a/apps/widadjust/metadata.json
+++ b/apps/widadjust/metadata.json
@@ -2,7 +2,7 @@
   "id": "widadjust",
   "name": "Adjust Clock",
   "icon": "icon.png",
-  "version": "0.04",
+  "version": "0.05",
   "description": "Adjusts clock continually in the background to counter clock drift",
   "tags": "widget",
   "supports": [ "BANGLEJS", "BANGLEJS2" ],

--- a/apps/widadjust/widadjust.app.js
+++ b/apps/widadjust/widadjust.app.js
@@ -234,11 +234,8 @@ function on_gps(fix) {
 
   msg += "\n" + updateTime(fix, now);
 
-  g.reset().clear().setFont("Vector", 31)
-    .setColor(1,1,1)
-    .fillRect(0, 24, 176, 100)
-    .setColor(0,0,0)
-    .drawString(msg, 3, 25);
+  g.reset().clear().setFont("Vector", 20)
+    .drawString(msg, 3, 3);
 }
 
 fmt.init();


### PR DESCRIPTION
<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
Current rendering is utterly glitched, at least in dark mode
<img width="176" height="176" alt="download" src="https://github.com/user-attachments/assets/6440b40c-2a4f-468d-ba70-d58151e8ff85" />
This PR switches to sane defaults and bumps the version