### PR TITLE
Add author as 'Espruino' for apps that don't have a viable author

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ and which gives information about the app for the Launcher.
   "name": "Readable name",    // readable name
   "shortName": "Short name",  // short name for launcher
   "version": "0.01",          // the version of this app
-  "author": "github_username",// username of app author (can be an array - ["author1", "author2"], used for tagging in PRs for the app)
+  "author": "github_username",// username of app author (GitHub username or 'Espruino' for anonymity)
   "description": "...",       // long description (can contain markdown)
   "icon": "icon.png",         // icon in apps/
   "screenshots" : [ { "url":"screenshot.png" } ], // optional screenshot for app

--- a/apps/a_dndtoggle/metadata.json
+++ b/apps/a_dndtoggle/metadata.json
@@ -3,6 +3,7 @@
   "name": "a_dndtoggle - Toggle Quiet Mode of the watch",
   "shortName": "A_DND Toggle",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Toggle Quiet Mode of the watch just by starting this app.",
   "icon": "a_dndtoggle.png",
   "type": "app",

--- a/apps/advcasio/metadata.json
+++ b/apps/advcasio/metadata.json
@@ -2,6 +2,7 @@
   "name": "Advanced Casio Clock",
   "shortName":"advcasio",
   "version":"0.06",
+  "author": "Espruino",
   "description": "An over-engineered clock inspired by Casio watches. It has current temperature, a timer using swipe and a scratchpad. Can be updated using a dedicated webapp.",
   "icon": "app.png",
   "tags": "clock",

--- a/apps/agenda/metadata.json
+++ b/apps/agenda/metadata.json
@@ -2,6 +2,7 @@
   "id": "agenda",
   "name": "Agenda",
   "version": "0.20",
+  "author": "Espruino",
   "description": "Simple agenda",
   "icon": "agenda.png",
   "screenshots": [{"url":"screenshot_agenda_overview.png"}, {"url":"screenshot_agenda_event1.png"}, {"url":"screenshot_agenda_event2.png"}],

