### PR TITLE
Twenties: refactor to use the scheduling library instead of its own timeouts

### DIFF
--- a/apps/twenties/ChangeLog
+++ b/apps/twenties/ChangeLog
@@ -5,3 +5,4 @@
 0.05: Improve energy efficiency
 0.06: Align with whole thirds of the hour.
 0.07: Fix TypeError on scheduling for the next day.
+0.08: Refactor to use the scheduling library.

--- a/apps/twenties/README.md
+++ b/apps/twenties/README.md
@@ -17,6 +17,7 @@ Only vibrates during work days and hours.
 Add settings page.
 Add setting for active days and hours.
 Add setting for buzz strength/pattern.
+Add entry in settings to re-run setup.
 
 ## Contributors
 

--- a/apps/twenties/README.md
+++ b/apps/twenties/README.md
@@ -12,6 +12,7 @@ Vibrates to remind you to stand up and look away for healthy living.
 
 Only vibrates during work days and hours.
 
-## Creator
+## Contributors
 
-[@splch](https://github.com/splch/)
+[@splch](https://github.com/splch/) (Creator)
+[@thyttan](https://github.com/thyttan/)

--- a/apps/twenties/README.md
+++ b/apps/twenties/README.md
@@ -12,6 +12,12 @@ Vibrates to remind you to stand up and look away for healthy living.
 
 Only vibrates during work days and hours.
 
+## Todo
+
+Add settings page.
+Add setting for active days and hours.
+Add setting for buzz strength/pattern.
+
 ## Contributors
 
 [@splch](https://github.com/splch/) (Creator)

--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -1,31 +1,6 @@
-(() => {
-  const LOOP_INTERVAL = 1.2e6; // 20 minutes
-  const BUZZ_INTERVAL = 2e4; // 20 seconds
-
-  const isWorkTime = (d) =>
-    d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
-
-  const scheduleNext = () => {
-    const now = new Date();
-    if (isWorkTime(now)) {
-      Bangle.buzz().then(() => setTimeout(Bangle.buzz, BUZZ_INTERVAL));
-      setTimeout(scheduleNext, LOOP_INTERVAL);
-    } else {
-      const next = new Date(now+864e5); // 24 hours
-      next.setHours(8, 0, 0, 0);
-      while (!isWorkTime(next)) next.setDate(next.getDate() + 1);
-      setTimeout(scheduleNext, next - now);
-    }
-  };
-
-  // Align so we fire at whole hour, 20 min past and 40 min past - not at arbitrary times.
-  const TIME_AT_BOOT = new Date();
-  const TIME_SINCE_WHOLE_THIRD_OF_HOUR = (TIME_AT_BOOT.getMinutes() % 20) * 6e4 + TIME_AT_BOOT.getSeconds() * 1e3;
-  setTimeout(scheduleNext,
-    LOOP_INTERVAL - TIME_SINCE_WHOLE_THIRD_OF_HOUR);
-  // Make sure we don't miss the 2nd buzz after 20 seconds if we rebooted during that interval.
-  if (TIME_SINCE_WHOLE_THIRD_OF_HOUR <= BUZZ_INTERVAL) {
-    setTimeout(Bangle.buzz, 
-      BUZZ_INTERVAL - TIME_SINCE_WHOLE_THIRD_OF_HOUR);
-  }
-})();
+{ // This boot script is deleted once the companion alarm is set up.
+  // The app will continue working by having the alarm rearm itself until
+  // the app is uninstalled.
+let alarms = require("Storage").readJSON("sched.json", 1) || [];
+if (!alarms.includes(a => a.id === "twenties")) {require("twenties").setup(alarms);}
+}

--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -2,5 +2,5 @@
   // The app will continue working by having the alarm rearm itself until
   // the app is uninstalled.
   require("twenties").setup();
-  require("Storage").erase("twenties.boot.js");
+  setTimeout(require("Storage").erase, 1000, "twenties.boot.js");
 }

--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -1,6 +1,6 @@
 { // This boot script is deleted once the companion alarm is set up.
   // The app will continue working by having the alarm rearm itself until
   // the app is uninstalled.
-let alarms = require("Storage").readJSON("sched.json", 1) || [];
-if (!alarms.includes(a => a.id === "twenties")) {require("twenties").setup();}
+  require("twenties").setup();
+  require("Storage").erase("twenties.boot.js");
 }

--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -2,5 +2,5 @@
   // The app will continue working by having the alarm rearm itself until
   // the app is uninstalled.
 let alarms = require("Storage").readJSON("sched.json", 1) || [];
-if (!alarms.includes(a => a.id === "twenties")) {require("twenties").setup(alarms);}
+if (!alarms.includes(a => a.id === "twenties")) {require("twenties").setup();}
 }

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -1,5 +1,4 @@
 {
-
   exports.getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
@@ -19,27 +18,14 @@
     return t;
   };
 
-  const S = require("sched");
-
-  exports.buzzAndRearm = function () {
+  exports.buzzAndSetup = function () {
     Bangle.buzz();
-    let twentiesAlarm = S.getAlarm("twenties");
-    twentiesAlarm.t = exports.getTimeAtNextBuzz();
-    S.setAlarm("twenties", twentiesAlarm);
-    S.reload();
+    exports.setup();
   };
 
-  // If twenties is not installed anymore the alarm is deleted (catch block). Otherwise buzz and rearm as usual (try block).
-  const JS_BUZZ_REARM_OR_DELETE_ALARM = `{
-    try {
-      require('twenties').buzzAndRearm();
-      // require("twenties").setup(); // For DEBUGGING as to regenerate the javascript string to evaluate in the alarm.
-    } catch(e) {
-      require("sched").setAlarm("twenties", undefined);
-      require("sched").reload();
-      throw(e);
-    }
-  }`;
+  const JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP = `require("sched").setAlarm("twenties", undefined); require("sched").reload(); require('twenties').buzzAndSetup();`;
+
+  const S = require("sched");
 
   exports.setup = function () {
     S.setAlarm("twenties", {
@@ -48,9 +34,9 @@
       dow: 0b0111110,
       hidden: true,
       group: "Hidden",
-      js: JS_BUZZ_REARM_OR_DELETE_ALARM
+      del: true,
+      js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
     });
     S.reload();
-    require("Storage").erase("twenties.boot.js");
   };
 }

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -3,6 +3,7 @@
   // - Add settings page.
   // - Add setting for active days and hours.
   // - Add setting for buzz strength/pattern.
+  // - Add entry in settings to re-run setup.
 
   const getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -3,9 +3,8 @@
   exports.getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
-    const isLookAwayTime = (d) => {
-      d.getMinutes() % 20 === 0 && d.getSeconds() < 20
-    }
+    const isLookAwayTime = (d) =>
+      d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();
     let t = 8 * 3600000;
     if (isWorkTime(NOW)) {

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -31,7 +31,6 @@
 
   exports.setup = function () {
     const TIME_AT_NEXT_BUZZ = getTimeAtNextBuzz();
-    const TIME_AT_SETUP = new Date();
     let alarm = {
       on: true,
       t: TIME_AT_NEXT_BUZZ,
@@ -40,12 +39,6 @@
       group: "Hidden",
       js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
     };
-    if (TIME_AT_NEXT_BUZZ <
-      TIME_AT_SETUP.getHours() * 3600000 +
-      TIME_AT_SETUP.getMinutes() * 60000 +
-      TIME_AT_SETUP.getSeconds() * 1000) { // FIXME: this is done to work around a behavior in sched library. I think that is maybe a :BUG: that we should fix there. But unsure. It's around https://github.com/espruino/BangleApps/blob/master/apps/sched/boot.js#L21-L21
-      alarm.last = Date().getDate();
-    }
     S.setAlarm("twenties", alarm);
     S.reload();
   };

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -1,4 +1,9 @@
 {
+  // TODO:
+  // - Add settings page.
+  // - Add setting for active days and hours.
+  // - Add setting for buzz strength/pattern.
+
   const getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -7,8 +7,6 @@
       d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();
     let t = 8 * 3600000;
-    print(NOW);
-    print(NOW.getSeconds());
     if (isWorkTime(NOW)) {
       if (isLookAwayTime(NOW)) {
         t = NOW.getHours() * 3600000 +
@@ -24,11 +22,11 @@
   const S = require("sched");
 
   exports.buzzAndRearm = function () {
-    print("buzz");
     Bangle.buzz();
     let twentiesAlarm = S.getAlarm("twenties");
     twentiesAlarm.t = exports.getTimeAtNextBuzz();
     S.setAlarm("twenties", twentiesAlarm);
+    S.reload();
   };
 
   // If twenties is not installed anymore the alarm is deleted (catch block). Otherwise buzz and rearm as usual (try block).

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -1,0 +1,45 @@
+{ // this code is called from `twenties.boot.js` in a scope where the `alarms` variable is defined.
+
+  exports.getTimeAtNextBuzz = () => {
+    const isWorkTime = (d) =>
+      d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
+    const NOW = new Date();
+    let timeAtNextBuzz = 8 * 3600000;
+    if (isWorkTime(NOW)) {
+      timeAtNextBuzz = NOW.getHours() * 3600000 +
+        (NOW.getMinutes() + (20 - NOW.getMinutes() % 20)) * 60000;
+    }
+    return timeAtNextBuzz;
+  }
+
+  const S = require("sched");
+
+  exports.buzzRearmOrDeleteAlarm = function () {
+    try { // Verify that twenties is still installed. If not delete its alarm.
+      require("twenties");
+    } catch (e) {
+      S.setAlarm("twenties", undefined);
+      S.reload();
+      return
+    }
+    Bangle.buzz()
+    let twentiesAlarm = S.getAlarm("twenties");
+    twentiesAlarm.t = exports.getTimeAtNextBuzz();
+    S.setAlarm("twenties", twentiesAlarm);
+  }
+
+  exports.setup = function (alarms) {
+    const TIME_AT_NEXT_BUZZ = exports.getTimeAtNextBuzz()
+    alarms.push({
+      id: "twenties",
+      on: true,
+      t: TIME_AT_NEXT_BUZZ,
+      dow: 0b0111110,
+      hidden: true,
+      js: "require('twenties').buzzRearmOrDeleteAlarm()"
+    });
+    S.setAlarms(alarms);
+    S.reload();
+    require("Storage").erase("twenties.boot.js");
+  }
+}

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -1,10 +1,10 @@
-{ // this code is called from `twenties.boot.js` in a scope where the `alarms` variable is defined.
+{
 
   exports.getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
     const isLookAwayTime = (d) => {
-      d.getMinutes() % 20 === 0 && d.getseconds < 20
+      d.getMinutes() % 20 === 0 && d.getSeconds() < 20
     }
     const NOW = new Date();
     let t = 8 * 3600000;

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -34,7 +34,6 @@
       dow: 0b0111110,
       hidden: true,
       group: "Hidden",
-      del: true,
       js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
     });
     S.reload();

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -7,6 +7,8 @@
       d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();
     let t = 8 * 3600000;
+    print(NOW);
+    print(NOW.getSeconds());
     if (isWorkTime(NOW)) {
       if (isLookAwayTime(NOW)) {
         t = NOW.getHours() * 3600000 +
@@ -17,41 +19,40 @@
       }
     }
     return t;
-  }
+  };
 
   const S = require("sched");
 
   exports.buzzAndRearm = function () {
+    print("buzz");
     Bangle.buzz();
     let twentiesAlarm = S.getAlarm("twenties");
     twentiesAlarm.t = exports.getTimeAtNextBuzz();
     S.setAlarm("twenties", twentiesAlarm);
-    S.setTimer();
-  }
+  };
 
   // If twenties is not installed anymore the alarm is deleted (catch block). Otherwise buzz and rearm as usual (try block).
   const JS_BUZZ_REARM_OR_DELETE_ALARM = `{
     try {
       require('twenties').buzzAndRearm();
+      // require("twenties").setup(); // For DEBUGGING as to regenerate the javascript string to evaluate in the alarm.
     } catch(e) {
-      S.setAlarm("twenties", undefined);
-      S.reload();
+      require("sched").setAlarm("twenties", undefined);
+      require("sched").reload();
+      throw(e);
     }
-  }`
+  }`;
 
-  exports.setup = function (alarms) {
-    const TIME_AT_NEXT_BUZZ = exports.getTimeAtNextBuzz()
-    alarms.push({
-      id: "twenties",
+  exports.setup = function () {
+    S.setAlarm("twenties", {
       on: true,
-      t: TIME_AT_NEXT_BUZZ,
+      t: exports.getTimeAtNextBuzz(),
       dow: 0b0111110,
       hidden: true,
       group: "Hidden",
       js: JS_BUZZ_REARM_OR_DELETE_ALARM
     });
-    S.setAlarms(alarms);
     S.reload();
     require("Storage").erase("twenties.boot.js");
-  }
+  };
 }

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -1,5 +1,5 @@
 {
-  exports.getTimeAtNextBuzz = () => {
+  const getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
     const isLookAwayTime = (d) =>
@@ -15,7 +15,6 @@
           (NOW.getMinutes() + (20 - NOW.getMinutes() % 20)) * 60000;
       }
     }
-    print(t);
     return t;
   };
 
@@ -31,7 +30,7 @@
   const S = require("sched");
 
   exports.setup = function () {
-    const TIME_AT_NEXT_BUZZ = exports.getTimeAtNextBuzz();
+    const TIME_AT_NEXT_BUZZ = getTimeAtNextBuzz();
     const TIME_AT_SETUP = new Date();
     let alarm = {
       on: true,

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -34,7 +34,8 @@
       t: TIME_AT_NEXT_BUZZ,
       dow: 0b0111110,
       hidden: true,
-      group: "Hidden",
+      msg: "Twenties",
+      group: "Twenties",
       js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
     };
     S.setAlarm("twenties", alarm);

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -3,13 +3,21 @@
   exports.getTimeAtNextBuzz = () => {
     const isWorkTime = (d) =>
       d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
-    const NOW = new Date();
-    let timeAtNextBuzz = 8 * 3600000;
-    if (isWorkTime(NOW)) {
-      timeAtNextBuzz = NOW.getHours() * 3600000 +
-        (NOW.getMinutes() + (20 - NOW.getMinutes() % 20)) * 60000;
+    const isLookAwayTime = (d) => {
+      d.getMinutes() % 20 === 0 && d.getseconds < 20
     }
-    return timeAtNextBuzz;
+    const NOW = new Date();
+    let t = 8 * 3600000;
+    if (isWorkTime(NOW)) {
+      if (isLookAwayTime(NOW)) {
+        t = NOW.getHours() * 3600000 +
+          NOW.getMinutes() * 60000 + 20 * 1000;
+      } else {
+        t = NOW.getHours() * 3600000 +
+          (NOW.getMinutes() + (20 - NOW.getMinutes() % 20)) * 60000;
+      }
+    }
+    return t;
   }
 
   const S = require("sched");
@@ -20,12 +28,13 @@
     } catch (e) {
       S.setAlarm("twenties", undefined);
       S.reload();
-      return
+      return;
     }
     Bangle.buzz()
     let twentiesAlarm = S.getAlarm("twenties");
     twentiesAlarm.t = exports.getTimeAtNextBuzz();
     S.setAlarm("twenties", twentiesAlarm);
+    S.setTimer()
   }
 
   exports.setup = function (alarms) {

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -19,10 +19,8 @@
   };
 
   exports.buzzAndSetup = function () {
-    setTimeout(() => { // Timeout to try and not interfere with `edgeclk` redrawing the time.
-      Bangle.buzz();
-      exports.setup();
-    }, 10)
+    Bangle.buzz();
+    exports.setup();
   };
 
   const JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP = `require("sched").setAlarm("twenties", undefined); require('twenties').buzzAndSetup();`;

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -15,6 +15,7 @@
           (NOW.getMinutes() + (20 - NOW.getMinutes() % 20)) * 60000;
       }
     }
+    print(t);
     return t;
   };
 
@@ -28,14 +29,23 @@
   const S = require("sched");
 
   exports.setup = function () {
-    S.setAlarm("twenties", {
+    const TIME_AT_NEXT_BUZZ = exports.getTimeAtNextBuzz();
+    const TIME_AT_SETUP = new Date();
+    let alarm = {
       on: true,
-      t: exports.getTimeAtNextBuzz(),
+      t: TIME_AT_NEXT_BUZZ,
       dow: 0b0111110,
       hidden: true,
       group: "Hidden",
       js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
-    });
+    };
+    if ( TIME_AT_NEXT_BUZZ <
+      TIME_AT_SETUP.getHours() * 3600000 +
+      TIME_AT_SETUP.getMinutes() * 60000 +
+      TIME_AT_SETUP.getSeconds() * 1000 ) { // FIXME: this is done to work around a behavior in sched library. I think that is maybe a :BUG: that we should fix there. But unsure. It's around https://github.com/espruino/BangleApps/blob/master/apps/sched/boot.js#L21-L21
+      alarm.last = Date().getDate();
+    }
+    S.setAlarm("twenties", alarm);
     S.reload();
   };
 }

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -22,20 +22,23 @@
 
   const S = require("sched");
 
-  exports.buzzRearmOrDeleteAlarm = function () {
-    try { // Verify that twenties is still installed. If not delete its alarm.
-      require("twenties");
-    } catch (e) {
-      S.setAlarm("twenties", undefined);
-      S.reload();
-      return;
-    }
-    Bangle.buzz()
+  exports.buzzAndRearm = function () {
+    Bangle.buzz();
     let twentiesAlarm = S.getAlarm("twenties");
     twentiesAlarm.t = exports.getTimeAtNextBuzz();
     S.setAlarm("twenties", twentiesAlarm);
-    S.setTimer()
+    S.setTimer();
   }
+
+  // If twenties is not installed anymore the alarm is deleted (catch block). Otherwise buzz and rearm as usual (try block).
+  const JS_BUZZ_REARM_OR_DELETE_ALARM = `{
+    try {
+      require('twenties').buzzAndRearm();
+    } catch(e) {
+      S.setAlarm("twenties", undefined);
+      S.reload();
+    }
+  }`
 
   exports.setup = function (alarms) {
     const TIME_AT_NEXT_BUZZ = exports.getTimeAtNextBuzz()
@@ -46,7 +49,7 @@
       dow: 0b0111110,
       hidden: true,
       group: "Hidden",
-      js: "require('twenties').buzzRearmOrDeleteAlarm()"
+      js: JS_BUZZ_REARM_OR_DELETE_ALARM
     });
     S.setAlarms(alarms);
     S.reload();

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -23,7 +23,7 @@
     exports.setup();
   };
 
-  const JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP = `require("sched").setAlarm("twenties", undefined); require("sched").reload(); require('twenties').buzzAndSetup();`;
+  const JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP = `require("sched").setAlarm("twenties", undefined); require('twenties').buzzAndSetup();`;
 
   const S = require("sched");
 

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -36,6 +36,7 @@
       t: TIME_AT_NEXT_BUZZ,
       dow: 0b0111110,
       hidden: true,
+      group: "Hidden",
       js: "require('twenties').buzzRearmOrDeleteAlarm()"
     });
     S.setAlarms(alarms);

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -20,8 +20,10 @@
   };
 
   exports.buzzAndSetup = function () {
-    Bangle.buzz();
-    exports.setup();
+    setTimeout(() => { // Timeout to try and not interfere with `edgeclk` redrawing the time.
+      Bangle.buzz();
+      exports.setup();
+    }, 10)
   };
 
   const JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP = `require("sched").setAlarm("twenties", undefined); require('twenties').buzzAndSetup();`;
@@ -39,10 +41,10 @@
       group: "Hidden",
       js: JS_DELETE_ALARM_THEN_BUZZ_AND_SETUP
     };
-    if ( TIME_AT_NEXT_BUZZ <
+    if (TIME_AT_NEXT_BUZZ <
       TIME_AT_SETUP.getHours() * 3600000 +
       TIME_AT_SETUP.getMinutes() * 60000 +
-      TIME_AT_SETUP.getSeconds() * 1000 ) { // FIXME: this is done to work around a behavior in sched library. I think that is maybe a :BUG: that we should fix there. But unsure. It's around https://github.com/espruino/BangleApps/blob/master/apps/sched/boot.js#L21-L21
+      TIME_AT_SETUP.getSeconds() * 1000) { // FIXME: this is done to work around a behavior in sched library. I think that is maybe a :BUG: that we should fix there. But unsure. It's around https://github.com/espruino/BangleApps/blob/master/apps/sched/boot.js#L21-L21
       alarm.last = Date().getDate();
     }
     S.setAlarm("twenties", alarm);

--- a/apps/twenties/metadata.json
+++ b/apps/twenties/metadata.json
@@ -11,5 +11,8 @@
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "allow_emulator": true,
   "readme": "README.md",
-  "storage": [{ "name": "twenties.boot.js", "url": "boot.js" }]
+  "storage": [
+    { "name": "twenties.boot.js", "url": "boot.js" },
+    { "name": "twenties", "url": "lib.js" }
+  ]
 }

--- a/apps/twenties/metadata.json
+++ b/apps/twenties/metadata.json
@@ -2,7 +2,7 @@
   "id": "twenties",
   "name": "Twenties",
   "shortName": "Twenties",
-  "version": "0.07",
+  "version": "0.08",
   "description": "Buzzes every 20m to stand / sit and look 20ft away for 20s.",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Work in progress.

Try the current iteration at: https://thyttan.github.io/BangleApps/?id=twenties