### PR TITLE
runapptests.js: Workaround for incomplete emulator reset

### DIFF
--- a/bin/runapptests.js
+++ b/bin/runapptests.js
@@ -423,13 +423,17 @@ function runTest(test, testState) {
         if (test.description)
           console.log(`"${test.description}`);
         console.log(`==============================`);
-        emu.factoryReset();
-        console.log("> SENDING APP "+test.app);
-        emu.tx(command);
-        if (verbose)
-          console.log("> SENT APP");
-        emu.tx("reset()\n");
-        console.log("> RESET");
+
+        emu.stopIdle();
+        return emu.init(EMU_OPTIONS).then(() => {
+          console.log("> SENDING APP " + test.app);
+          emu.tx(command);
+          if (verbose)
+            console.log("> SENT APP");
+          emu.tx("reset()\n");
+          console.log("> RESET");
+        });
+
 
       });
 
@@ -503,7 +507,7 @@ let handleConsoleOutput = (d) => {
 
 let testState = [];
 
-emu.init({
+const EMU_OPTIONS = {
   EMULATOR : EMULATOR,
   DEVICEID : DEVICEID,
   rxCallback : (ch)=>{
@@ -512,7 +516,9 @@ emu.init({
   consoleOutputCallback: (d)=>{
     handleConsoleOutput(d);
   }
-}).then(function() {
+};
+
+emu.init(EMU_OPTIONS).then(function() {
   // Emulator is now loaded
   console.log("Loading tests");
   let p = Promise.resolve();

--- a/bin/runapptests.js
+++ b/bin/runapptests.js
@@ -469,7 +469,7 @@ function runTest(test, testState) {
       emu.stopIdle();
     });
     return p;
-  });
+  }).catch(err => console.log("Error during getAppFilesString:" + err));
 }
 
 
@@ -518,69 +518,66 @@ const EMU_OPTIONS = {
   }
 };
 
-emu.init(EMU_OPTIONS).then(function() {
-  // Emulator is now loaded
-  console.log("Loading tests");
-  let p = Promise.resolve();
-  let apps = apploader.apps;
+console.log("Loading tests");
+let p = Promise.resolve();
+let apps = apploader.apps;
 
-  apps.push(DEMOAPP);
+apps.push(DEMOAPP);
 
-  if (process.argv.includes("--id")) {
-    let f = process.argv[process.argv.indexOf("--id") + 1];
-    apps = apps.filter(e=>e.id==f);
-    if (apps.length == 0){
-      console.log("No apps left after filtering for " + f);
-      process.exit(255);
-    }
+if (process.argv.includes("--id")) {
+  let f = process.argv[process.argv.indexOf("--id") + 1];
+  apps = apps.filter(e=>e.id==f);
+  if (apps.length == 0){
+    console.log("No apps left after filtering for " + f);
+    process.exit(255);
+  }
+}
+
+apps.forEach(app => {
+  let test = DEMOTEST;
+  if (app.id != DEMOAPP.id){
+    let testFile = APP_DIR+"/"+app.id+"/test.json";
+    if (!require("fs").existsSync(testFile)) return;
+    test = JSON.parse(require("fs").readFileSync(testFile).toString());
+    test.app = app.id;
   }
 
-  apps.forEach(app => {
-    let test = DEMOTEST;
-    if (app.id != DEMOAPP.id){
-      let testFile = APP_DIR+"/"+app.id+"/test.json";
-      if (!require("fs").existsSync(testFile)) return;
-      test = JSON.parse(require("fs").readFileSync(testFile).toString());
-      test.app = app.id;
-    }
-    p = p.then(()=>{
-      const testName = test.app + (test.description ? ` - ${test.description}` : '');
-      return withTimeout(runTest(test, testState), TEST_TIMEOUT_MS, testName)
-        .catch(err => {
-          if (err.isTimeout) {
-            console.log("> TIMEOUT:", err.message);
-            // Clean up emulator state after timeout
-            try {
-              emu.stopIdle();
-            } catch (e) {
-              console.error("Failed to stop emulator after timeout:", e.message);
-            }
-            testState.push({
-              app: test.app,
-              number: -1,
-              result: "TIMEOUT",
-              description: "Test timed out",
-              error: err.message
-            });
-          } else {
-            throw err;
+  p = p.then(()=>{
+    const testName = test.app + (test.description ? ` - ${test.description}` : '');
+    return withTimeout(runTest(test, testState), TEST_TIMEOUT_MS, testName)
+      .catch(err => {
+        if (err.isTimeout) {
+          console.log("> TIMEOUT:", err.message);
+          // Clean up emulator state after timeout
+          try {
+            emu.stopIdle();
+          } catch (e) {
+            console.error("Failed to stop emulator after timeout:", e.message);
           }
-        });
+          testState.push({
+            app: test.app,
+            number: -1,
+            result: "TIMEOUT",
+            description: "Test timed out",
+            error: err.message
+          });
+        } else {
+          throw err;
+        }
+      });
     });
-  });
-  p.finally(()=>{
-    console.log("\n\n");
-    console.log("Overall results:");
-    console.table(testState);
+});
+p.finally(()=>{
+  console.log("\n\n");
+  console.log("Overall results:");
+  console.table(testState);
 
-    // Exit with appropriate code - count failures and timeouts
-    const exitCode = testState.reduce((a, c) => {
-      return a || ((c.result === "SUCCESS") ? 0 : 1);
-    }, 0);
+  // Exit with appropriate code - count failures and timeouts
+  const exitCode = testState.reduce((a, c) => {
+    return a || ((c.result === "SUCCESS") ? 0 : 1);
+  }, 0);
 
-    process.exit(exitCode);
-  });
-  return p;
+  process.exit(exitCode);
 });
 
 /*


### PR DESCRIPTION
This works around the incomplete reset in `emu.factoryReset()` by a full re-init for every test run.

I have poked around in the emulator itself, but could not get it working correctly. This is a bit slower than it was, but at least the `Uncaught SyntaxError: Got [ERASED] expected EOF` errors seem to be gone for now. I think it is somehow related to the internal state of `Storage` that does not get fully reset on factory reset.

The tests do not run in this repo because no apps changed, but you can have a look at the actions output here: [https://github.com/halemmerich/BangleApps/actions/runs/27714695139/job/81984461701](https://github.com/halemmerich/BangleApps/actions/runs/27714695139/job/81984461701)