### PR TITLE
[Launch] Use Bangle.haptic for haptics if available

### DIFF
--- a/apps/iconlaunch/ChangeLog
+++ b/apps/iconlaunch/ChangeLog
@@ -28,3 +28,4 @@
       Ensure 'oneClickExit' is the default
 0.21: Display placeholder icons at start and render line by line to the screen to make loading seem faster
 0.22: Use launcher_utils library for app cacheing  and fast load
+0.23: Use Bangle.haptic if available

--- a/apps/iconlaunch/app.js
+++ b/apps/iconlaunch/app.js
@@ -99,8 +99,10 @@
     const iconN = E.clip(Math.floor((e.x - R.x) / itemSize), 0, appsN - 1);
     const appId = id * appsN + iconN;
     if( settings.direct && launchCache.apps[appId])
+      if(Bangle.haptic) Bangle.haptic("touch");
       return require("launch_utils").loadApp(launchCache.apps[appId]);
     if (appId == selectedItem && launchCache.apps[appId])
+      if(Bangle.haptic) Bangle.haptic("touch");
       return require("launch_utils").loadApp(launchCache.apps[appId]);
 
     selectedItem = appId;

--- a/apps/iconlaunch/app.js
+++ b/apps/iconlaunch/app.js
@@ -98,13 +98,14 @@
   let selectItem = function(id, e) {
     const iconN = E.clip(Math.floor((e.x - R.x) / itemSize), 0, appsN - 1);
     const appId = id * appsN + iconN;
-    if( settings.direct && launchCache.apps[appId])
+    if( settings.direct && launchCache.apps[appId]) {
       if(Bangle.haptic) Bangle.haptic("touch");
       return require("launch_utils").loadApp(launchCache.apps[appId]);
-    if (appId == selectedItem && launchCache.apps[appId])
+    }
+    if (appId == selectedItem && launchCache.apps[appId]) {
       if(Bangle.haptic) Bangle.haptic("touch");
       return require("launch_utils").loadApp(launchCache.apps[appId]);
-
+    }
     selectedItem = appId;
     if (scroller) scroller.draw();
   };

--- a/apps/iconlaunch/metadata.json
+++ b/apps/iconlaunch/metadata.json
@@ -2,7 +2,7 @@
 	"id": "iconlaunch",
 	"name": "Icon Launcher",
 	"shortName" : "Icon launcher",
-	"version": "0.22",
+	"version": "0.23",
 	"icon": "app.png",
 	"author": "TheGLander",
 	"description": "A launcher inspired by smartphones, with an icon-only scrollable menu.",

--- a/apps/launch/ChangeLog
+++ b/apps/launch/ChangeLog
@@ -30,3 +30,4 @@
       Add Height option to set menu item height independently of Font
 0.26: Use launcher_utils library for app cacheing  and fast load
       Highlight each item if showScroller calls draw(selected=true)
+0.27: Use Bangle.haptic if available

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -49,7 +49,7 @@
       select : i => {
         var app = apps[i];
         if (!app) return;
-        if (Bangle.haptic) Bangle.haptic();
+        if (Bangle.haptic) Bangle.haptic("touch");
         if (!app.src || require("Storage").read(app.src)===undefined) {
           E.showScroller();
           E.showMessage(/*LANG*/"App Source\nNot found");

--- a/apps/launch/app.js
+++ b/apps/launch/app.js
@@ -49,6 +49,7 @@
       select : i => {
         var app = apps[i];
         if (!app) return;
+        if (Bangle.haptic) Bangle.haptic();
         if (!app.src || require("Storage").read(app.src)===undefined) {
           E.showScroller();
           E.showMessage(/*LANG*/"App Source\nNot found");

--- a/apps/launch/metadata.json
+++ b/apps/launch/metadata.json
@@ -2,7 +2,7 @@
   "id": "launch",
   "name": "Launcher",
   "shortName": "Launcher",
-  "version": "0.26",
+  "version": "0.27",
   "author": "gfwilliams",
   "description": "This is needed to display a menu allowing you to choose your own applications. You can replace this with a customised launcher.",
   "readme": "README.md",


### PR DESCRIPTION
Use Bangle.haptic for haptics if available. Currently it always calls the haptic function, but since it's a core app, it might be better to have it as a setting as well?