### PR TITLE
Allow custom apps to opt into app tests

### DIFF
--- a/bin/runapptests.js
+++ b/bin/runapptests.js
@@ -411,7 +411,7 @@ function runTest(test, testState) {
   apploader.reset();
   var app = apploader.apps.find(a=>a.id==test.app);
   if (!app) ERROR(`App ${JSON.stringify(test.app)} not found`);
-  if (app.custom) ERROR(`App ${JSON.stringify(appId)} requires HTML customisation`);
+  if (app.custom && !test.allowCustomApp) ERROR(`App ${JSON.stringify(app.id)} requires HTML customisation`);
   
   return apploader.getAppFilesString(app).then(command => {
     let p = Promise.resolve();


### PR DESCRIPTION
## Summary
- Allow `test.json` files to explicitly opt custom apps into `bin/runapptests.js` by setting `allowCustomApp`.
- Keep the existing default behavior for custom apps that do not opt in.
- Fix the custom-app error path to report `app.id` instead of the undefined `appId` variable.

## Rationale
Some custom apps still have deterministic packaged defaults and emulator-testable storage/module behavior. This keeps custom apps blocked by default while allowing app authors to opt into the documented test runner when their test intentionally covers the metadata/default-storage path rather than customizer-generated content.

## Validation
- `node -c bin/runapptests.js`
- `node bin/runapptests.js --id demoappfortestformat`
- `git diff --check`
