### PR TITLE
Fix timer snooze 5m button

### DIFF
--- a/apps/sched/ChangeLog
+++ b/apps/sched/ChangeLog
@@ -42,3 +42,4 @@
 0.39: Allow a press of the button to stop/snooze the alarm when it's gone off
 0.40: Prevent time-of-day alarms set via setAlarm() that have a time earlier than the current time triggering immediately after #4220 fix; schedule them for tomorrow by default to match original behavior
 0.41: Fix issue with snoozing alarms and timers beyond midnight causing the alarm/timer to go off immediately instead of snoozing
+0.42: Fix timer snooze 5m button adding 6 minutes instead of 5

--- a/apps/sched/metadata.json
+++ b/apps/sched/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "sched",
   "name": "Scheduler",
-  "version": "0.41",
+  "version": "0.42",
   "author": "gfwilliams",
   "description": "Scheduling library for alarms and timers",
   "icon": "app.png",

--- a/apps/sched/sched.js
+++ b/apps/sched/sched.js
@@ -49,7 +49,7 @@ function showSnoozeMenu(alarm){
   if(alarm.timer){
 
     let timerLength=alarm.timer;
-    let buttons={ "15s": 15, "30s":30,"1m":60 ,"2m":120,"5m":360};
+    let buttons={ "15s": 15, "30s":30,"1m":60 ,"2m":120,"5m":300};
     let formattedLength = formatMS(timerLength)+"*";
     buttons[formattedLength] = Math.round(timerLength/1000);
     //different button lengths


### PR DESCRIPTION
I had noticed snoozing a timer by holding and clicking the 5m button added 6 minutes instead of 5. I found the code had `360`(= 60 * **6**) and changed it to `300`(= 60 * **5**).