### PR TITLE
[twenties] Schedule for next day

### DIFF
--- a/apps/twenties/boot.js
+++ b/apps/twenties/boot.js
@@ -11,7 +11,7 @@
       Bangle.buzz().then(() => setTimeout(Bangle.buzz, BUZZ_INTERVAL));
       setTimeout(scheduleNext, LOOP_INTERVAL);
     } else {
-      const next = new Date();
+      const next = new Date(now+864e5); // 24 hours
       next.setHours(8, 0, 0, 0);
       while (!isWorkTime(next)) next.setDate(next.getDate() + 1);
       setTimeout(scheduleNext, next - now);


### PR DESCRIPTION
After work hours, schedule for tomorrow 8am rather than today 8am. Otherwise, the negative timeout seems to trigger instantly and the function `scheduleNext` is constantly running in the background until the next work day.