### PR TITLE
Add required firmware version to README and sanitycheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ and which gives information about the app for the Launcher.
   "provides_modules" : ["messageicons"] // optional, this app provides a module that can be used with 'require'
   "provides_widgets" : ["battery"] // optional, this app provides a type of widget - 'alarm/battery/bluetooth/pedometer/message'
   "provides_features" : ["welcome"] // optional, this app provides some feature, used to ensure two aren't installed at once. Currently just 'welcome'
+  "requiredFw" : "2v20", // optional, specify a minimum firmware version your app needs to work properly
   "default" : true,           // set if an app is the default implementer of something (a widget/module/etc)
   "readme": "README.md",      // if supplied, a link to a markdown-style text file
                               // that contains more information about this app (usage, etc)

--- a/apps/loadanim/metadata.json
+++ b/apps/loadanim/metadata.json
@@ -3,7 +3,8 @@
   "shortName":"Load Anim",
   "version":"0.02",
   "author": "gfwilliams",
-  "description": "Add an animation that happens while Bangle.js is loading an app. Requires 2v29+ (or 2v28 cutting edge) firmware to work.",
+  "description": "Add an animation that happens while Bangle.js is loading an app.",
+  "requiredFw": "2v29"
   "icon": "app.png",
   "screenshots" : [ { "url":"screenshot.png" } ],
   "type": "settings",

--- a/apps/loadanim/metadata.json
+++ b/apps/loadanim/metadata.json
@@ -4,7 +4,7 @@
   "version":"0.02",
   "author": "gfwilliams",
   "description": "Add an animation that happens while Bangle.js is loading an app.",
-  "requiredFw": "2v29"
+  "requiredFw": "2v29",
   "icon": "app.png",
   "screenshots" : [ { "url":"screenshot.png" } ],
   "type": "settings",

--- a/bin/sanitycheck.js
+++ b/bin/sanitycheck.js
@@ -169,7 +169,7 @@ const APP_KEYS = [
   'sortorder', 'readme', 'custom', 'customConnect', 'interface', 'storage', 'data',
   'supports', 'allow_emulator',
   'dependencies', 'provides_modules', 'provides_widgets', 'provides_features', "default",
-  "author"
+  "author","requiredFw"
 ];
 const STORAGE_KEYS = ['name', 'url', 'content', 'evaluate', 'noOverwite', 'supports', 'noOverwrite'];
 const DATA_KEYS = ['name', 'wildcard', 'storageFile', 'url', 'content', 'evaluate'];


### PR DESCRIPTION
From App loader core [#92](https://github.com/espruino/EspruinoAppLoaderCore/pull/92), adds the `requiredFw` field to readme and `sanitycheck.js`

Also adds requiredFw to `loadanim` and removes the description message about the firmware, as the app loader now handles it.