### PR TITLE
tennisscores 0.02: readable error messages on the watch screen

### DIFF
--- a/apps/tennisscores/ChangeLog
+++ b/apps/tennisscores/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New App!
+0.02: Readable error screen: short human messages (No connection, Request timed out, Check API key, ...) instead of raw error text, plus a tap-to-retry hint

--- a/apps/tennisscores/app.js
+++ b/apps/tennisscores/app.js
@@ -13,6 +13,7 @@ let matches = [];  // slimmed live matches
 let fixtures = []; // slimmed upcoming fixtures
 let index = 0;     // current page
 let lastError = "";
+let errDetail = "";
 let updatedAt = null;
 let autoTimer = null;
 let loading = false;
@@ -27,7 +28,25 @@ function apiGet(path) {
   return Bangle.http(BASE + path, {
     timeout: 15000,
     headers: {Authorization: "Bearer " + settings.apikey}
-  }).then(ev => JSON.parse(ev.resp));
+  }).then(ev => {
+    let r = JSON.parse(ev.resp);
+    // the API reports failures as {"error":"unauthorized"} etc
+    if (r && r.error) throw new Error(r.error);
+    return r;
+  });
+}
+
+// map a rejection to a short, watch-readable message (null = not recognised)
+function humanError(e) {
+  let s = "" + ((e && e.message) || e);
+  if (/unauthori[sz]ed|forbidden/i.test(s)) return /*LANG*/"Check API key";
+  if (/rate.?limit|too many/i.test(s)) return /*LANG*/"Rate limited";
+  if (/timeout|timed out/i.test(s)) return /*LANG*/"Request timed out";
+  if (/bluetooth/i.test(s)) return /*LANG*/"Not connected";
+  if (/gadgetbridge/i.test(s)) return /*LANG*/"Needs Gadgetbridge";
+  if (/connect|resolve|unreachable|network|internet|dns/i.test(s)) return /*LANG*/"No connection";
+  if (/bad response|json|parse|expect/i.test(s)) return /*LANG*/"Bad response";
+  return null;
 }
 
 function trunc(s, n) {
@@ -115,7 +134,10 @@ function refresh() {
     draw();
   }).catch(e => {
     loading = false;
-    lastError = ("" + ((e && e.message) || e)).substr(0, 60);
+    let h = humanError(e);
+    lastError = h || /*LANG*/"Error";
+    // only surface the raw text (small, below) when we can't name the problem
+    errDetail = h ? "" : ("" + ((e && e.message) || e)).substr(0, 40);
     state = "error";
     scheduleAuto();
     draw();
@@ -226,10 +248,16 @@ function draw() {
     g.setFont("6x8").setFontAlign(0, 1);
     g.drawString("livetennisapi.com", (R.x + R.x2) / 2, R.y2);
   } else if (state === "error") {
-    drawCentered([/*LANG*/"Error"], R);
-    g.setFont("6x8").setFontAlign(0, -1);
-    g.drawString(g.wrapString(lastError, R.w - 8).slice(0, 3).join("\n"), (R.x + R.x2) / 2, (R.y + R.y2) / 2 + 4);
-    drawFooter(R);
+    g.setFont("6x8", 2).setFontAlign(0, -1);
+    let lines = g.wrapString(lastError, R.w - 8);
+    let y = (R.y + R.y2) / 2 - lines.length * 9 - (errDetail ? 8 : 0);
+    g.drawString(lines.join("\n"), (R.x + R.x2) / 2, y);
+    if (errDetail) {
+      g.setFont("6x8").setFontAlign(0, -1);
+      g.drawString(g.wrapString(errDetail, R.w - 8).slice(0, 2).join("\n"), (R.x + R.x2) / 2, y + lines.length * 18 + 4);
+    }
+    g.setFont("6x8").setFontAlign(0, 1);
+    g.drawString(/*LANG*/"tap to retry", (R.x + R.x2) / 2, R.y2);
   } else {
     drawCentered([/*LANG*/"Loading..."], R);
   }

--- a/apps/tennisscores/metadata.json
+++ b/apps/tennisscores/metadata.json
@@ -1,7 +1,7 @@
 { "id": "tennisscores",
   "name": "Tennis Scores",
   "shortName": "Tennis",
-  "version": "0.01",
+  "version": "0.02",
   "author": "bensynapse",
   "description": "Live tennis scores and upcoming fixtures from the Live Tennis API. Shows score, serving player and next matches for a configurable tour (requires Gadgetbridge and an API key)",
   "icon": "app.png",


### PR DESCRIPTION
Follow-up to #4316, as promised. When merging, @thyttan asked:

> Minor thing, the timeout error is a bit hard to read on the watch screen [...] if you fix the presentation of the errors please post another PR 👍

This fixes the presentation of every error state. Before, any failure dumped the raw rejection text ("Timeout", "Failed to connect to api.livetennisapi.com/0.0.0.0:443", ...) wrapped in the 6x8 font under a generic "Error" heading — unreadable at watch size, as in thyttan's screenshot. Now each failure is mapped to a short human message, centered and wrapped in the large (6x8 x2) font, with a small "tap to retry" hint at the bottom (tap was already the app's refresh gesture):

| Failure | Before | After |
|---|---|---|
| Request timed out (`Bangle.http` "Timeout") | `Error` + raw `Timeout` in tiny font | **Request timed out** |
| Phone unreachable / no internet / DNS (Gadgetbridge `err` strings like "Failed to connect to ...", "Unable to resolve host ...") | raw multi-line URL soup | **No connection** |
| Not connected to Bluetooth | raw `Not connected to Bluetooth` | **Not connected** |
| No `Bangle.http` (no Gadgetbridge/android app) | raw `Gadgetbridge required` | **Needs Gadgetbridge** |
| Bad/expired API key (API returns `{"error":"unauthorized"}`) | `Bad response` (misleading) | **Check API key** |
| API rate limit hit | `Bad response` | **Rate limited** |
| Unparseable/empty body | raw parse error | **Bad response** |
| Anything unrecognised | raw text | **Error** + first 40 chars in small font below, so it stays debuggable |

The API error body (`{"error":"..."}`) is now checked after JSON parse, which is what turns a 401 into "Check API key" instead of the old misleading "Bad response". The missing-key case (`No API key / Set one in Settings`) already had its own screen and is unchanged. No other behavior changes.

Housekeeping per convention: version bumped to 0.02 in `metadata.json`, ChangeLog line added.

Checks: `bin/sanitycheck.js` passes (0 errors, 0 warnings) and `eslint apps/tennisscores --max-warnings 0` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
