### PR TITLE
[twenties] Fix TypeError on scheduling for the next day

### DIFF
--- a/apps/twenties/ChangeLog
+++ b/apps/twenties/ChangeLog
@@ -4,3 +4,4 @@
 0.04: Convert to boot code
 0.05: Improve energy efficiency
 0.06: Align with whole thirds of the hour.
+0.07: Fix TypeError on scheduling for the next day.

--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -11,7 +11,7 @@
       Bangle.buzz().then(() => setTimeout(Bangle.buzz, BUZZ_INTERVAL));
       setTimeout(scheduleNext, LOOP_INTERVAL);
     } else {
-      const next = new Date(now);
+      const next = new Date();
       next.setHours(8, 0, 0, 0);
       while (!isWorkTime(next)) next.setDate(next.getDate() + 1);
       setTimeout(scheduleNext, next - now);

--- a/apps/twenties/metadata.json
+++ b/apps/twenties/metadata.json
@@ -2,7 +2,7 @@
   "id": "twenties",
   "name": "Twenties",
   "shortName": "Twenties",
-  "version": "0.06",
+  "version": "0.07",
   "description": "Buzzes every 20m to stand / sit and look 20ft away for 20s.",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Twenties v0.06 introduced a bug that prevents it to set a timer for the next work day.
This error message appears in the IDE after the last buzz of the day:
```
Uncaught TypeError: Variables of type Object are not supported in date constructor
    at .boot0:52:38
            const next = new Date(now);
```