### PR TITLE
Stop new alarms set before current time of day from triggering…

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -40,3 +40,4 @@
 0.37: Ensure we always execute an alarm, even if it was >1 minute in the past. This fixes missed alarms when >1 alarm is scheduled next to each other (fix #2712)
 0.38: Fix timer going off immediately if it was long enough it went to the next day (#4220)
 0.39: Allow a press of the button to stop/snooze the alarm when it's gone off
+0.40: Prevent time-of-day alarms set via setAlarm() that have a time earlier than the current time triggering immediately after #4220 fix; schedule them for tomorrow by default to match original behavior

--- a/apps/sched/lib.js
+++ b/apps/sched/lib.js
@@ -36,6 +36,10 @@ exports.setAlarm = function(id, alarm) {
     if (alarm.on!==false) alarm.on=true;
     if (alarm.timer) { // if it's a timer, set the start time as a time from *now*
       exports.resetTimer(alarm);
+    } else { // If it's an alarm, default to triggering tomorrow if time < current time of day
+      if (alarm.last===undefined) {
+        alarm.last = alarm.t < require("time_utils").getCurrentTimeMillis() ? new Date().getDate() : 0;
+      }
     }
     alarms.push(alarm);
   }

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.39",
+  "version": "0.40",
   "author": "gfwilliams",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",


### PR DESCRIPTION
instantly after #4220 fix

Proposal to fix #4232. May need some review and testing.

<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
