### PR TITLE
[messagegui] Add support for notification actions

### DIFF
--- a/apps/messagegui/ChangeLog
+++ b/apps/messagegui/ChangeLog
@@ -125,3 +125,4 @@
       Use E.on("kill" event to ensure we always save messages before changing app
       Simplify message handling now messages lib automatically applies Bangle.messages
 0.92: Add support for displaying the time since the message was received using the 'date' parameter when pushing a message.
+0.93: Add support for notification actions.

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -6,6 +6,10 @@
     body,
     sender,
     tel:string,
+    reply:bool,
+    positive:bool,
+    negative:bool,
+    actions: [{title:string}],
     new:true // not read yet
   }
 */
@@ -300,6 +304,44 @@ function showMusicMessage(msg) {
   }, 400);
 }
 
+function showActionsMenu(msg) {
+  cancelReloadTimeout();
+  var menu = {"":{ title:/*LANG*/"Actions", back:() => showMessage(msg.id, true) }};
+  // Custom actions
+  if (msg.actions) 
+    msg.actions.forEach((action, idx) => {
+      menu[action.title] = () => {
+        msg.new = false;
+        Bluetooth.println("");
+        Bluetooth.println(JSON.stringify({t:"notify",n:"INVOKE_ACTION",id:msg.id,action:idx}));
+        returnToCheckMessages();
+      };
+    });
+  if (msg.reply && reply)
+    menu[/*LANG*/"Reply"] = () => {
+      msg.new = false;
+      replying = true;
+      reply.reply({msg:msg})
+        .then(r => {
+          Bluetooth.println(JSON.stringify(r));
+          replying=false;
+          returnToCheckMessages();
+        })
+        .catch(() => { 
+          replying=false; 
+          showMessage(msg.id); 
+        });
+    };
+  if (msg.positive)
+    menu[/*LANG*/"Open"] = () => {
+      msg.new = false; 
+      cancelReloadTimeout(); 
+      Bangle.messageResponse(msg,true); 
+      returnToCheckMessages();
+    };
+  E.showMenu(menu);
+}
+
 function showMessageSettings(msg) {
   active = "settings";
   var menu = {"":{
@@ -312,6 +354,10 @@ function showMessageSettings(msg) {
   showMessage to the message list, so add the option here */
   if (process.env.BOARD=="BANGLEJS")
     menu[/*LANG*/"Message List"] = () => { returnToMain(); };
+
+  if (msg.actions && msg.actions.length) {
+    menu[/*LANG*/"Actions"] = ()=>{ showActionsMenu(msg); };
+  }
 
   if (msg.reply && reply)
     menu[/*LANG*/"Reply"] = () => {
@@ -449,7 +495,10 @@ function showMessage(msgid, persist) {
     else if (!ld)
       g.setFontAlign(-1,-1).drawString(date,r.x+6,r.y+5);
   }
-  if (msg.reply && reply) {
+  if (msg.actions && msg.actions.length) {
+    posHandler = ()=>{ showActionsMenu(msg); };
+    rowRightDraw = function(r) {g.setColor("#0f0").drawImage(atob("QRABAAAAAAAAAcAAAAAAAMAB8AAAAAAAcAD4AAAAAAA8ADgAAAAAAB8AAAAAAAAAD8AAAH//////8AcAP//////8B8Af//////4D4A///////gDgAAAAAAB+AAAAAAAAAD4AAAAAAAAAHgAcAAAAAAAOAB8AAAAAAAYAD4AAAAAAAAADgA=="),r.x+r.w-64,r.y+2);};
+  } else if (msg.reply && reply) {
     posHandler = ()=>{
       replying = true;
       msg.new = false;

--- a/apps/messagegui/app.js
+++ b/apps/messagegui/app.js
@@ -307,16 +307,6 @@ function showMusicMessage(msg) {
 function showActionsMenu(msg) {
   cancelReloadTimeout();
   var menu = {"":{ title:/*LANG*/"Actions", back:() => showMessage(msg.id, true) }};
-  // Custom actions
-  if (msg.actions) 
-    msg.actions.forEach((action, idx) => {
-      menu[action.title] = () => {
-        msg.new = false;
-        Bluetooth.println("");
-        Bluetooth.println(JSON.stringify({t:"notify",n:"INVOKE_ACTION",id:msg.id,action:idx}));
-        returnToCheckMessages();
-      };
-    });
   if (msg.reply && reply)
     menu[/*LANG*/"Reply"] = () => {
       msg.new = false;
@@ -331,7 +321,17 @@ function showActionsMenu(msg) {
           replying=false; 
           showMessage(msg.id); 
         });
-    };
+    };  
+  // Custom actions
+  if (msg.actions) 
+    msg.actions.forEach((action, idx) => {
+      menu[action.title] = () => {
+        msg.new = false;
+        Bluetooth.println("");
+        Bluetooth.println(JSON.stringify({t:"notify",n:"INVOKE_ACTION",id:msg.id,action:idx}));
+        returnToCheckMessages();
+      };
+    });
   if (msg.positive)
     menu[/*LANG*/"Open"] = () => {
       msg.new = false; 
@@ -497,7 +497,7 @@ function showMessage(msgid, persist) {
   }
   if (msg.actions && msg.actions.length) {
     posHandler = ()=>{ showActionsMenu(msg); };
-    rowRightDraw = function(r) {g.setColor("#0f0").drawImage(atob("QRABAAAAAAAAAcAAAAAAAMAB8AAAAAAAcAD4AAAAAAA8ADgAAAAAAB8AAAAAAAAAD8AAAH//////8AcAP//////8B8Af//////4D4A///////gDgAAAAAAB+AAAAAAAAAD4AAAAAAAAAHgAcAAAAAAAOAB8AAAAAAAYAD4AAAAAAAAADgA=="),r.x+r.w-64,r.y+2);};
+    rowRightDraw = function(r) {g.setColor("#0f0").drawImage(atob("QRABAAAAAAAABwAAAAAAAMAHwAAAAAAAcAPgAAAAAAA8AOAAAAAAAB8AAAAAAAAAD8AAAH//////8BwAP//////8HwAf//////4PgA///////gOAAAAAAAB+AAAAAAAAAD4AAAAAAAAAHgBwAAAAAAAOAHwAAAAAAAYAPgAAAAAAAAAOAA=="),r.x+r.w-64,r.y+2);};
   } else if (msg.reply && reply) {
     posHandler = ()=>{
       replying = true;

--- a/apps/messagegui/metadata.json
+++ b/apps/messagegui/metadata.json
@@ -2,7 +2,7 @@
   "id": "messagegui",
   "name": "Message UI",
   "shortName": "Messages",
-  "version": "0.92",
+  "version": "0.93",
   "author": "rigrig",
   "description": "Default app to display notifications from iOS and Gadgetbridge/Android",
   "icon": "app.png",


### PR DESCRIPTION
**GadgetBridge PR:** https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/6468

Link: https://kidneyhex.github.io/BangleApps/?id=messagegui

This adds support for Android notification "custom actions". 

GB sends an array of "actions" with just title properties, and then the index from that array is the ID sent back to GB with the INVOKE_ACTION command, so it triggers the action on the notification.

Examples where this is used:
* Task apps that have a "Perform", "Skip", or "Fail" (Do It Now, Habitica)
* Email apps that have "Trash", "Archive", "Spam" buttons (FairEmail, Gmail, Thunderbird)

What the actions array looks like:
```json
{
  "t": "notify",
  "id": 1234567890,
...
  "positive": true,
  "negative": true,
  "actions": [
    { "title": "Archive" },
    { "title": "Mark as read" },
    { "title": "Snooze" }
  ]
}
```

What the message back to GB looks like:
```json
{ "t":"notify", "n":"INVOKE_ACTION", "id":1234567890, "action":0 }
```

### Preview 

If there are actions, it shows a new swipe icon with the three vertical dots for "more actions" (a kebab menu icon):

<img width="176" height="176" alt="screenshot_20260723-082051" src="https://github.com/user-attachments/assets/a4c62139-d451-42cc-978b-fe1d96fbbdc5" />

If you swipe right, it then shows a menu with each action. If there's a "Reply" option, that will be next after the actions. If there's a "positive" option, that will be last as "Open".

<img width="176" height="176" alt="screenshot_20260723-091600" src="https://github.com/user-attachments/assets/bf5db2b6-1840-4b21-a240-77ae843d8390" />

"Actions" is also added to the message menu (when clicking the envelope icon in the message header).

### Questions
1) Should this be optional, with a settings parameter to either enable or disable it?

2) Should a "Dismiss" option that performs the "negative" action be added to the actions list?

3) Unicode: I have not tested what happens if action titles contain non-english text.
