### PR TITLE
[twenties] Fix missing last buzz at 18:00:20

### DIFF
--- a/apps/twenties/ChangeLog
+++ b/apps/twenties/ChangeLog
@@ -6,3 +6,4 @@
 0.06: Align with whole thirds of the hour.
 0.07: Fix TypeError on scheduling for the next day.
 0.08: Refactor to use the scheduling library.
+0.09: Fix missing last buzz

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -6,8 +6,9 @@
   // - Add entry in settings to re-run setup.
 
   const getTimeAtNextBuzz = () => {
-    const isWorkTime = (d) =>
-      d.getDay() % 6 && d.getHours() >= 8 && d.getHours() < 18;
+    let workStart = new Date().setHours(8, 0, 0, 0);
+    let workdEnd = new Date().setHours(18, 0, 20, 0);
+    const isWorkTime = (d) => d.getDay() % 6 && d >= workStart && d < workdEnd;
     const isLookAwayTime = (d) =>
       d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -6,13 +6,15 @@
   // - Add entry in settings to re-run setup.
 
   const getTimeAtNextBuzz = () => {
-    let workStart = new Date().setHours(8, 0, 0, 0);
-    let workEnd = new Date().setHours(18, 0, 20, 0);
+    let workStart = new Date();
+    let workEnd = new Date();
+    workStart.setHours(8, 0, 0, 0);
+    workEnd.setHours(18, 0, 20, 0);
     const isWorkTime = (d) => d.getDay() % 6 && d >= workStart && d < workEnd;
     const isLookAwayTime = (d) =>
       d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();
-    let t = 8 * 3600000;
+    let t = workStart.getHours() * 3600000 + workStart.getMinutes() * 60000;
     if (isWorkTime(NOW)) {
       if (isLookAwayTime(NOW)) {
         t = NOW.getHours() * 3600000 +

--- a/apps/twenties/lib.js
+++ b/apps/twenties/lib.js
@@ -7,8 +7,8 @@
 
   const getTimeAtNextBuzz = () => {
     let workStart = new Date().setHours(8, 0, 0, 0);
-    let workdEnd = new Date().setHours(18, 0, 20, 0);
-    const isWorkTime = (d) => d.getDay() % 6 && d >= workStart && d < workdEnd;
+    let workEnd = new Date().setHours(18, 0, 20, 0);
+    const isWorkTime = (d) => d.getDay() % 6 && d >= workStart && d < workEnd;
     const isLookAwayTime = (d) =>
       d.getMinutes() % 20 === 0 && d.getSeconds() < 20;
     const NOW = new Date();

--- a/apps/twenties/metadata.json
+++ b/apps/twenties/metadata.json
@@ -2,7 +2,7 @@
   "id": "twenties",
   "name": "Twenties",
   "shortName": "Twenties",
-  "version": "0.08",
+  "version": "0.09",
   "description": "Buzzes every 20m to stand / sit and look 20ft away for 20s.",
   "icon": "app.png",
   "type": "bootloader",


### PR DESCRIPTION
Following up on the bug I reported in https://github.com/espruino/BangleApps/pull/4231, this changes how `isWorkTime()` is calculated to ensure than 18:00:00 is considered work time and 18:00:20 isn't.

Rather than stacking conditions like `d.getHours() < 18 || d.getHours() == 18 && d.getMinutes() == 0 && d.getSeconds() < 20`, I introduced new `Date` objects for the work day boundaries and compare the objects directly. That will also make it easier to eventually make the active hours user-configurable.