### PR TITLE
[GridLaunch] Fix last row not showing

### DIFF
--- a/apps/gridlaunch/ChangeLog
+++ b/apps/gridlaunch/ChangeLog
@@ -1,1 +1,2 @@
 0.01: New app
+0.02: Fix last row not showing apps

--- a/apps/gridlaunch/app.js
+++ b/apps/gridlaunch/app.js
@@ -1,4 +1,3 @@
-
 let s = require("Storage");
 let settings = Object.assign(
   {showClocks:false,showLaunchers:false, showWidgets:true},s.readJSON("gridlaunch.settings.json")||{});
@@ -16,25 +15,24 @@ if(settings.showWidgets){
 }
 E.showScroller({
   h : 70,
-  c : chunkedApps.length-1,
+  c : chunkedApps.length,
   draw : (idx, r) => {
     if (!chunkedApps[idx]) return;
 
-    const iconW = 43;
+    const iconW = 48*0.9;
     const third = r.w / 3;
     const x0 = r.x + (third * 0.5) - (iconW / 2);
     const x1 = r.x + (third * 1.5) - (iconW / 2);
     const x2 = r.x + (third * 2.5) - (iconW / 2);
 
-    // 2. Strict checks ensure s.read() is only executed if BOTH the app and icon exist
     if (chunkedApps[idx][0] && chunkedApps[idx][0].icon) {
-      g.drawImage(s.read(chunkedApps[idx][0].icon), x0, r.y, {scale:0.9});
+      g.drawImage(s.read(chunkedApps[idx][0].icon), x0, r.y-3, {scale:0.9});
     }
     if (chunkedApps[idx][1] && chunkedApps[idx][1].icon) {
       g.drawImage(s.read(chunkedApps[idx][1].icon), x1, r.y+26, {scale:0.9});
     }
     if (chunkedApps[idx][2] && chunkedApps[idx][2].icon) {
-      g.drawImage(s.read(chunkedApps[idx][2].icon), x2, r.y, {scale:0.9});
+      g.drawImage(s.read(chunkedApps[idx][2].icon), x2, r.y-3, {scale:0.9});
     }
   },
   select : (idx, touch) => {
@@ -49,12 +47,9 @@ E.showScroller({
         if (!app.src || s.read(app.src)===undefined) {
           E.showScroller();
           E.showMessage(/*LANG*/"App Source\nNot found");
-          setTimeout(drawMenu, 2000);
         } else {
           require("launch_utils").loadApp(app);
       }
   },
   back : Bangle.showClock,
 });
-
-

--- a/apps/gridlaunch/metadata.json
+++ b/apps/gridlaunch/metadata.json
@@ -2,7 +2,7 @@
   "id": "gridlaunch",
   "name": "Grid Launcher",
   "shortName": "Grid Launch",
-  "version": "0.01",
+  "version": "0.02",
   "author": "RKBoss6",
   "description": "A simple grid launcher in a familiar style",
   "icon": "icon.png",


### PR DESCRIPTION
This is a really silly mistake, but when testing, I had mistook the blank row caused by the invisible [imc icon](https://github.com/espruino/BangleApps/pull/4334) to mean that there was an extra row present. I've fixed that now, so the last row of apps will be shown.