### PR TITLE
[C25K] Remember the day and week of program

### DIFF
--- a/apps/c25k/ChangeLog
+++ b/apps/c25k/ChangeLog
@@ -2,3 +2,4 @@
 0.02: Add rep info to time screen
 0.03: Add option to pause/resume workout (Bangle.js 1 only)
 0.04: Add possibility of creating a custom exercise
+0.05: Remember the day and week of program

--- a/apps/c25k/app.js
+++ b/apps/c25k/app.js
@@ -1,5 +1,6 @@
-var week = 1; // Stock plan: programme week
-var day = 1; // Stock plan: programe day
+var settings = require('Storage').readJSON("c25k.json", true) || {week: 1, day: 1};
+var week = settings.week; // Stock plan: programme week
+var day = settings.day; // Stock plan: programe day
 var run = 1; // Custom plan: running time
 var walk = 0; // Custom plan: walking time
 var reps = 1; // Custom plan: repetition count
@@ -18,6 +19,18 @@ var pauseOrResumeWatch; // Watch for button presses to pause/resume countdown
 var defaultFontSize = (process.env.HWVERSION == 2) ? 7 : 9; // Default font size, Banglejs 2 has smaller
 var activityBgColour; // Background colour of current activity
 var currentActivity; // To store the current activity
+
+function incrementDay() {
+  if (day == 3) {
+    week = week < 8 ? week+1 : 1;
+    day = 1;
+  } else {
+    day += 1;
+  }
+  settings.week = week;
+  settings.day = day;
+  require('Storage').writeJSON("c25k.json", settings);
+}
 
 function outOfTime() {
   buzz();
@@ -226,6 +239,7 @@ var mainmenu = {
   "Custom run": function() { E.showMenu(custommenu); },
   "Start": function() {
     currentActivity = PLAN[week - 1][day -1];
+    incrementDay();
     startActivity();
   },
   "Exit": function() { load(); },

--- a/apps/c25k/metadata.json
+++ b/apps/c25k/metadata.json
@@ -2,7 +2,7 @@
   "id": "c25k",
   "name": "C25K",
   "icon": "app.png",
-  "version":"0.04",
+  "version":"0.05",
   "author": "Erovia",
   "description": "Unofficial app for the Couch to 5k training plan",
   "readme": "README.md",


### PR DESCRIPTION
The main screen of C25K proposes choosing a day and week, then starting the running program for that day. Currently it always starts at week 1 day 1, and it's the user who has to remember their progress and set the correct day. 

This adds a settings file to remember the day and week, and increments it automatically.

`incrementDay()` is called when the running program is started from the app's main menu, rather than when the exercise finishes, so that the function isn't triggered by custom exercises.