### PR TITLE
[Alarm] fix alarms with same label overlapping in menus only showing one of them

### DIFF
--- a/apps/alarm/ChangeLog
+++ b/apps/alarm/ChangeLog
@@ -61,3 +61,4 @@
       Also fix groups when going back from 'showNewMenu'
 0.54: Hide hidden alarms from main menu by default, change in settings, see readme.
       Hide the `Hidden` setting from "New..." menu by default, change in settings.
+0.55: Fix alarms with same label overlapping in menu only showing one of them.

--- a/apps/alarm/app.js
+++ b/apps/alarm/app.js
@@ -94,8 +94,11 @@ function showMainMenu(scroll, group, scrollback) {
     const showAlarmInGroupMenu = settings.showGroup && (group ? E_GROUP === group : false);
     if (showAlarmInMainMenu && showAlarmInGroupMenu) throw new Error("Alarm should not belong to both main and group menu."); // To catch if future changes mess it up.
     if(showAlarmInMainMenu || showAlarmInGroupMenu) {
-      const label = trimLabel(getLabel(e),40);
-      menu[label] = {
+      const LABEL = trimLabel(getLabel(e),40);
+      let i = 0;
+      const addSuffix = (word, i) => i ? word + " ("+i+")" : word;
+      while (menu[addSuffix(LABEL, i)]) {i++;}
+      menu[addSuffix(LABEL, i)] = {
         value: e.on,
         onchange: (v, touch) => {
           if (touch && (2==touch.type || 145<touch.x)) { // Long touch or touched icon.

--- a/apps/alarm/metadata.json
+++ b/apps/alarm/metadata.json
@@ -2,7 +2,7 @@
   "id": "alarm",
   "name": "Alarms & Timers",
   "shortName": "Alarms",
-  "version": "0.54",
+  "version": "0.55",
   "author": "gfwilliams",
   "description": "Set alarms and timers on your Bangle",
   "icon": "app.png",


### PR DESCRIPTION
closes #4248

<!-- 

Thanks for submitting a pull request! 

Please see https://github.com/espruino/BangleApps/wiki/App-Contribution
for some suggestions that make it easier for us to merge your work.

Before submitting, please ensure that `Actions` for your
repository (https://github.com/your_user/BangleApps/actions) shows a green 
tick next to the latest commit.

If there's a red cross, click on it, then click on `build` under `nodejs.yml`
to see a list of warnings/errors and where they occur.

-->