--- a/apps/apphist/metadata.json
+++ b/apps/apphist/metadata.json
@@ -1,6 +1,7 @@
 { "id": "apphist",
   "name": "App History",
   "version": "0.02",
+  "author": "Espruino",
   "icon": "icon.png",
   "description": "Lets you navigate back trough the series of apps since last you were on the clock face.  Works with the software back button and hardware button.",
   "type":"bootloader",

--- a/apps/arrow/metadata.json
+++ b/apps/arrow/metadata.json
@@ -2,6 +2,7 @@
   "id": "arrow",
   "name": "Arrow Compass",
   "version": "0.06",
+  "author": "Espruino",
   "description": "Moving arrow compass that points North, shows heading, with tilt correction. Based on jeffmer's Navigation Compass",
   "icon": "arrow.png",
   "type": "app",

--- a/apps/barometer/metadata.json
+++ b/apps/barometer/metadata.json
@@ -2,6 +2,7 @@
   "name": "Barometer",
   "shortName":"Barometer",
   "version":"0.04",
+  "author": "Espruino",
   "description": "A simple barometer that displays the current air pressure",
   "icon": "barometer.png",
   "tags": "tool,outdoors",

--- a/apps/batchart/metadata.json
+++ b/apps/batchart/metadata.json
@@ -3,6 +3,7 @@
   "name": "Battery Chart",
   "shortName": "Battery Chart",
   "version": "0.14",
+  "author": "Espruino",
   "description": "A widget and an app for recording and visualizing battery percentage over time.",
   "icon": "app.png",
   "tags": "app,widget,battery,time,record,chart,tool",

--- a/apps/bbreaker/metadata.json
+++ b/apps/bbreaker/metadata.json
@@ -3,6 +3,7 @@
     "shortName":"BrickBreaker",
     "icon": "bbreaker.png",
     "version":"0.04",
+    "author": "Espruino",
     "description": "A simple BreakOut clone for the Banglejs",
     "tags": "game",
     "readme": "README.md",

--- a/apps/blockclock/metadata.json
+++ b/apps/blockclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "blockclock",
   "name": "Block Clock",
   "version": "0.1",
+  "author": "Espruino",
   "description": "This is a simple clock using minimalist 2x2 pixel numerical digits",
   "icon": "app.png",
   "type": "clock",

--- a/apps/calendar/metadata.json
+++ b/apps/calendar/metadata.json
@@ -2,6 +2,7 @@
   "id": "calendar",
   "name": "Calendar",
   "version": "0.21",
+  "author": "Espruino",
   "description": "Monthly calendar, displays holidays uploaded from the web interface and scheduled events.",
   "icon": "calendar.png",
   "screenshots": [{"url":"screenshot_calendar.png"}],

--- a/apps/cards/metadata.json
+++ b/apps/cards/metadata.json
@@ -2,6 +2,7 @@
   "id": "cards",
   "name": "Cards",
   "version": "0.05",
+  "author": "Espruino",
   "description": "Display loyalty cards",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot_cards_overview.png"}, {"url":"screenshot_cards_card1.png"}, {"url":"screenshot_cards_card2.png"}, {"url":"screenshot_cards_barcode.png"}, {"url":"screenshot_cards_qrcode.png"}],

--- a/apps/chargent/metadata.json
+++ b/apps/chargent/metadata.json
@@ -1,6 +1,7 @@
 { "id": "chargent",
   "name": "Charge Gently",
   "version": "0.07",
+  "author": "Espruino",
   "description": "When charging, reminds you to disconnect the watch to prolong battery life.",
   "icon": "icon.png",
   "type": "bootloader",

--- a/apps/chimer/metadata.json
+++ b/apps/chimer/metadata.json
@@ -2,6 +2,7 @@
   "id": "chimer",
   "name": "Chimer",
   "version": "0.05",
+  "author": "Espruino",
   "description": "A fork of Hour Chime that adds extra features such as: \n - Buzz or beep on every 60, 30 or 15 minutes. \n - Repeat Chime up to 3 times \n - Set hours to disable chime",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/clkinfofw/metadata.json
+++ b/apps/clkinfofw/metadata.json
@@ -1,6 +1,7 @@
 { "id": "clkinfofw",
   "name": "Firmware Clockinfo",
   "version":"0.02",
+  "author": "Espruino",
   "description": "For clocks that display 'clockinfo', this displays the firmware version string",
   "icon": "app.png",
   "type": "clkinfo",

--- a/apps/clkinfogps/metadata.json
+++ b/apps/clkinfogps/metadata.json
@@ -2,6 +2,7 @@
   "id": "clkinfogps",
   "name": "GPS Grid Ref Clockinfo",
   "version":"0.02",
+  "author": "Espruino",
   "description": "Clockinfo that displays the GPS OS Grid Reference",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot1.png"}],

--- a/apps/clkinfom/metadata.json
+++ b/apps/clkinfom/metadata.json
@@ -2,6 +2,7 @@
   "id": "clkinfom",
   "name": "RAM Clock Info",
   "version":"0.01",
+  "author": "Espruino",
   "description": "Clockinfo that displays % used memory",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/crowclk/metadata.json
+++ b/apps/crowclk/metadata.json
@@ -2,6 +2,7 @@
   "id": "crowclk",
   "name": "Crow Clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A simple clock based on Bold Clock that has MST3K's Crow T. Robot for a face",
   "icon": "crow_clock.png",
   "screenshots": [{"url":"screenshot_crow.png"}],

--- a/apps/daisy/metadata.json
+++ b/apps/daisy/metadata.json
@@ -1,6 +1,7 @@
 { "id": "daisy",
   "name": "Daisy",
   "version": "0.17",
+  "author": "Espruino",
   "dependencies": {"mylocation":"app"},
   "description": "A beautiful digital clock with large ring gauge, idle timer and a cyclic information line that includes, day, date, steps, battery, sunrise and sunset times",
   "icon": "app.png",

--- a/apps/dejivaisu/metadata.json
+++ b/apps/dejivaisu/metadata.json
@@ -2,6 +2,7 @@
   "id": "dejivaisu",
   "name": "Dejivaisu",
   "version": "0.1",
+  "author": "Espruino",
   "description": "A clock loosely inspired by a certain digital device. Includes an (optional) animated mascot and a seconds animation.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/deko/metadata.json
+++ b/apps/deko/metadata.json
@@ -2,6 +2,7 @@
   "id": "deko",
   "name": "Deko Clock",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Clock with Art Deko font",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/drinkcounter/metadata.json
+++ b/apps/drinkcounter/metadata.json
@@ -3,6 +3,7 @@
   "name": "Drink Counter",
   "shortName": "Drink Counter",
   "version": "0.26",
+  "author": "Espruino",
   "description": "Counts drinks you had for science. Calculates blood alcohol content (BAC)",
   "allow_emulator":true,
   "icon": "drinkcounter.png",

--- a/apps/entonclk/metadata.json
+++ b/apps/entonclk/metadata.json
@@ -2,6 +2,7 @@
   "id": "entonclk",
   "name": "Enton Clock",
   "version": "0.3",
+  "author": "Espruino",
   "description": "A simple clock using the Audiowide font with timer. ",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/ffcniftya/metadata.json
+++ b/apps/ffcniftya/metadata.json
@@ -2,6 +2,7 @@
   "id": "ffcniftya",
   "name": "Nifty-A Clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A nifty clock with time and date",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot_nifty.png"}],

--- a/apps/ffcniftyb/metadata.json
+++ b/apps/ffcniftyb/metadata.json
@@ -2,6 +2,7 @@
   "id": "ffcniftyb",
   "name": "Nifty-B Clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A nifty clock (series B) with time, date and colour configuration",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/flashcards/metadata.json
+++ b/apps/flashcards/metadata.json
@@ -3,6 +3,7 @@
   "name": "Flash Cards",
   "shortName": "Flash Cards",
   "version": "1.32",
+  "author": "Espruino",
   "description": "Flash cards based on public Trello board",
   "readme":"README.md",
   "screenshots" : [ { "url":"screenshot.png" }],  

--- a/apps/flipper/metadata.json
+++ b/apps/flipper/metadata.json
@@ -3,6 +3,7 @@
   "id": "flipper",
   "name": "flipper",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Switch between dark and light theme and vice versa, combine with pattern launcher and swipe to flip.",
   "readme":"README.md",
   "screenshots": [{"url":"app.png"}],

--- a/apps/fontclock/metadata.json
+++ b/apps/fontclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "fontclock",
   "name": "Font Clock",
   "version": "0.01",
+  "author": "Espruino",
   "description": "Choose the font and design of clock face from a library of available designs",
   "icon": "fontclock.png",
   "type": "clock",

--- a/apps/gpssetup/metadata.json
+++ b/apps/gpssetup/metadata.json
@@ -3,6 +3,7 @@
   "name": "GPS Setup",
   "shortName": "GPS Setup",
   "version": "0.04",
+  "author": "Espruino",
   "description": "Configure the GPS power options and store them in the GPS nvram",
   "icon": "gpssetup.png",
   "tags": "gps,tools,outdoors",

--- a/apps/gpstouch/metadata.json
+++ b/apps/gpstouch/metadata.json
@@ -2,6 +2,7 @@
   "id": "gpstouch",
   "name": "GPS Touch",
   "version": "0.02",
+  "author": "Espruino",
   "description": "A touch based GPS watch, shows OS map reference",
   "icon": "gpstouch.png",
   "screenshots": [{"url":"screenshot4.png"},{"url":"screenshot2.png"},{"url":"screenshot3.png"},{"url":"screenshot1.png"}],

--- a/apps/hourstrike/metadata.json
+++ b/apps/hourstrike/metadata.json
@@ -3,6 +3,7 @@
   "name": "Hour Strike",
   "shortName": "Hour Strike",
   "version": "0.09",
+  "author": "Espruino",
   "description": "Strike the clock on the hour. A great tool to remind you an hour has passed!",
   "icon": "app-icon.png",
   "tags": "tool,alarm",

--- a/apps/hwid_a_battery_widget/metadata.json
+++ b/apps/hwid_a_battery_widget/metadata.json
@@ -4,6 +4,7 @@
   "shortName":"H Battery Widget",
   "icon": "widget.png",
   "version":"0.11",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/hworldclock/metadata.json
+++ b/apps/hworldclock/metadata.json
@@ -3,6 +3,7 @@
   "name": "Hanks World Clock",
   "shortName": "Hanks World Clock",
   "version": "0.37",
+  "author": "Espruino",
   "description": "Current time zone plus up to three others",
   "allow_emulator":true,
   "icon": "app.png",

--- a/apps/impwclock/metadata.json
+++ b/apps/impwclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "impwclock",
   "name": "Imprecise Word Clock",
   "version": "0.07",
+  "author": "Espruino",
   "description": "Imprecise word clock for vacations, weekends, and those who never need accurate time.",
   "icon": "clock-impword.png",
   "type": "clock",

--- a/apps/intervalTimer/metadata.json
+++ b/apps/intervalTimer/metadata.json
@@ -4,6 +4,7 @@
   "shortName":"Interval Timer",
   "icon": "app.png",
   "version":"0.01",
+  "author": "Espruino",
   "description": "Interval Timer for workouts, HIIT, or whatever else.",
   "tags": "timer,interval,hiit,workout",
   "readme":"README.md",

--- a/apps/jbm8b/metadata.json
+++ b/apps/jbm8b/metadata.json
@@ -3,6 +3,7 @@
   "name": "Magic 8 Ball",
   "shortName": "Magic 8 Ball",
   "version": "0.03",
+  "author": "Espruino",
   "description": "A simple fortune telling app",
   "icon": "app.png",
   "tags": "game",

--- a/apps/jbm8b_IT/metadata.json
+++ b/apps/jbm8b_IT/metadata.json
@@ -3,6 +3,7 @@
   "name": "Magic 8 Ball Italiano",
   "shortName": "Magic 8 Ball IT",
   "version": "0.01",
+  "author": "Espruino",
   "description": "La palla predice il futuro",
   "icon": "app.png",
   "screenshots": [{"url":"bangle1-magic-8-ball-italiano-screenshot.png"}],

--- a/apps/kanagsec/metadata.json
+++ b/apps/kanagsec/metadata.json
@@ -3,6 +3,7 @@
 	"name": "Kanagawa clock",
 	"shortName":"kanagawa",
 	"version": "0.04",
+	"author": "Espruino",
 	"description": "A clock that displays the great wave of kanagawa (image from wikipedia) with seconds in active mode.",
 	"icon": "app.png",
 	"tags": "clock,kanagawa,wave",

--- a/apps/kitchen/metadata.json
+++ b/apps/kitchen/metadata.json
@@ -2,6 +2,7 @@
   "id": "kitchen",
   "name": "Kitchen Combo",
   "version": "0.15",
+  "author": "Espruino",
   "description": "Combination of the Stepo, Walkersclock, Arrow and Waypointer apps into a multiclock format. 'Everything but the kitchen sink'",
   "icon": "kitchen.png",
   "type": "clock",

--- a/apps/largeclock/metadata.json
+++ b/apps/largeclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "largeclock",
   "name": "Large Clock",
   "version": "0.11",
+  "author": "Espruino",
   "description": "A readable and informational digital watch, with date, seconds and moon phase",
   "icon": "largeclock.png",
   "type": "clock",

--- a/apps/lato/metadata.json
+++ b/apps/lato/metadata.json
@@ -2,6 +2,7 @@
   "id": "lato",
   "name": "Lato",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A Lato Font clock with fast load and clock_info",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/limelight/metadata.json
+++ b/apps/limelight/metadata.json
@@ -2,6 +2,7 @@
   "id": "limelight",
   "name": "Limelight",
   "version": "0.04",
+  "author": "Espruino",
   "description": "Simple analogue clock (with configurable fonts) based on the work of @Andreas_Rozek (Simple_Clock)",
   "icon": "limelight.png",
   "readme":"README.md",

--- a/apps/lunaclock/metadata.json
+++ b/apps/lunaclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "lunaclock",
   "name": "Luna Clock",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Simple clock face inspired by the moon.",
   "icon": "app.png",
   "screenshots": [{"url":"screenshot.png"}],

--- a/apps/matrixclock/metadata.json
+++ b/apps/matrixclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "matrixclock",
   "name": "Matrix Clock",
   "version": "0.07",
+  "author": "Espruino",
   "description": "inspired by The Matrix, a clock of the same style",
   "icon": "matrixclock.png",
   "screenshots": [{"url":"matrix_green_on_black.jpg"}],

--- a/apps/measuretime/metadata.json
+++ b/apps/measuretime/metadata.json
@@ -2,6 +2,7 @@
   "id": "measuretime",
   "name": "Measure Time",
   "version": "0.3",
+  "author": "Espruino",
   "description": "Measure Time in a fancy way.",
   "icon": "measuretime_icon.png",
   "screenshots": [

--- a/apps/mylocation/metadata.json
+++ b/apps/mylocation/metadata.json
@@ -5,6 +5,7 @@
   "type": "settings",
   "screenshots": [{"url":"screenshot_1.png"}],
   "version": "0.11",
+  "author": "Espruino",
   "description": "Sets and stores the latitude and longitude of your preferred City. It can be set from GPS, waypoints or webinterface. `mylocation.json` can be used by other apps that need your main location. See README for details.",
   "readme": "README.md",
   "tags": "tool,utility",

--- a/apps/nesclock/metadata.json
+++ b/apps/nesclock/metadata.json
@@ -3,6 +3,7 @@
   "name": "NES Clock",
   "shortName": "NES Clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A clock themed after different NES title screens.",
   "readme":"README.md",
   "icon": "app.png",

--- a/apps/nightwatch/metadata.json
+++ b/apps/nightwatch/metadata.json
@@ -7,6 +7,7 @@
   "icon":"nightwatch.icon.png",
   "screenshots" : [ { "url":"screenshot.png","url":"screenshot2.png" } ],
   "version":"1.1",
+  "author": "Espruino",
   "description":"Logs sensor readings (currently T and p), show min/max and graph.",
   "tags": "tools,outdoors",
   "storage": [

--- a/apps/oxofocus/metadata.json
+++ b/apps/oxofocus/metadata.json
@@ -3,6 +3,7 @@
   "shortName":"Oxo Focus",
   "icon": "app.png",
   "version":"0.02",
+  "author": "Espruino",
   "description": "Play the computer while it learns to play Naughts and Crosses!",
   "readme": "README.md",
   "tags": "game",

--- a/apps/pastel/metadata.json
+++ b/apps/pastel/metadata.json
@@ -3,6 +3,7 @@
   "name": "Pastel Clock",
   "shortName": "Pastel",
   "version": "0.20",
+  "author": "Espruino",
   "description": "A Configurable clock with custom fonts, background and weather display. Has a cyclic information line that includes, day, date, battery, sunrise and sunset times",
   "icon": "pastel.png",
   "dependencies": {"mylocation":"app","weather":"app"},

--- a/apps/pebble/metadata.json
+++ b/apps/pebble/metadata.json
@@ -3,6 +3,7 @@
   "name": "Pebble Clock",
   "shortName": "Pebble",
   "version": "0.11",
+  "author": "Espruino",
   "description": "A pebble style clock to keep the rebellion going",
   "readme": "README.md",
   "icon": "pebble.png",

--- a/apps/pizzatimer/metadata.json
+++ b/apps/pizzatimer/metadata.json
@@ -3,6 +3,7 @@
   "name": "Pizza Timer",
   "shortName": "Pizza Timer",
   "version": "0.02",
+  "author": "Espruino",
   "description": "A timer app for when you cook Pizza. Some say it can also time other things",
   "icon": "pizza.png",
   "tags": "timer,tool,pizza",

--- a/apps/pokewalk/metadata.json
+++ b/apps/pokewalk/metadata.json
@@ -2,6 +2,7 @@
   "id": "pokewalk",
   "name": "pokewalk clock",
   "version": "0.01",
+  "author": "Espruino",
   "description": "A very simple watchface featuring a Pokemon trainer on a walk.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/pomodo/metadata.json
+++ b/apps/pomodo/metadata.json
@@ -2,6 +2,7 @@
   "id": "pomodo",
   "name": "Pomodoro",
   "version": "0.02",
+  "author": "Espruino",
   "description": "A simple pomodoro timer.",
   "icon": "pomodoro.png",
   "type": "app",

--- a/apps/presentation_timer/metadata.json
+++ b/apps/presentation_timer/metadata.json
@@ -2,6 +2,7 @@
   "id": "presentation_timer",
   "name": "Presentation Timer",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A touch based presentation timer for Bangle JS 2",
   "icon": "presentation_timer.png",
   "screenshots": [{"url":"screenshot1.png"},{"url":"screenshot2.png"},{"url":"screenshot3.png"},{"url":"screenshot4.png"}],

--- a/apps/primetimelato/metadata.json
+++ b/apps/primetimelato/metadata.json
@@ -1,6 +1,7 @@
 { "id": "primetimelato",
   "name": "Prime Lato",
   "version": "0.04",  
+  "author": "Espruino",
   "type": "clock",
   "description": "A clock that tells you the primes of the time in the Lato font",
   "icon": "app.png",

--- a/apps/pushups/metadata.json
+++ b/apps/pushups/metadata.json
@@ -3,6 +3,7 @@
   "name": "Pushups",
   "shortName": "Pushups",
   "version": "0.1",
+  "author": "Espruino",
   "description": "Pushups countdown using the accelerometer.",
   "allow_emulator":false,
   "icon": "pushups.png",

--- a/apps/qalarm/metadata.json
+++ b/apps/qalarm/metadata.json
@@ -4,6 +4,7 @@
   "shortName": "Q Alarm",
   "icon": "app.png",
   "version": "0.05",
+  "author": "Espruino",
   "description": "[Not recommended - use 'Alarm & Timer' app] Alarm and timer app with days of week and 'hard' option.",
   "tags": "tool,alarm,widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],

--- a/apps/rclock/metadata.json
+++ b/apps/rclock/metadata.json
@@ -3,6 +3,7 @@
   "name": "Round clock with seconds,  minutes and date",
   "shortName": "Round Clock",
   "version": "0.08",
+  "author": "Espruino",
   "description": "Designed round clock with ticks for minutes and seconds and heart rate indication",
   "icon": "app.png",
   "type": "clock",

--- a/apps/rebble/metadata.json
+++ b/apps/rebble/metadata.json
@@ -3,6 +3,7 @@
   "name": "Rebble Clock",
   "shortName": "Rebble",
   "version": "0.19",
+  "author": "Espruino",
   "description": "A Pebble style clock, with configurable background, three sidebars including steps, day, date, sunrise, sunset, long live the rebellion",
   "readme": "README.md",
   "icon": "rebble.png",

--- a/apps/red7game/metadata.json
+++ b/apps/red7game/metadata.json
@@ -3,6 +3,7 @@
   "shortName" : "Red 7",
   "icon": "icon.png",
   "version":"0.07",
+  "author": "Espruino",
   "description": "An implementation of the card game Red 7 for your watch. Play against the AI and be the last player still in the game to win!",
   "tags": "game",
   "supports":["BANGLEJS2"],

--- a/apps/rings/metadata.json
+++ b/apps/rings/metadata.json
@@ -3,6 +3,7 @@
   "name": "Rings - an animated watchface",
   "shortName": "Rings",
   "version": "0.03",
+  "author": "Espruino",
   "description": "Ring based watchface that animates to show the date when unlocked. Inspired by / remixed from Rinkulainen.",
   "icon": "app.png",
   "screenshots": [{

--- a/apps/rndmclk/metadata.json
+++ b/apps/rndmclk/metadata.json
@@ -2,6 +2,7 @@
   "id": "rndmclk",
   "name": "Random Clock Loader",
   "version": "0.04",
+  "author": "Espruino",
   "description": "Load a different clock whenever the LCD is switched on.",
   "icon": "rndmclk.png",
   "type": "widget",

--- a/apps/rtorch/metadata.json
+++ b/apps/rtorch/metadata.json
@@ -3,6 +3,7 @@
   "name": "Red Torch",
   "shortName": "RedTorch",
   "version": "0.03",
+  "author": "Espruino",
   "description": "Turns screen RED to help you see in the dark without breaking your night vision. Select from the launcher or on Bangle 1 press BTN3,BTN1,BTN3,BTN1 quickly to start when in any app that shows widgets",
   "icon": "app.png",
   "tags": "tool,torch",

--- a/apps/seiko-5actus/metadata.json
+++ b/apps/seiko-5actus/metadata.json
@@ -4,6 +4,7 @@
     "icon": "seiko-5actus.png",
     "screenshots": [{"url":"screenshot.png"}],
     "version": "0.04",
+    "author": "Espruino",
     "description": "A watch designed after then Seiko 5actus from the 1970's",
     "tags": "clock",
     "type": "clock",

--- a/apps/shortcuts/metadata.json
+++ b/apps/shortcuts/metadata.json
@@ -3,6 +3,7 @@
   "name": "Shortcuts",
   "shortName": "Shortcuts",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Quickly load your favourite apps from (almost) any watch face.",
   "icon": "app.png",
   "type": "bootloader",

--- a/apps/simplest/metadata.json
+++ b/apps/simplest/metadata.json
@@ -2,6 +2,7 @@
   "id": "simplest",
   "name": "Simplest Clock",
   "version": "0.06",
+  "author": "Espruino",
   "description": "The simplest working clock, acts as a tutorial piece",
   "readme": "README.md",
   "icon": "simplest.png",

--- a/apps/simplestpp/metadata.json
+++ b/apps/simplestpp/metadata.json
@@ -3,6 +3,7 @@
   "name": "Simplest++ Clock",
   "shortName": "Simplest++",
   "version": "0.04",
+  "author": "Espruino",
   "description": "The simplest working clock, with clock_info, acts as a tutorial piece",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/slidingtext/metadata.json
+++ b/apps/slidingtext/metadata.json
@@ -2,6 +2,7 @@
   "id": "slidingtext",
   "name": "Sliding Clock",
   "version": "0.12",
+  "author": "Espruino",
   "description": "Inspired by the Pebble sliding clock, old times are scrolled off the screen and new times on. You are also able to change language on the fly so you can see the time written in other languages using button 1. Currently English, French, Japanese, Spanish and German are supported",
   "icon": "slidingtext.png",
   "screenshots": [{"url":"slidingtext-screenshot.english.png"},{"url":"slidingtext-screenshot.english2.png"},{"url":"slidingtext-screenshot.hybrid.png"}],

--- a/apps/smtswch/metadata.json
+++ b/apps/smtswch/metadata.json
@@ -3,6 +3,7 @@
   "name": "Smart Switch",
   "shortName": "Smart Switch",
   "version": "0.01",
+  "author": "Espruino",
   "description": "Using EspruinoHub, control your smart devices on and off via Bluetooth Low Energy!",
   "icon": "app.png",
   "type": "app",

--- a/apps/solarclock/metadata.json
+++ b/apps/solarclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "solarclock",
   "name": "Solar Clock",
   "version": "0.03",
+  "author": "Espruino",
   "description": "Using your current or chosen location the solar watch face shows the Sun's sky position, time and date. Also allows you to wind backwards and forwards in time to see the sun's position",
   "icon": "solar_clock.png",
   "type": "clock",

--- a/apps/stacker/metadata.json
+++ b/apps/stacker/metadata.json
@@ -2,6 +2,7 @@
   "name": "Stacker",
   "shortName":"Stacker",
   "version": "0.03",
+  "author": "Espruino",
   "description": "Game of Stacking",
   "icon": "app.png",
   "tags": "game",

--- a/apps/stepo/metadata.json
+++ b/apps/stepo/metadata.json
@@ -2,6 +2,7 @@
   "id": "stepo",
   "name": "Stepometer Clock",
   "version": "0.03",
+  "author": "Espruino",
   "description": "A large font watch, displays step count in a doughnut guage and warns of low battery, requires one of the steps widgets to be installed",
   "icon": "stepo.png",
   "type": "clock",

--- a/apps/stetho/metadata.json
+++ b/apps/stetho/metadata.json
@@ -2,6 +2,7 @@
   "id": "stetho",
   "name": "Stethoscope",
   "version": "0.01",
+  "author": "Espruino",
   "description": "Hear your heart rate",
   "icon": "stetho.png",
   "tags": "health",

--- a/apps/stopwatch/metadata.json
+++ b/apps/stopwatch/metadata.json
@@ -2,6 +2,7 @@
   "id": "stopwatch",
   "name": "Stopwatch Touch",
   "version": "0.07",
+  "author": "Espruino",
   "description": "A touch based stop watch for Bangle JS 2",
   "icon": "stopwatch.png",
   "screenshots": [{"url":"screenshot1.png"},{"url":"screenshot2.png"},{"url":"screenshot3.png"}],

--- a/apps/sweepclock/metadata.json
+++ b/apps/sweepclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "sweepclock",
   "name": "Sweep Clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "Smooth sweep secondhand with single hour numeral. Use button 1 to toggle the numeral font, button 3 to change the colour theme and button 4 to change the date placement",
   "icon": "sweepclock.png",
   "type": "clock",

--- a/apps/swiperclocklaunch/metadata.json
+++ b/apps/swiperclocklaunch/metadata.json
@@ -2,6 +2,7 @@
   "id": "swiperclocklaunch",
   "name": "Swiper Clock Launch",
   "version": "0.07",
+  "author": "Espruino",
   "description": "Navigate between clock and launcher with Swipe action",
   "icon": "swiperclocklaunch.png",
   "type": "bootloader",

--- a/apps/synthwave/metadata.json
+++ b/apps/synthwave/metadata.json
@@ -2,6 +2,7 @@
   "id": "synthwave",
   "name": "synthwave clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A watchface with an animated 3D scene.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/tabata/metadata.json
+++ b/apps/tabata/metadata.json
@@ -3,6 +3,7 @@
   "name": "Tabata",
   "shortName": "Tabata - Control High-Intensity Interval Training",
   "version": "0.03",
+  "author": "Espruino",
   "description": "Control high-intensity interval training (according to tabata: https://en.wikipedia.org/wiki/Tabata_method).",
   "icon": "tabata.png",
   "tags": "workout,health",

--- a/apps/tapelauncher/metadata.json
+++ b/apps/tapelauncher/metadata.json
@@ -2,6 +2,7 @@
   "id": "tapelauncher",
   "name": "Tape Launcher",
   "version": "0.02",
+  "author": "Espruino",
   "description": "An App launcher, icons displayed in a horizontal tape, swipe or use buttons",
   "icon": "icon.png",
   "type": "launch",

--- a/apps/thering/metadata.json
+++ b/apps/thering/metadata.json
@@ -1,6 +1,7 @@
 { "id": "thering",
   "name": "The Ring",
   "version": "0.03",
+  "author": "Espruino",
   "description": "A proof of concept clock with large ring guage for steps using pre-set images, acts as a tutorial piece for discussion",
   "icon": "app.png",
   "tags": "clock",

--- a/apps/timerclk/metadata.json
+++ b/apps/timerclk/metadata.json
@@ -3,6 +3,7 @@
 	"name": "Timer Clock",
 	"shortName":"Timer Clock",
 	"version": "0.07",
+	"author": "Espruino",
 	"description": "A clock with stopwatches, timers and alarms build in.",
 	"icon": "app-icon.png",
 	"type": "clock",

--- a/apps/tinycmc/metadata.json
+++ b/apps/tinycmc/metadata.json
@@ -4,6 +4,7 @@
   "shortName":"tinycmc",
   "icon": "icon.png",
   "version": "0.02",
+  "author": "Espruino",
   "description": "TinyCMC is a bangle.js Coinmarketcap API client",
   "type": "app",
   "tags": "tools",

--- a/apps/twentyeightbysix/metadata.json
+++ b/apps/twentyeightbysix/metadata.json
@@ -3,6 +3,7 @@
   "shortName": "28x6",
   "icon": "app.png",
   "version":"0.04",
+  "author": "Espruino",
   "description": "A 28 Hour, 6 Day Week Clock. Lines up with a 24 hour, 7 Day Week Clock every Monday.",
   "tags": "clock",
   "storage": [

--- a/apps/vectorclock/metadata.json
+++ b/apps/vectorclock/metadata.json
@@ -2,6 +2,7 @@
   "id": "vectorclock",
   "name": "Vector Clock",
   "version": "0.10",
+  "author": "Espruino",
   "description": "A digital clock that uses the built-in vector font.",
   "icon": "app.png",
   "type": "clock",

--- a/apps/walkersclock/metadata.json
+++ b/apps/walkersclock/metadata.json
@@ -3,6 +3,7 @@
   "name": "Walkers Clock",
   "shortName": "Walkers Clock",
   "version": "0.05",
+  "author": "Espruino",
   "description": "A large font watch, displays steps, can switch GPS on/off, displays grid reference",
   "icon": "walkersclock48.png",
   "type": "clock",

--- a/apps/warpdrive/metadata.json
+++ b/apps/warpdrive/metadata.json
@@ -2,6 +2,7 @@
   "id": "warpdrive",
   "name": "warpdrive clock",
   "version": "0.04",
+  "author": "Espruino",
   "description": "A watchface with an animated 3D scene.",
   "readme": "README.md",
   "icon": "app.png",

--- a/apps/waypointer/metadata.json
+++ b/apps/waypointer/metadata.json
@@ -2,6 +2,7 @@
   "id": "waypointer",
   "name": "Way Pointer",
   "version": "0.11",
+  "author": "Espruino",
   "description": "Navigate to a waypoint using the GPS for bearing and compass to point way, uses the same waypoint interface as GPS Navigation",
   "icon": "waypointer.png",
   "tags": "tool,outdoors,gps",

--- a/apps/weatherClock/metadata.json
+++ b/apps/weatherClock/metadata.json
@@ -3,6 +3,7 @@
   "name": "Weather Clock",
   "shortName": "Weather Clock",
   "version": "0.07",
+  "author": "Espruino",
   "description": "A clock which displays current weather conditions (requires Gadgetbridge and Weather apps).",
   "icon": "app.png",
   "dependencies": {"weather":"app"},

--- a/apps/widbata/metadata.json
+++ b/apps/widbata/metadata.json
@@ -5,6 +5,7 @@
   "icon": "widbata.png",
   "screenshots": [{"url":"screenshot_widbata_1.png"}],
   "version":"0.05",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2", "BANGLEJS3"],
   "readme": "README.md",

--- a/apps/widbatc/metadata.json
+++ b/apps/widbatc/metadata.json
@@ -5,6 +5,7 @@
   "icon": "icon.png",
   "screenshots": [{"url":"screenshot.png"}],
   "version":"0.02",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2", "BANGLEJS3"],
   "readme": "README.md",

--- a/apps/widbgjs/metadata.json
+++ b/apps/widbgjs/metadata.json
@@ -5,6 +5,7 @@
   "icon": "screenshot.png",
   "screenshots": [{"url":"screenshot.png"}],
   "version": "0.04",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/widcom/metadata.json
+++ b/apps/widcom/metadata.json
@@ -2,6 +2,7 @@
   "id": "widcom",
   "name": "Compass Widget",
   "version": "0.02",
+  "author": "Espruino",
   "description": "Tiny widget to show the power on/off status of the Compass",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widdevst/metadata.json
+++ b/apps/widdevst/metadata.json
@@ -1,6 +1,7 @@
 { "id": "widdevst",
   "name": "Device Status Widget",
   "version": "0.05",
+  "author": "Espruino",
   "description": "Shows power status of Bluetooth, Compass, GPS and Heart Rate Monitor as well as storage and memory usage.",
   "icon": "icon.png",
   "type": "widget",

--- a/apps/widgps/metadata.json
+++ b/apps/widgps/metadata.json
@@ -2,6 +2,7 @@
   "id": "widgps",
   "name": "GPS Widget",
   "version": "0.09",
+  "author": "Espruino",
   "description": "Tiny widget to show the power and fix status of the GPS/GNSS",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widhrt/metadata.json
+++ b/apps/widhrt/metadata.json
@@ -2,6 +2,7 @@
   "id": "widhrt",
   "name": "HRM Widget",
   "version": "0.06",
+  "author": "Espruino",
   "description": "Tiny widget to show the power on/off status of the Heart Rate Monitor",
   "icon": "widget.png",
   "type": "widget",

--- a/apps/widhrtplus/metadata.json
+++ b/apps/widhrtplus/metadata.json
@@ -4,6 +4,7 @@
   "icon": "widget.png",
   "screenshots": [{"url":"screenshot.png"}],
   "version":"0.01",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS2"],
   "readme": "README.md",

--- a/apps/widpa/metadata.json
+++ b/apps/widpa/metadata.json
@@ -5,6 +5,7 @@
   "icon": "screenshot_widpa.png",
   "screenshots": [{"url":"screenshot_widpa.png"}],
   "version":"0.04",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/widpb/metadata.json
+++ b/apps/widpb/metadata.json
@@ -5,6 +5,7 @@
   "icon": "screenshot_widpb.png",
   "screenshots": [{"url":"screenshot_widpb.png"}],
   "version":"0.05",
+  "author": "Espruino",
   "type": "widget",
   "supports": ["BANGLEJS", "BANGLEJS2"],
   "readme": "README.md",

--- a/apps/widtemp/metadata.json
+++ b/apps/widtemp/metadata.json
@@ -2,6 +2,7 @@
     "id": "widtemp",
     "name": "Temperature widget",
     "version": "0.02",
+    "author": "Espruino",
     "description": "A temperature widget, showing the current internal temperature",
     "readme": "README.md",
     "icon": "widtemp.png",

--- a/apps/wohrm/metadata.json
+++ b/apps/wohrm/metadata.json
@@ -2,6 +2,7 @@
   "id": "wohrm",
   "name": "Workout HRM",
   "version": "0.10",
+  "author": "Espruino",
   "description": "Workout heart rate monitor notifies you with a buzz if your heart rate goes above or below the set limits.",
   "icon": "app.png",
   "type": "app",


### PR DESCRIPTION
Stems from #4239, adds a line in metadata:
`author: "Espruino"` to apps that don't have an author.