### PR TITLE
[Settings README] Improve slight errors

### DIFF
--- a/apps/setting/README.md
+++ b/apps/setting/README.md
@@ -8,9 +8,10 @@ This is Bangle.js's main settings menu:
 * **Sound/Vibration** - Set how Bangle.js makes noise and vibrates (including Quiet mode)
 * **Utils** - Utilities, including resetting settings
 
-**New Users:** these are some settings you'll probably want to change right away:
+**New Users:** These are some settings you'll probably want to change right away:
 
 * **Calibrate LCD** Make sure that the LCD touchscreen responds to touches where you expect them to
+* **Calibrate Battery** Leave your watch charging for around 5 hours and calibrate battery so the watch reports accurate battery percentages.
 * **Locale** Set whether you want 12 hour time, and what day of the week the week starts on.
 
 See below for options under each heading:
@@ -23,19 +24,19 @@ This is where you adjust settings for an individual app. (eg. Health app: Adjust
 
 * **Theme** Adjust the colour scheme. Choose between light mode, dark mode, or a custom theme. To adjust themes in more detail you can also use the [Theme Switcher App](https://banglejs.com/apps/?id=themesetter)
 * **LCD** Configure settings about the screen. How long it stays on, how bright it is, and when it turns on - see below.
-* **Locale** set time zone, the time format (12/24h, for supported clocks) and the first day of the week
-* **Clock** if you have more than one clock face, select the default one
-* **Launcher** if you have more than one app launcher, select the default one
+* **Locale** Set time zone, the time format (12/24h, for supported clocks) and the first day of the week
+* **Clock** If you have more than one clock face, select the default one
+* **Launcher** If you have more than one app launcher, select the default one
 * **Date & Time** Configure the current time - Note that this can be done much more easily by choosing 'Set Time' from the App Loader
 * **Altitude** On Bangle.js 2, calibrate the altitude (which varies depending on Air Pressure). Tap `Adjust Up`/`Adjust Down` to move the reported altitude by around 10m
 
 ## Sound/Vibration
 
-* **Beep** most Bangle.js do not have a speaker inside, but they can use the vibration motor to beep in different pitches. You can change the behaviour here to use a Piezo speaker if one is connected
-* **Vibration** enable/disable the vibration motor
-* **Haptic Strength** For devices that have firmware versions 2v29.14 or higher, this will show a menu where you can customize the strength of the vibration in response to user input, or turn  off.
-* **Quiet Mode** prevent notifications/alarms from vibrating/beeping/turning the screen on - see below
-* **Charge Vibration** buzz when charging is initiated
+* **Beep** Bangle.js 1 and 2 do not have a speaker inside, but they can use the vibration motor to beep in different pitches. Bangle.js 1 has a piezo speaker which beeps, and you can change the behaviour here to use a Piezo speaker if one is connected to Bangle.js 2
+* **Vibration** Enable/disable the vibration motor
+* **Haptic Strength** For devices that have firmware versions 2v29.14 or higher, this will show a menu where you can customize the strength of the vibration in response to user input, or turn off.
+* **Quiet Mode** Prevent notifications/alarms from vibrating/beeping/turning the screen on - see below
+* **Charge Vibration** Buzz when charging is initiated
 
 ## Bluetooth
 
@@ -48,24 +49,24 @@ This is where you adjust settings for an individual app. (eg. Health app: Adjust
 * **Whitelist** allows you to specify only specific devices that you will let connect to your Bangle.js. Simply choose the menu item, then `Add Device`, and then connect to Bangle.js with the device you want to add. If you are already connected you will have to disconnect first. Changes will take effect when you exit the `Settings` app.
   * **NOTE:** iOS devices and newer Android devices often implement Address Randomisation and change their Bluetooth address every so often. If you device's address changes, you will be unable to connect until you update the whitelist again.
 * **Privacy** - (Bangle.js 2 only) enables BLE privacy mode (see [NRF.setSecurity](https://www.espruino.com/Reference#l_NRF_setSecurity)). This randomises the Bangle's MAC address and can also
-remove advertising of its name. **This can cause connection issues with apps that expect to keep a permanent connection like iOS/Gadgetbridge**
+remove advertising of its name. **This can cause connection issues with apps that expect to keep a permanent connection like iOS/BlueWatch/Gadgetbridge**
 
 ## LCD
 
-* **LCD Brightness** set how bright the LCD is. Due to hardware limitations in the LCD backlight, you may notice flicker if the LCD is not at 100% brightness.
-* **LCD Timeout** how long should the LCD stay on for if no activity is detected. 0=stay on forever
-* **Rotation** allows you to rotate (or mirror) what's displayed on the screen, eg. for left-handed wearers (needs 2v16 or 2v15 cutting edge firmware to work reliably)
-* **Wake on X** should the given activity wake up the Bangle.js LCD?
+* **LCD Brightness** Set how bright the LCD is. Due to hardware limitations in the LCD backlight, you may notice a slight flicker if the LCD is not at 100% brightness.
+* **LCD Timeout** How long should the LCD stay on for if no activity is detected. 0=stay on forever
+* **Rotation** Allows you to rotate (or mirror) what's displayed on the screen, eg. for left-handed wearers (needs 2v16 or 2v15 cutting edge firmware to work reliably)
+* **Wake on X** Should the given activity wake up the Bangle.js LCD?
   * On Bangle.js 2 when locked the touchscreen is turned off to save power. Because of this,
     `Wake on Tap` actually uses the accelerometer, and you need to actually tap the display to wake Bangle.js.
-* **Twist X** these options adjust the sensitivity of `Wake on Twist` to ensure Bangle.js wakes up with just the right amount of wrist movement.
-* **Calibrate** on Bangle.js 2, pop up a screen allowing you to calibrate the touchscreen, ensuring your touches are mapped to the right place on the screen. (Highly reccomended for new users!)
+* **Twist X** These options adjust the sensitivity of `Wake on Twist` to ensure Bangle.js wakes up with just the right amount of wrist movement.
+* **Calibrate** On Bangle.js 2, pop up a screen allowing you to calibrate the touchscreen, ensuring your touches are mapped to the right place on the screen. (Highly recommended for new users!)
 
 ## Locale
 
-* **Time Zone** your current Time zone. This is usually set automatically by the App Loader
-* **Time Format** whether you want a 24 or 12 hour clock. However not all clocks will honour this.
-* **Start Week On** start the displayed week on Sunday, or Monday. This currently only applies to the Alarm app.
+* **Time Zone** Your current Time zone. This is usually set automatically by the App Loader
+* **Time Format** Whether you want a 24 or 12 hour time to be displayed. However, not all clocks will honour this.
+* **Start Week On** Start the displayed week on Sunday, or Monday. This currently only applies to the Alarm app.
 
 ## Quiet Mode
 
@@ -90,7 +91,7 @@ The exact effects depend on the app.  In general the watch will not wake up by i
 * **Flatten Battery** Turns on all devices and draws as much power as possible, attempting to flatten the Bangle.js battery. This can still take 5+ hours.
 * **Calibrate Battery** If you're finding your battery percentage meter isn't accurate, leave your Bangle.js on charge for at least 3 hours, and then choose this menu option. It will measure the battery voltage when full and will allow Bangle.js to report a more accurate battery percentage.
 * **Reset Settings** Reset the settings (as set in this app) to defaults. Does not reset settings for other apps.
-* **Factory Reset** (not available on Bangle.js 1) - wipe **everything** and return to a factory state
+* **Factory Reset** (Not available on Bangle.js 1) - wipe **everything** and return the watch to a factory state
 * **Turn Off** Turn Bangle.js off
 
 # Development


### PR DESCRIPTION
Updates the readme with better capitalization/consistency, and adds a calibrate battery section in the new user's guide. 

This is just a slight pet peeve of mine, where capitalization isn't consistent. Thanks for putting up with this :)