### PR TITLE
harden: wrap URL query params in encodeURIComponent in airqualityci clkinfo.js

### DIFF
--- a/apps/airqualityci/ChangeLog
+++ b/apps/airqualityci/ChangeLog
@@ -1,1 +1,2 @@
 0.01: Initial clockinfo release
+0.02: Harden URL construction with encodeURIComponent for city, state, country, and API key params

--- a/apps/airqualityci/clkinfo.js
+++ b/apps/airqualityci/clkinfo.js
@@ -8,7 +8,7 @@
       config.rows.forEach((row) => {
         if (row.url) {
           let el = row.url.replace(/\/$/, "").split("/").reverse();
-          let url = `https://api.airvisual.com/v2/city?city=${el[0]}&state=${el[1]}&country=${el[2]}&key=${config.apiKey}`;
+          let url = `https://api.airvisual.com/v2/city?city=${encodeURIComponent(el[0])}&state=${encodeURIComponent(el[1])}&country=${encodeURIComponent(el[2])}&key=${encodeURIComponent(config.apiKey)}`;
           data[row.url] = data[row.url] || {};
           // If neither attempt nor time are set, then we have never tried
           // If attempt was set more than 1 minute ago, try again

--- a/apps/airqualityci/metadata.json
+++ b/apps/airqualityci/metadata.json
@@ -1,6 +1,6 @@
 { "id": "airqualityci",
   "name": "Air Quality Clockinfo",
-  "version": "0.01",
+  "version": "0.02",
   "author": "chuckwagoncomputing",
   "description": "Create clockinfos for air quality and temperature",
   "icon": "app.png",

--- a/apps/airqualityci/test.json
+++ b/apps/airqualityci/test.json
@@ -1,12 +1,13 @@
 {
   "app": "airqualityci",
+  "allowCustomApp": true,
   "setup": [
     {
       "id": "default",
       "steps": [
-        {"t": "cmd", "js": "var capturedUrl = null; Bangle.http = function(url) { capturedUrl = url; return new Promise(function(){}); };"},
+        {"t": "cmd", "js": "var capturedUrl = null; Bangle.http = function(url) { capturedUrl = url; return {then: function(cb) { return {catch: function(){}}; }}; };"},
         {"t": "cmd", "js": "require('Storage').writeJSON('airqualityci.settings.json', {apiKey: 'test key&special', rows: [{url: 'US/New York/New York City', name: 'NYC', mode: 1}]});"},
-        {"t": "cmd", "js": "var clkinfo = eval(require('Storage').read('airqualityci.clkinfo.js')); clkinfo.items[0].get(function(){});"}
+        {"t": "cmd", "js": "var clkinfo = eval(require('Storage').read('airqualityci.clkinfo.js'))(); clkinfo.items[0].get(function(){});"}
       ]
     }
   ],

--- a/apps/airqualityci/test.json
+++ b/apps/airqualityci/test.json
@@ -1,0 +1,27 @@
+{
+  "app": "airqualityci",
+  "setup": [
+    {
+      "id": "default",
+      "steps": [
+        {"t": "cmd", "js": "var capturedUrl = null; Bangle.http = function(url) { capturedUrl = url; return new Promise(function(){}); };"},
+        {"t": "cmd", "js": "require('Storage').writeJSON('airqualityci.settings.json', {apiKey: 'test key&special', rows: [{url: 'US/New York/New York City', name: 'NYC', mode: 1}]});"},
+        {"t": "cmd", "js": "var clkinfo = eval(require('Storage').read('airqualityci.clkinfo.js')); clkinfo.items[0].get(function(){});"}
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "URL parameters are percent-encoded (spaces and special chars in location and API key)",
+      "steps": [
+        {"t": "setup", "id": "default"},
+        {"t": "assert", "js": "capturedUrl !== null", "is": "truthy"},
+        {"t": "assert", "js": "capturedUrl.includes('city=New%20York%20City')", "is": "truthy"},
+        {"t": "assert", "js": "capturedUrl.includes('state=New%20York')", "is": "truthy"},
+        {"t": "assert", "js": "capturedUrl.includes('country=US')", "is": "truthy"},
+        {"t": "assert", "js": "capturedUrl.includes('key=test%20key%26special')", "is": "truthy"},
+        {"t": "assert", "js": "!capturedUrl.includes('city=New York')", "is": "truthy"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Harden URL construction in `apps/airqualityci/clkinfo.js` by wrapping the city, state, country, and API key query parameters in `encodeURIComponent()`.

## Motivation

The current code interpolates user-configured values directly into a URL template string. While the values come from the device's own settings (not arbitrary user input), `encodeURIComponent()` is the correct way to build URL query strings: it ensures that any spaces or special characters in a location name (e.g. "New York", "São Paulo") don't malform the request URL.

This is defensive URL/input handling — not a critical security fix. The API key is transmitted over HTTPS and `encodeURIComponent()` does not prevent it from appearing in server or proxy logs.

## Changes

- `apps/airqualityci/clkinfo.js` — four `encodeURIComponent()` calls added to URL construction (line 11)
- `apps/airqualityci/metadata.json` — version bumped to 0.02
- `apps/airqualityci/ChangeLog` — entry added for 0.02
- `apps/airqualityci/test.json` — emulator test added (see Testing below)

## Testing

Tested using the repo's emulator-based test runner (per TESTING.md):

```
node bin/runapptests.js --id airqualityci --verbose
```

Result: **SUCCESS** — all 6 assertions passed, including:
- `city=New%20York%20City` (space encoded)
- `state=New%20York` (space encoded)
- `country=US` (unchanged)
- `key=test%20key%26special` (space and `&` encoded)
- Negative assertion: raw `city=New York` does NOT appear in the URL