### PR TITLE
[angles] Restore display orientation on exit

### DIFF
--- a/apps/angles/ChangeLog
+++ b/apps/angles/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New App!
 0.02: Minor code improvements
+0.03: Restore screen orientation

--- a/apps/angles/app.js
+++ b/apps/angles/app.js
@@ -45,3 +45,8 @@ Bangle.setUI({
     draw();
   }
 });
+
+// Restore the original screen rotation
+E.on('kill', function() {
+    g.setRotation(0 | require('Storage').readJSON("setting.json").rotate);
+});

--- a/apps/angles/metadata.json
+++ b/apps/angles/metadata.json
@@ -2,7 +2,7 @@
   "id": "angles",
   "name": "Angles (Spirit Level)",
   "shortName": "Angles",
-  "version": "0.02",
+  "version": "0.03",
   "author": "gfwilliams",
   "description": "Shows Angle or Relative angle in degrees (Digital Protractor/Inclinometer). Place Bangle sideways against a surface with the button facing away for best readings.",
   "icon": "icon.png",


### PR DESCRIPTION
The Angles app rotates the display sideways, and it remains in that orientation after going back to the clock. This adds an E.kill event to restore the preferred orientation on exit.