### PR TITLE
fix ac_ac customizer textbox width

### DIFF
--- a/apps/ac_ac/Customizer.html
+++ b/apps/ac_ac/Customizer.html
@@ -673,7 +673,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-tl-custom-url" size="50"></td>
+      <td><input type="url" id="complication-tl-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -695,7 +695,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-t-custom-url" size="50"></td>
+      <td><input type="url" id="complication-t-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -717,7 +717,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-tr-custom-url" size="50"></td>
+      <td><input type="url" id="complication-tr-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -739,7 +739,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-l-custom-url" size="50"></td>
+      <td><input type="url" id="complication-l-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -761,7 +761,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-r-custom-url" size="50"></td>
+      <td><input type="url" id="complication-r-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -783,7 +783,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-bl-custom-url" size="50"></td>
+      <td><input type="url" id="complication-bl-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -805,7 +805,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-b-custom-url" size="50"></td>
+      <td><input type="url" id="complication-b-custom-url" size="40"></td>
     </tr>
 
     <tr>
@@ -827,7 +827,7 @@ console.log(AppSource)
     <tr>
       <td></td>
       <td>custom URL:</td>
-      <td><input type="url" id="complication-br-custom-url" size="50"></td>
+      <td><input type="url" id="complication-br-custom-url" size="40"></td>
     </tr>
   </tbody></table>
 </p>


### PR DESCRIPTION
For the app "A Configurable Analog Clock" the textboxes in the customizer in the section complications are wider than the configuration window. Entering a long URL into these results in a left shift of the UI elements. The result is, that the upload button at the end of the page is not visible any more.
This RP reduces the width for the mentioned textboxes from 50 to 40px, to fix the described problem.

Tested with Chromium and Firefox.
[Link to my BangleApps repo](https://danieldecker.github.io/BangleApps/?c=&q=ac_ac).
