### PR TITLE
taglaunch: fastload

### DIFF
--- a/apps/taglaunch/ChangeLog
+++ b/apps/taglaunch/ChangeLog
@@ -8,3 +8,4 @@
 0.07: Clear cached app list when updating showClocks setting
 0.08: Add haptic feedback option when selecting app or category in menu, increase vector size limit in settings
 0.09: Add option to set up to 3 shortcut apps that you can access straight from the tag menu for quicker access
+0.10: Fast load apps similar to launcher_utils library

--- a/apps/taglaunch/app.js
+++ b/apps/taglaunch/app.js
@@ -42,7 +42,7 @@ let sort = (a, b) => {
 
 // cache app list so launcher loads more quickly
 let launchCache = s.readJSON("taglaunch.cache.json", true)||{};
-let launchHash = require("Storage").hash(/\.info/);
+let launchHash = s.hash(/\.info/);
 if (launchCache.hash!=launchHash) {
   let appsByTag = Object.keys(tags).reduce((acc,curr)=> (acc[curr]=[],acc),{});
   s.list(/\.info$/).map(app=>s.readJSON(app,1))
@@ -86,7 +86,7 @@ const unload = () => {
 
 let shortcuts=settings.shortcuts;
 let noShortcuts=shortcuts[0]==""&&shortcuts[1]==""&&shortcuts[2]=="";
-  
+
 let loadShortcut=function(idx){
   if(shortcuts[idx]!=""){
     const p = settings.buzz ? Bangle.buzz(25) : Promise.resolve();
@@ -121,14 +121,25 @@ let showTagMenu = (tag) => {
       const loadApp = () => {
         let app = appsByTag[tag][i];
         if (!app) return;
-        if (!app.src || require("Storage").read(app.src)===undefined) {
+        if (!app.src || s.read(app.src)===undefined) {
           Bangle.setUI();
           E.showMessage(/*LANG*/"App Source\nNot found");
           setTimeout(showMainMenu, 2000);
         } else {
-          load(app.src);
+          if (app.wid===undefined) {
+            // If we hadn't stored whether the app uses widgets before, check now
+            let src = s.read(app.src);
+            app.wid = (src!==undefined)&&src.includes("Bangle.loadWidgets");
+            s.writeJSON("taglaunch.cache.json", launchCache);
+          }
+          if (app.wid || global.WIDGETS===undefined) Bangle.load(app.src); // if app uses widgets or we don't have any, we can fast load into it
+          else if (Object.keys(WIDGETS).every(w=>!!WIDGETS[w].remove)) { // are widgets unloadable? !! needed before 2v29 fw
+            Object.keys(WIDGETS).forEach(w=>WIDGETS[w].remove());
+            delete global.WIDGETS;
+            Bangle.load(app.src);
+          } else load(app.src); // otherwise default to slow load
         }
-      };    
+      };
       if(settings.buzz){
         Bangle.buzz(25);
         //let the buzz have effect
@@ -136,7 +147,7 @@ let showTagMenu = (tag) => {
       }else{
         loadApp();
       }
-      
+
     },
     back : showMainMenu,
     remove: unload
@@ -149,7 +160,7 @@ let showMainMenu = () => {
     h : 64*scaleval, c : noShortcuts ? tagKeys.length : tagKeys.length+1,
     draw : (i, r) => {
       g.clearRect((r.x),(r.y),(r.x+r.w-1), (r.y+r.h-1));
-      
+
       if(!noShortcuts)i-=1;
       if(i==-1){
         for(let j=0;j<3;j++){
@@ -161,7 +172,7 @@ let showMainMenu = () => {
           }
         }
 
-        
+
       }else{
         let tag = tagKeys[i]; g.setFont(font).setFontAlign(-1,0).drawString(tags[tag].name,64*scaleval,r.y+(32*scaleval));
 
@@ -175,11 +186,11 @@ let showMainMenu = () => {
       if(!noShortcuts)i-=1;
       if(i==-1){
         if(e.x<g.getWidth()/3){
-          loadShortcut(0)
-        }else if(e.x<(g.getWidth()/3)*2){    
-          loadShortcut(1)
-        }else{     
-          loadShortcut(2)
+          loadShortcut(0);
+        }else if(e.x<(g.getWidth()/3)*2){
+          loadShortcut(1);
+        }else{
+          loadShortcut(2);
         }
       }else{
         if(settings.buzz)Bangle.buzz(25);

--- a/apps/taglaunch/app.js
+++ b/apps/taglaunch/app.js
@@ -31,6 +31,7 @@ if ("font" in settings){
     scaleval = (font.split("x")[1])/20;
   }
 }
+const appimgs = {};
 
 let sort = (a, b) => {
   let n=(0|a.sortorder)-(0|b.sortorder);
@@ -113,8 +114,8 @@ let showTagMenu = (tag) => {
       g.clearRect((r.x),(r.y),(r.x+r.w-1), (r.y+r.h-1));
       g.setFont(font).setFontAlign(-1,0).drawString(app.name,64*scaleval,r.y+(32*scaleval));
       if (app.icon) {
-        if (!app.img) app.img = s.read(app.icon); // load icon if it wasn't loaded
-        try {g.drawImage(app.img,8*scaleval, r.y+(8*scaleval), {scale: scaleval});} catch(e){}
+        if (!appimgs[app.id]) appimgs[app.id] = s.read(app.icon); // load icon if it wasn't loaded
+        try {g.drawImage(appimgs[app.id],8*scaleval, r.y+(8*scaleval), {scale: scaleval});} catch(e){}
       }
     },
     select : i => {

--- a/apps/taglaunch/metadata.json
+++ b/apps/taglaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "taglaunch",
   "name": "Tag Launcher",
   "shortName": "Taglauncher",
-  "version": "0.09",
+  "version": "0.10",
   "author": "nxdefiant",
   "description": "Launcher that puts all applications into submenus based on their tag, with three customizable app shortcuts at the top. With many applications installed this can result in a faster application selection than the linear access from the default launcher.",
   "readme": "README.md",


### PR DESCRIPTION
Fast load apps similar to launcher_utils library

We can't just use launcher_utils because it does not store the tags we need.