### PR TITLE
fix(tally): jump to settings when no tally types are configured

### DIFF
--- a/apps/tally/ChangeLog
+++ b/apps/tally/ChangeLog
@@ -1,2 +1,3 @@
 0.01: New app!
 0.02: Handle duplicate menu entries in the app
+0.03: Go straight to settings when no tally types are configured yet, instead of an empty list

--- a/apps/tally/app.js
+++ b/apps/tally/app.js
@@ -103,4 +103,10 @@ function tfmt(tally) {
     return "".concat(d.getHours(), ":").concat(pad2(d.getMinutes()));
 }
 var pad2 = function (s) { return ("0" + s.toFixed(0)).slice(-2); };
-showTallies(readTallies());
+var tallyCfg = storage.readJSON("tallycfg.json", 1) || [];
+if (tallyCfg.length === 0) {
+    eval(storage.read("tally.settings.js"))(function () { return load(); });
+}
+else {
+    showTallies(readTallies());
+}

--- a/apps/tally/app.ts
+++ b/apps/tally/app.ts
@@ -123,4 +123,11 @@ function tfmt(tally: Tally) {
 
 const pad2 = (s: number) => ("0" + s.toFixed(0)).slice(-2);
 
-showTallies(readTallies());
+const tallyCfg = storage.readJSON("tallycfg.json", 1) as TallySettings || [];
+if (tallyCfg.length === 0) {
+  // No tally types configured yet, so there's nothing to log and nothing
+  // to show here - go straight to settings so the user can add one.
+  eval(storage.read("tally.settings.js") as string)(() => load());
+} else {
+  showTallies(readTallies());
+}

--- a/apps/tally/metadata.json
+++ b/apps/tally/metadata.json
@@ -2,7 +2,7 @@
   "id": "tally",
   "name": "Tally Keeper",
   "shortName": "Tally",
-  "version": "0.02",
+  "version": "0.03",
   "author": "bobrippling",
   "description": "Add to a tally from clock info",
   "icon": "app.png",


### PR DESCRIPTION
Fixes #3853

On first install (or after removing all tally types), the app opened
straight to an empty "Tallies" list with no way to tell what to do next
— nothing to tally, and no visible path to add a type.

`app.js` now checks `tallycfg.json` (the configured tally types) before
showing the list; if it's empty, it loads the app's own settings screen
instead, using the same `eval(storage.read("<id>.settings.js"))(back)`
pattern already used elsewhere in this repo (e.g. `alarm`, `zambretti`).

Bumped to 0.03 with a ChangeLog entry.

## Test plan
- [x] Rebuilt `app.js` from `app.ts` via the real `typescript/build.sh`
      (`tsc`), rather than hand-editing the compiled output.
- [x] `node bin/sanitycheck.js` — 0 errors, 0 warnings (31 known/
      pre-existing errors and 13 known warnings elsewhere, unrelated).
- [x] `npx eslint apps/tally --max-warnings 0` — clean.
- [ ] Not tested on real Bangle.js 2 hardware or the emulator (none
      available in my environment) — would appreciate a maintainer or
      the reporter confirming the on-device behavior.